### PR TITLE
Add atom link tag to layout

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,7 @@
   <link rel="icon" type="image/png" sizes="96x96" href="/favicon-96x96.png">
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
   <link rel="manifest" href="/manifest.json">
+  <link rel="home" type="application/atom+xml" title="Papers" href="/papers.atom">
   <meta name="msapplication-TileColor" content="#ffffff">
   <meta name="msapplication-TileImage" content="/ms-icon-144x144.png">
   <meta name="theme-color" content="#ffffff">


### PR DESCRIPTION
This adds a link tag to the layout so that software can automatically
discover the RSS feed.  This is valuable when, for instance, pasting the
site's URL into a feed reader and letting the reader discover the feed's
existence.