### PR TITLE
Adding weekly mailer rake task

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,3 +258,6 @@ DEPENDENCIES
   web-console (~> 2.0)
   webmock (~> 1.19.0)
   will_paginate (~> 3.1)
+
+BUNDLED WITH
+   1.13.6

--- a/app/mailers/notifications.rb
+++ b/app/mailers/notifications.rb
@@ -6,4 +6,10 @@ class Notifications < ApplicationMailer
     @paper = paper
     mail(:to => EDITOR_EMAILS, :subject => "New submission: #{paper.title}")
   end
+
+  def editor_weekly_email(editor, pending_issues, assigned_issues)
+    @pending_issues = pending_issues
+    @assigned_issues = assigned_issues
+    mail(:to => editor["email"], :subject => "JOSS weekly editor update for #{editor['login']}")
+  end
 end

--- a/app/models/review_issue.rb
+++ b/app/models/review_issue.rb
@@ -1,0 +1,72 @@
+# This is a Helper Class to make it easier to filter/select review issues from
+# GitHub.
+
+class ReviewIssue
+
+  # Download all of the current open issues on review repo
+  def self.download_review_issues(review_repo)
+    open_issues = GITHUB.list_issues(review_repo, :state => 'open')
+
+    # TODO: Generate some stats on recently closed issues too
+    # closed_issues = github.list_issues(@nwo, :state => 'closed')
+
+    # Loop through open issues and create ReviewIssues for future manipulation
+    review_issues = []
+
+    open_issues.each do |issue|
+      next if issue.labels.collect {|l| l.name }.include?('paused')
+      if issue.title.match(/\[PRE REVIEW\]/)
+        review_issues << ReviewIssue.new(issue, state="open")
+      elsif issue.title.match(/\[REVIEW\]/)
+        review_issues << ReviewIssue.new(issue, state="open")
+      else
+        Rails.logger.info("Failing to initialize issue: #{issue.title} (#{issue.number})")
+      end
+    end
+
+    return review_issues.sort_by! {|i| i.created_at }
+  end
+
+  # Filter the review issues for editor
+  def self.review_issues_for_editor(review_issues, editor)
+    editor_issues = []
+    review_issues.each do |issue|
+      if issue.body.match(/\*\*Editor:\*\*\s*(@\S*|Pending)/i)
+        if issue.editor == editor["login"]
+          comments = GITHUB.issue_comments(ENV['REVIEW_REPO'], issue.number)
+          issue.last_comment = comments.last
+          issue.comment_count = comments.count
+          editor_issues << issue
+        end
+      end
+    end
+
+    return editor_issues
+  end
+
+  attr_accessor :title, :body, :comments, :labels, :state, :open, :number, :created_at,
+                :comment_count, :last_comment
+
+  def initialize(raw_issue, state)
+    @title = raw_issue['title']
+    @body = raw_issue['body']
+    @number = raw_issue['number']
+    @created_at = raw_issue['created_at']
+    @state = state
+  end
+
+  # Is this a 'PRE REVIEW' issue?
+  def pre_review?
+    title.match(/\[PRE REVIEW\]/)
+  end
+
+  # Extract the Editor from the issue body
+  def editor
+    body.match(/\*\*Editor:\*\*\s*(@\S*|Pending)/i)[1]
+  end
+
+  # Extract the Reviewer from the issue body
+  def reviewer
+    body.match(/\*\*Reviewer:\*\*\s*(@\S*|Pending)/i)[1]
+  end
+end

--- a/app/views/notifications/editor_weekly_email.html.erb
+++ b/app/views/notifications/editor_weekly_email.html.erb
@@ -1,0 +1,28 @@
+<% if @pending_issues.any? %>
+<h4>Here are the papers currently without an editor</h4>
+<p><em>Please consider volunteering to edit one (or more) of these papers</em></p>
+
+  <% @pending_issues.each do |issue| %>
+<ul>
+  <li><%= issue.title %></li>
+  <li>Submitted: <%= issue.created_at.strftime('%F') %></li>
+  <li>https://github.com/<%= ENV['REVIEW_REPO']%>/issues/<%= issue.number %></li>
+</ul>
+  <% end %>
+<% end %>
+
+<% if @assigned_issues.any? %>
+<h4>Here are the papers you are currently editing:</h4>
+
+  <% @assigned_issues.each do |issue| %>
+<ul>
+  <li><%= issue.title %></li>
+  <li>Submitted: <%= issue.created_at.strftime('%F') %></li>
+  <li>Total comments: <%= issue.comment_count %></li>
+  <li>Last comment: by @<%= issue.last_comment['user']['login']%> <%= time_ago_in_words(issue.last_comment['created_at']) %> ago</li>
+  <li>https://github.com/<%= ENV['REVIEW_REPO']%>/issues/<%= issue.number %></li>
+</ul>
+  <% end %>
+<% else %>
+<p>You don't seem to be editing any papers. Please consider volunteering to edit one of the pending papers above.</p>
+<% end %>

