### PR TITLE
Adds Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ The JOSS submission tool is hosted at http://joss.theoj.org
 
 If you're looking for the JOSS reviews repository head over here: https://github.com/openjournals/joss-reviews/issues
 
+## Code of Conduct
+
+In order to have a more open and welcoming community, JOSS adheres to a code of conduct adapted from the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+
+Please adhere to this code of conduct in any interactions you have in the JOSS community. It is strictly enforced on all official JOSS repositories, the JOSS website, and resources. If you encounter someone violating these terms, please let the Editor-in-Chief ([@arfon](https://github.com/arfon)) or someone on the [editorial board](http://joss.theoj.org/about#editorial_board) know and we will address it as soon as possible.
+
 ## Contributing
 
 [![Build Status](https://travis-ci.org/openjournals/joss.svg?branch=master)](https://travis-ci.org/openjournals/joss)

--- a/app/views/home/about.html.erb
+++ b/app/views/home/about.html.erb
@@ -29,7 +29,15 @@
 
         <p>We have a simple submission workflow and extensive documentation to help you prepare your submission. If your software is already well documented then paper preparation should take no more than an hour.</p>
 
-        <p>You can read more about our motivations to build JOSS in our <%= link_to "announcement blog post", "http://www.arfon.org/announcing-the-journal-of-open-source-software", :target => "_blank" %>.
+        <p>You can read more about our motivations to build JOSS in our <%= link_to "announcement blog post", "http://www.arfon.org/announcing-the-journal-of-open-source-software", :target => "_blank" %>.</p>
+
+      </div>
+      <div class="main" id="code_of_conduct">
+        <h1>Code of Conduct</h1>
+
+        <p>Although JOSS spaces may feel informal at times, we want to remind authors and reviewers (and anyone else) that this is a professional space. As such, the JOSS community adheres to a code of conduct adapted from the <%= link_to "Contributor Covenant", "http://contributor-covenant.org", :target => "_blank" %> code of conduct.</p>
+
+        <p>Authors and reviewers will be required to confirm they have read our <%= link_to "code of conduct", "https://github.com/openjournals/joss/blob/master/CODE_OF_CONDUCT.md", :target => "_blank" %>, and are expected to adhere to it in all JOSS spaces and associated interactions.</p>
       </div>
 
       <div class="main" id="author_guidelines">

--- a/app/views/papers/new.html.erb
+++ b/app/views/papers/new.html.erb
@@ -37,6 +37,10 @@
           <input type="checkbox" id="author-check">
           I certify that I am submitting software for which I am a primary author
         </label>
+        <label>
+          <input type="checkbox" id="author-check">
+          I confirm that I read and will adhere to the JOSS <a href="/about#code_of_conduct">code of conduct</a>.
+        </label>
         <div class="form-actions">
           <%= submit_tag("Submit paper", :class => "btn disabled", :disabled => "disabled", :id => "author-submit") %>
         </div>


### PR DESCRIPTION
This commit adds a code of conduct (adapted from the Contributor Covenant
Code of Conduct), and adds a section discussing it to the about page.
It also adds a checkbox for authors to confirm they have read it.