### PR TITLE
Always have an @ in the GitHub username

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -14,6 +14,8 @@ class HomeController < ApplicationController
   end
 
   def update_profile
+    check_github_username
+
     if current_user.update_attributes(user_params)
       redirect_to(:back, :notice => "Profile updated")
     end
@@ -24,6 +26,15 @@ class HomeController < ApplicationController
   end
 
 private
+
+  def check_github_username
+    if user_params.has_key?('github_username')
+      if !user_params['github_username'].strip.start_with?('@')
+        old = user_params['github_username']
+        user_params['github_username'] = old.prepend('@')
+      end
+    end
+  end
 
   def user_params
     params.require(:user).permit(:email, :github_username)

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -62,5 +62,17 @@ describe HomeController, :type => :controller do
       expect(user.reload.email).to eq("albert@gmail.com")
       expect(user.reload.github_username).to eq("@jimmy")
     end
+
+    it "should add an @ to their GitHub username if they don't use one" do
+      user = create(:user, :email => nil, :github_username => nil)
+      allow(controller).to receive_message_chain(:current_user).and_return(user)
+      params = {:email => "albert@gmail.com", :github_username => "jimmy_no_at"}
+      request.env["HTTP_REFERER"] = papers_path
+
+      post :update_profile, :user => params
+      expect(response).to be_redirect # as it's updated the email
+      expect(user.reload.email).to eq("albert@gmail.com")
+      expect(user.reload.github_username).to eq("@jimmy_no_at")
+    end
   end
 end


### PR DESCRIPTION
Currently we don't check that people are actually putting an `@` in their GitHub username. This PR fixes that, adding one if missing.