--- a/app/views/notifications/editor_weekly_email.text.erb
+++ b/app/views/notifications/editor_weekly_email.text.erb
@@ -1,0 +1,26 @@
+<% if @pending_issues.any? %>
+Here are the papers currently without an editor
+
+** Please consider volunteering to edit one (or more) of these papers **
+
+  <%= @pending_issues.each do |issue| %>
+- <%= issue.title %>
+- Submitted: <%= issue.created_at.strftime('%F') %>
+- https://github.com/<%= ENV['REVIEW_REPO']%>/issues/<%= issue.number %>
+  <% end %>
+<% end %>
+
+<% if @assigned_issues.any? %>
+Here are the papers you are currently editing:
+
+  <%= @assigned_issues.each do |issue| %>
+- <%= issue.title %>
+- Submitted: <%= issue.created_at.strftime('%F') %>
+- Total comments: <%= issue.comment_count %>
+- Last comment: by @<%= issue.last_comment['user']['login']%> <%= time_ago_in_words(issue.last_comment['created_at']) %> ago
+- https://github.com/<%= ENV['REVIEW_REPO']%>/issues/<%= issue.number %>
+  <% end %>
+
+<% else %>
+You don't seem to be editing any papers. Please consider volunteering to edit one of the pending papers above.
+<% end %>

--- a/lib/tasks/editorials.rake
+++ b/lib/tasks/editorials.rake
@@ -1,0 +1,16 @@
+namespace :editorials do
+  desc "Send weekly emails to editors"
+  task :send_weekly_emails => :environment do
+    review_issues = ReviewIssue.download_review_issues(ENV['REVIEW_REPO'])
+    # Sort issues in place in order of date created
+
+    # binding.pry
+    pending_issues = review_issues.select { |i| i.editor == "Pending" }
+
+    # Loop through editors and send them their weekly email :-)
+    YAML.load(ENV['EDITORS']).each do |editor|
+      editor_issues = ReviewIssue.review_issues_for_editor(review_issues, editor)
+      Notifications.editor_weekly_email(editor, pending_issues, editor_issues).deliver_now!
+    end
+  end
+end

--- a/lib/tasks/editorials.rake
+++ b/lib/tasks/editorials.rake
@@ -1,16 +1,19 @@
 namespace :editorials do
   desc "Send weekly emails to editors"
   task :send_weekly_emails => :environment do
-    review_issues = ReviewIssue.download_review_issues(ENV['REVIEW_REPO'])
-    # Sort issues in place in order of date created
+    # We run this task daily on Heroku but only want the email
+    # sent once per week (on a Sunday)
+    if Time.now.sunday?
+      review_issues = ReviewIssue.download_review_issues(ENV['REVIEW_REPO'])
+      # Sort issues in place in order of date created
 
-    # binding.pry
-    pending_issues = review_issues.select { |i| i.editor == "Pending" }
+      pending_issues = review_issues.select { |i| i.editor == "Pending" }
 
-    # Loop through editors and send them their weekly email :-)
-    YAML.load(ENV['EDITORS']).each do |editor|
-      editor_issues = ReviewIssue.review_issues_for_editor(review_issues, editor)
-      Notifications.editor_weekly_email(editor, pending_issues, editor_issues).deliver_now!
+      # Loop through editors and send them their weekly email :-)
+      YAML.load(ENV['EDITORS']).each do |editor|
+        editor_issues = ReviewIssue.review_issues_for_editor(review_issues, editor)
+        Notifications.editor_weekly_email(editor, pending_issues, editor_issues).deliver_now!
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds a weekly email for JOSS editors to notify them of:
- The currently un-assigned reviews and...
- Their reviews with current status etc.