### PR TITLE
Resolve font files

### DIFF
--- a/vendor/assets/bower_components/octicons/octicons/octicons.scss
+++ b/vendor/assets/bower_components/octicons/octicons/octicons.scss
@@ -1,12 +1,9 @@
-$octicons-font-path: "." !default;
-$octicons-version:   "83cf61c381c06806e0a3925d1a13c772b25161d2";
-
 @font-face {
   font-family: 'octicons';
-  src: url('#{$octicons-font-path}/octicons.eot?#iefix&v=#{$octicons-version}') format('embedded-opentype'),
-       url('#{$octicons-font-path}/octicons.woff?v=#{$octicons-version}') format('woff'),
-       url('#{$octicons-font-path}/octicons.ttf?v=#{$octicons-version}') format('truetype'),
-       url('#{$octicons-font-path}/octicons.svg?v=#{$octicons-version}#octicons') format('svg');
+  src: font-url('octicons.eot?#iefix') format('embedded-opentype'),
+       font-url('octicons.woff') format('woff'),
+       font-url('octicons.ttf') format('truetype'),
+       font-url('octicons.svg?#octicons') format('svg');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
This PR changes the url generated for the font files in `octicons.scss` using the `font-url` helper.

I can not reproduce the asset precompiling in the joss production server but the regular asset:precompile rake task generates now the correct url in application.css, so this should fix #79.  