### PR TITLE
Adding content licensing words. Fixes #112

### DIFF
--- a/app/views/home/about.html.erb
+++ b/app/views/home/about.html.erb
@@ -5,6 +5,7 @@
       <a class="menu-item" href="#author_guidelines">Author guidelines</a>
       <a class="menu-item" href="#reviewer_guidelines">Reviewer guidelines</a>
       <a class="menu-item" href="#editorial_board">Editorial board</a>
+      <a class="menu-item" href="#content_license">Content Licensing</a>
     </nav>
 
     <div class="three-fourths column">
@@ -302,6 +303,11 @@
           <p>Astronomer exploring the role of data science in academia at <a href="http://escience.washington.edu/">University of Washington's eScience Institute</a>. Core contributor to <a href="http://scikit-learn.org/">scikit-learn</a> and other science-focused Python packages.</p>
         </div>
 
+        <div class="main" id="content_license">
+          <h1>Content Licensing</h1>
+          <p><a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons Licence" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/80x15.png" /></a> Copyright of JOSS papers is retained by submitting authors and accepted papers are subject to a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.</p>
+          <p>Any code snippets included in JOSS papers are subject to the <a href="https://opensource.org/licenses/MIT" target="_blank">MIT license</a> regardless of the license of the submitted software package under review.</p>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Screen-grab of what this looks like on the site:

<img width="761" alt="screen shot 2016-05-17 at 10 52 01 pm" src="https://cloud.githubusercontent.com/assets/4483/15347810/07830ef4-1c82-11e6-8623-5a1a794768a7.png">

/ cc #112