### PR TITLE
[Solves #322] Update dx.doi.org to doi.org links 

### DIFF
--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -124,16 +124,16 @@ class Paper < ActiveRecord::Base
   end
 
   # Make sure that DOIs have a full http URL
-  # e.g. turn 10.6084/m9.figshare.828487 into http://dx.doi.org/10.6084/m9.figshare.828487
+  # e.g. turn 10.6084/m9.figshare.828487 into https://doi.org/10.6084/m9.figshare.828487
   def doi_with_url
     return "DOI pending" unless archive_doi
 
     bare_doi = archive_doi[/\b(10[.][0-9]{4,}(?:[.][0-9]+)*\/(?:(?!["&\'<>])\S)+)\b/]
 
-    if archive_doi.include?("http://dx.doi.org/")
+    if archive_doi.include?("https://doi.org/")
       return archive_doi
     elsif bare_doi
-      return "http://dx.doi.org/#{bare_doi}"
+      return "https://doi.org/#{bare_doi}"
     else
       return archive_doi
     end
@@ -213,9 +213,9 @@ class Paper < ActiveRecord::Base
     state.humanize.downcase
   end
 
-  # Returns DOI with URL e.g. "http://dx.doi.org/10.21105/joss.00001"
+  # Returns DOI with URL e.g. "https://doi.org/10.21105/joss.00001"
   def cross_ref_doi_url
-    "http://dx.doi.org/#{doi}"
+    "https://doi.org/#{doi}"
   end
 
   def status_badge

--- a/spec/controllers/papers_controller_spec.rb
+++ b/spec/controllers/papers_controller_spec.rb
@@ -77,7 +77,7 @@ describe PapersController, :type => :controller do
       allow(controller).to receive_message_chain(:current_user).and_return(user)
       paper_count = Paper.count
 
-      paper_params = {:title => "Yeah whateva", :body => "something", :repository_url => "https://github.com/foo/bar", :archive_doi => "http://dx.doi.org/10.6084/m9.figshare.828487", :software_version => "v1.0.1"}
+      paper_params = {:title => "Yeah whateva", :body => "something", :repository_url => "https://github.com/foo/bar", :archive_doi => "https://doi.org/10.6084/m9.figshare.828487", :software_version => "v1.0.1"}
       post :create, :paper => paper_params
       expect(response).to be_redirect # as it's created the thing
       expect(Paper.count).to eq(paper_count + 1)
@@ -88,7 +88,7 @@ describe PapersController, :type => :controller do
       allow(controller).to receive_message_chain(:current_user).and_return(user)
       paper_count = Paper.count
 
-      paper_params = {:title => "Yeah whateva", :body => "something", :repository_url => "", :archive_doi => "http://dx.doi.org/10.6084/m9.figshare.828487"}
+      paper_params = {:title => "Yeah whateva", :body => "something", :repository_url => "", :archive_doi => "https://doi.org/10.6084/m9.figshare.828487"}
       post :create, :paper => paper_params
 
       expect(response.body).to match /Your paper could not be saved/
@@ -101,7 +101,7 @@ describe PapersController, :type => :controller do
       paper_count = Paper.count
       request.env["HTTP_REFERER"] = new_paper_path
 
-      paper_params = {:title => "Yeah whateva", :body => "something", :repository_url => "https://github.com/foo/bar", :archive_doi => "http://dx.doi.org/10.6084/m9.figshare.828487", :software_version => "v1.0.1"}
+      paper_params = {:title => "Yeah whateva", :body => "something", :repository_url => "https://github.com/foo/bar", :archive_doi => "https://doi.org/10.6084/m9.figshare.828487", :software_version => "v1.0.1"}
       post :create, :paper => paper_params
       expect(response).to be_redirect # as it's redirected us
       expect(Paper.count).to eq(paper_count)

--- a/spec/factories/papers_factory.rb
+++ b/spec/factories/papers_factory.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     title             'arfon / fidgit'
     body              'An ungodly union of GitHub and Figshare http://fidgit.arfon.org'
     repository_url    'http://github.com/arfon/fidgit'
-    archive_doi       'http://dx.doi.org/10.0001/zenodo.12345'
+    archive_doi       'https://doi.org/10.0001/zenodo.12345'
     software_version  'v1.0.0'
 
     created_at  { Time.now }

--- a/spec/models/paper_spec.rb
+++ b/spec/models/paper_spec.rb
@@ -44,17 +44,16 @@ describe Paper do
     expect(paper.pretty_repository_name).to eq("arfon / joss-reviews")
   end
 
-  it "should know how to return a pretty DOI" do
-    paper = create(:paper, :archive_doi => "http://dx.doi.org/10.6084/m9.figshare.828487")
+  it 'should know how to return a pretty DOI' do
+    paper = create(:paper, archive_doi: 'https://doi.org/10.6084/m9.figshare.828487')
 
     expect(paper.pretty_doi).to eq("10.6084/m9.figshare.828487")
   end
 
+  it 'should know how to return a DOI with a full URL' do
+    paper = create(:paper, archive_doi: '10.6084/m9.figshare.828487')
 
-  it "should know how to return a DOI with a full URL" do
-    paper = create(:paper, :archive_doi => "10.6084/m9.figshare.828487")
-
-    expect(paper.doi_with_url).to eq("http://dx.doi.org/10.6084/m9.figshare.828487")
+    expect(paper.doi_with_url).to eq('https://doi.org/10.6084/m9.figshare.828487')
   end
 
   it "should bail creating a full DOI URL if if can't figure out what to do" do


### PR DESCRIPTION
Updated all links containing `http://dx.doi.org` to `https://doi.org`
https://github.com/openjournals/joss/issues/322