### PR TITLE
Adding ability to withdraw papers

### DIFF
--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -31,6 +31,7 @@ class Paper < ActiveRecord::Base
     state :superceded
     state :accepted
     state :rejected
+    state :withdrawn
 
     event :reject do
       transitions :to => :rejected
@@ -46,6 +47,10 @@ class Paper < ActiveRecord::Base
 
     event :accept do
       transitions :to => :accepted
+    end
+
+    event :withdraw do
+      transitions :to => :withdrawn
     end
   end
 

--- a/spec/models/paper_spec.rb
+++ b/spec/models/paper_spec.rb
@@ -103,4 +103,12 @@ describe Paper do
 
     expect {paper.save}.to change { ActionMailer::Base.deliveries.count }.by(1)
   end
+
+  it "should be able to be withdrawn at any time" do
+    paper = create(:paper, :state => "accepted")
+    assert Paper.visible.include?(paper)
+
+    paper.withdraw!
+    refute Paper.visible.include?(paper)
+  end
 end


### PR DESCRIPTION
Sometimes we need to be able to withdraw papers. This is a simple PR to add a new state (`withdrawn`) and transition to move papers to this state.

/ cc https://github.com/openjournals/joss-reviews/issues/10