### PR TITLE
Update review body to discourage centithreads (#163)

### DIFF
--- a/app/views/shared/review_body.erb
+++ b/app/views/shared/review_body.erb
@@ -12,8 +12,11 @@ Status badge code:
 HTML: <a href="http://joss.theoj.org/papers/<%= paper.sha %>"><img src="http://joss.theoj.org/papers/<%= paper.sha %>/status.svg"></a>
 Markdown: [![status](http://joss.theoj.org/papers/<%= paper.sha %>/status.svg)](http://joss.theoj.org/papers/<%= paper.sha %>)
 ```
+**Reviewers and authors**: please avoid lengthy details of difficulties in the review thread; prefer to create a new issue in the <a href="<%= paper.repository_url %>">target repository</a> and link to those issues (especially acceptance-blockers) in the review thread below.  (For completists: if the target issue tracker is also on Github, linking the review thread in the issue or vice versa will create corresponding breadcrumb trails in the link target.)
 
 ## Reviewer questions
+
+
 
 ### Conflict of interest
 


### PR DESCRIPTION
Further work on https://github.com/openjournals/joss/issues/163

to try to avoid review-derailing or lengthy back-and-forth between reviewer and author.  (Rather, put that back-and-forth in its own issue and report only on its initiation and resolution within the review thread.)