### PR TITLE
Starting work on Markdown views

### DIFF
--- a/app/views/home/about.md
+++ b/app/views/home/about.md
@@ -1,0 +1,440 @@
+<div class="about-page columns">
+  <nav class="menu one-fourth column">
+    <a class="menu-item selected" href="#about">About</a>
+    <a class="menu-item" href="#code_of_conduct">Code of Conduct</a>
+    <a class="menu-item" href="#osi">Open Source Initiative</a>
+    <a class="menu-item" href="#author_guidelines">Author Guidelines</a>
+    <a class="menu-item" href="#reviewer_guidelines">Reviewer Guidelines</a>
+    <a class="menu-item" href="#editorial_board">Editorial Board</a>
+    <a class="menu-item" href="#costs">Cost and Sustainability Model</a>
+    <a class="menu-item" href="#content_license">Content Licensing</a>
+  </nav>
+
+  <div class="three-fourths column">
+    <div class="main" id="about">
+
+# The Journal of Open Source Software
+
+<p class="lead">The Journal of Open Source Software (JOSS) is a <strong>developer friendly</strong> journal for research software packages.</p>
+
+### What _exactly_ do you mean by 'journal'
+
+The Journal of Open Source Software (JOSS) is an academic journal (ISSN 2475-9066) with a formal peer review process that is designed to _improve the quality of the software submitted_. Upon acceptance into JOSS, a CrossRef DOI is minted and we list your paper on the JOSS website.
+
+### Don't we have enough journals already?
+
+Perhaps, and in a perfect world we'd rather papers about software weren't necessary but we recognize that for most researchers, papers and not software are the currency of academic research and that citations are required for a good career.
+
+We built this journal because we believe that after you've done the hard work of writing great software, it shouldn't take weeks and months to write a paper about your work.
+
+### You said _developer friendly_, what do you mean?
+
+We have a simple submission workflow and extensive documentation to help you prepare your submission. If your software is already well documented then paper preparation should take no more than an hour.
+
+You can read more about our motivations to build JOSS in our [announcement blog post](http://www.arfon.org/announcing-the-journal-of-open-source-software)
+
+<p class="lead"><%= link_to "Volunteer to review for JOSS", "/reviewer-signup.html" %>!</p>
+
+# [](#code_of_conduct) Code of Conduct
+
+Although JOSS spaces may feel informal at times, we want to remind authors and reviewers (and anyone else) that this is a professional space. As such, the JOSS community adheres to a code of conduct adapted from the [Contributor Covenant](http://contributor-covenant.org)
+
+Authors and reviewers will be required to confirm they have read our [code of conduct"](https://github.com/openjournals/joss/blob/master/CODE_OF_CONDUCT.md), and are expected to adhere to it in all JOSS spaces and associated interactions
+
+# [](#osi) Open Source Initiative
+
+<%= image_tag "osi_small.png", :class => "left", :style => "padding-right: 10px;" %>
+
+The Journal of Open Source Software is a proud affiliate of the [Open Source Initiative](https://opensource.org/). As such we are committed to public support for open source software and the role OSI plays therein. You can read more about the OSI's affilate program [here](https://opensource.org/affiliates/about).
+
+# [](#author_guidelines) Author Guidelines
+
+<p class="lead">If you've already licensed your code and have good documentation then we expect that it should take <strong>less than an hour</strong> to prepare and submit your paper to JOSS.</p>
+
+## What does a typical submission flow look like?
+
+Before you submit we need you to:
+
+- Make software available in an open repository (GitHub, Bitbucket etc.) and include an [OSI approved open source license](https://opensource.org/licenses)
+- Author a short Markdown paper `paper.md` with a title, summary, author names, affiliations, and key references. See [this example paper](https://github.com/arfon/fidgit/tree/master/paper)
+- Ideally we would also like you to create a metadata file and include it in your repository describing your software. [This script](https://gist.github.com/arfon/478b2ed49e11f984d6fb) automates the generation of this metadata.
+
+## [](#paper_structure) What should my paper contain?
+
+JOSS welcomes submissions from broadly diverse research areas. For this reason, we request that authors include in the paper some sentences that would explain the software functionality and domain of use to a non-specialist reader. Your submission should probably be somewhere between 250-1000 words.
+
+- A list of the authors of the software and their affiliations
+- A summary describing the high-level functionality and purpose of the software for a diverse, non-specialist audience
+- A clear statement of need that illustrates the purpose of the software
+- A list of key references including a link to the software archive
+- Mentions (if applicable) of any ongoing research projects using the software or recent scholarly publications enabled by it
+
+As this list shows JOSS papers are only permitted to contain a limited set of metadata (see header below), Summary &amp; Reference sections. See [this example paper](https://github.com/arfon/fidgit/tree/master/paper). Given this paper format it is _not_  permitted to write a "full length" paper i.e. one that includes software documentation such as API (Application Programming Interface) functionality, as this should instead be outlined in the software documentation.
+
+<pre style="font-size: 15px; background: #efefef; padding: 10px 15px;">
+---
+title: 'Fidgit: An ungodly union of GitHub and figshare'
+tags:
+- example
+- tags
+- for the paper
+authors:
+- name: Arfon M Smith
+ orcid: 0000-0000-0000-1234
+ affiliation: 1
+- name: Mickey Mouse
+ orcid: 0000-0000-0000-1234
+ affiliation: 2
+affiliations:
+- name: Space Telescope Science Institute
+ index: 1
+- name: Disney Inc.
+ index: 2
+date: 14 February 2016
+bibliography: paper.bib
+---
+
+# Summary
+
+- A summary describing the high-level functionality and purpose of the software
+for a diverse, non-specialist audience
+- A clear statement of need that illustrates the purpose of the software
+- A list of key references including a link to the software archive
+- Mentions (if applicable) of any ongoing research projects using the software
+or recent scholarly publications enabled by it
+
+Citations to entries in paper.bib should be in
+[rMarkdown](http://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html)
+format.
+
+Figures can be included like this: ![Fidgit deposited in figshare.](figshare_article.png)
+
+# References
+</pre>
+
+Submission then is as simple as:
+
+- Filling in the short [submission form]('/papers/new')
+- Waiting for reviewers to be assigned over in the review repository
+
+      <br />
+
+## [](#submission_requirements) What are your requirements for submission?
+
+- Your software should be open source as per [the OSI definition](https://opensource.org/osd)
+- Your software should have an *obvious* research application
+- You should be a major contributor to the software you are submitting
+- Should be a significant contribution to the available open source software that either enables some new research challenges to be addressed or makes addressing research challenges significantly better (e.g., faster, easier, simpler)
+- Should be feature complete (no half-baked solutions)
+- Minor, 'utility' packages are not acceptable
+
+JOSS publishes articles about research software. This definition includes software that: solves complex modeling problems in a scientific context (physics, mathematics, biology, medicine, social science, neuroscience, engineering); supports the functioning of research instruments or the execution of research experiments; extracts knowledge from large data sets; offers a mathematical library, or similar.
+
+If you think your submission is not an obvious fit or have a question then please submit [https://is.gd/josspre](a pre-submission enquiry).
+
+
+      <br />
+
+## What about submissions that rely upon proprietary languages/development environments?
+
+We strongly prefer software that doesn't rely upon proprietary (paid for) development environments/programming languages. However, provided _your_ submission meets our submission requirements (including having a valid open source license) then we will consider your submission for review. Should your submission be accepted for review, we may ask you, the submitting author, to help us find reviewers who already have the required development environment installed.
+
+      <br />
+
+## What does a typical review process look like?
+
+We encourage you to familiarize yourself with our [reviewer guidelines](#reviewer_guidelines) as this will help you understand what our reviewers will be looking for. Broadly speaking though, provided you have followed our pre-submission steps and meet our submission requirements then you should expect a rapid review (typically less than two weeks).
+
+After submission:
+
+- One or more JOSS reviewers are assigned and the review is carried out in the <%= link_to "JOSS reviews repository", "https://github.com/#{Rails.configuration.joss_review_repo}", :target => "_blank" %></li>
+        <li>Authors respond to reviewer-raised issues (if any are raised) on the submitted repository's issue tracker.  Reviewer contributions, like any other contributions, should be acknowledged in the repository.</li>
+        <li>Upon successful completion of the review, deposit a copy of your (updated) software repository with a data-archiving service such as <%= link_to "Zenodo", "https://zenodo.org/", :target => "_blank" %> or <%= link_to "figshare", "https://figshare.com/", :target => "_blank" %>, issue a DOI for the software archive, and update the review issue thread with your DOI.</li>
+        <li>After assignment of a DOI, your paper metadata is deposited in CrossRef and listed on the JOSS website.</li>
+        <li>And that's it.</li>
+      </ul>
+    </div>
+
+    <div class="main" id="reviewer_guidelines">
+      <h1>Reviewer Guidelines</h1>
+
+      <p class="lead">Firstly, thank you so much for agreeing to review for the Journal of Open Source Software (JOSS), we're delighted to have your help. This document is designed to outline our editorial guidelines and help you understand our requirements for accepting a submission into the JOSS. Our review process is based on a tried-and-tested approach of the <a href="http://ropensci.org/blog/2016/03/28/software-review" target="_blank">ROpenSci collaboration</a>.</p>
+
+      <h2>Some guiding principles for you the reviewer</h2>
+
+      <p>We like to think of JOSS as a 'developer friendly' journal. That is, if the submitting authors have followed best practices (have documentation, tests, continuous integration, and a license) then their review should be extremely rapid.</p>
+      <p>For those authors that don't quite meet the bar, please try to give clear feedback on how they could improve their submission. A key goal of JOSS is to raise the quality of research software generally and you (the experienced reviewer) are well placed to give this feedback.</p>
+      <p>We encourage reviewers to file issues against the <a href="#author_guidelines">submitted repository</a>'s issue tracker. Include in your review links to any new issues that you the reviewer believe to be impeding the acceptance of the repository. (If the submitted repository is a GitHub repository, mentioning the review issue URL in the submitted repository's issue tracker will create a mention in the review issue's history.)</p>
+
+      <h2>The JOSS paper</h2>
+
+      <p>The JOSS paper (the PDF associated with this submission) should only include:</p>
+
+      <ul>
+        <li>A list of the authors of the software</li>
+        <li>Author affiliations</li>
+        <li>A short summary describing the high-level functionality of the software</li>
+        <li>A list of key references including a link to the software archive</li>
+      </ul>
+
+      <p>Note the paper should <em>not</em> include software documentation such as API (Application Programming Interface) functionality, as this should be outlined in the software documentation.</p>
+
+      <h2>Software license</h2>
+
+      <p>There should be an <%= link_to "OSI approved", "https://opensource.org/licenses/alphabetical" %> license included in the repository. Common licenses such as those listed on <%= link_to "http://choosealicense.com", "http://choosealicense.com" %> are preferred. Note there should be an actual license file present in the repository not just a reference to the license.</p>
+
+      <blockquote>
+        <p>
+          Acceptable: A plain-text LICENSE file with the contents of an OSI approved license<br />
+          Not acceptable: A phrase such as 'MIT license' in a README file
+        </p>
+      </blockquote>
+
+      <h2>Documentation</h2>
+
+      <p>There should be sufficient documentation for you, the reviewer to understand the core functionality of the software under review. A high-level overview of this documentation should be included in a README file (or equivalent). There should be:</p>
+
+      <h3>A statement of need</h3 >
+
+      <p>The authors should clearly state what problems the software is designed to solve and who the target audience is.</p>
+
+      <h3>Installation instructions</h3>
+
+      <p>There should be a clearly-stated list of dependencies. Ideally these should be handled with an automated package management solution.</p>
+
+      <blockquote>
+        <p>
+          Good: A package management file such as a <code>Gemfile</code> or <code>package.json</code> or equivalent<br />
+          OK: A list of dependencies to install<br />
+          Bad (not acceptable): Reliance on other software not listed by the authors
+        </p>
+      </blockquote>
+
+      <h3>Example usage</h3>
+
+      <p>The authors should include examples of how to use the software (ideally to solve real-world analysis problems).</p>
+
+      <h3>API documentation</h3>
+
+      <p>Reviewers should check that the software API is documented to a suitable level. This decision is left largely to the discretion of the reviewer and their experience of evaluating the software.</p>
+
+      <blockquote>
+        <p>
+          Good: All functions/methods are documented including example inputs and outputs<br />
+          OK: Core API functionality is documented<br />
+          Bad (not acceptable): API is undocumented
+        </p>
+      </blockquote>
+
+      <h3>Tests</h3>
+
+      <p>Authors are strongly encouraged to include an automated test suite covering the core functionality of their software.</p>
+
+      <blockquote>
+        <p>
+          Good: An automated test suite hooked up to an external service such as Travis-CI or similar<br />
+          OK: Documented manual steps that can be followed to check the expected functionality of the software (e.g. a sample input file to assert behaviour)<br />
+          Bad (not acceptable): No way for you the reviewer to check whether the software works
+        </p>
+      </blockquote>
+
+      <h3>Community guidelines</h3>
+
+      <p>There should be clear guidelines for third-parties wishing to:</p>
+
+      <ul>
+        <li>Contribute to the software</li>
+        <li>Report issues or problems with the software</li>
+        <li>Seek support</li>
+      </ul>
+
+      <h3>Examples</h3>
+
+      <p>Include here some examples of well-documented software for people to review.</p>
+
+      <h2>Functionality</h2>
+
+      <p>Reviewers are expected to install the software they are reviewing and to verify the core functionality of the software.</p>
+
+      <h2>Other considerations</h2>
+
+      <h3>An important note about 'novel' software</h3>
+
+      <p>Submissions that implement solutions already solved in other software packages are accepted into JOSS provided that they meet the criteria listed above and cite prior similar work.</p>
+
+      <h3>What happens if the software I'm reviewing doesn't meet the JOSS criteria?</h3>
+      <p>We ask that reviewers grade submissions in one of three categories: 1) Accept 2) Minor Revisions 3) Major Revisions. Unlike some journals we do not reject outright submissions requiring major revisions - we're more than happy to give the author as long as they need to make these modifications/improvements.</p>
+
+      <h3>What about submissions that rely upon proprietary languages/development environments?</h3>
+
+      <p>As outlined in our author guidelines, submissions that rely upon a proprietary/closed source language or development environment are acceptable provided that they meet the other submission requirements and that you, the reviewer, are able to install the software &amp; verify the functionality of the submission as required by our reviewer guidelines.</p>
+
+      <p>If an open source or free variant of the programming language exists, feel free to encourage the submitting author to consider making their software compatible with the open source/free variant.</p>
+    </div>
+
+    <div class="main" id="editorial_board">
+      <h1>Editorial Board</h1>
+
+      <div class="editor">
+        <%= image_tag "editors/arfon.jpg", :class => "avatar left", :width => 100 %>
+        <h3><a href="http://arfon.org">Arfon Smith (@arfon)</a>, Editor-in-Chief</h3>
+        <p>A lapsed academic with a passion for new models of scientific collaboration, he's used big telescopes to study <%= link_to "dust in space", "http://www.arfon.org/thesis", :target => "_blank" %>, built sequencing pipelines in <%= link_to "Cambridge", "http://www.sanger.ac.uk/", :target => "_blank" %> and engaged millions of people in online citizen science by co-founding the <%= link_to "Zooniverse", "http://www.zooniverse.org", :target => "_blank" %>.</p>
+      </div>
+
+      <h2 style="padding-top: 10px;">Topic Editors</h2>
+
+      <div class="editor">
+        <%= image_tag "editors/lorena.png", :class => "avatar left", :width => 100 %>
+        <h3><a href="http://lorenabarba.com">Lorena A Barba (@labarba)</a>, Editor: Computational Science and Engineering &amp; High-performance Computing</h3>
+        <p>Associate Professor of Mechanical and Aerospace Engineering at the George Washington University, leading a research group in computational fluid dynamics, computational physics and high-performance computing. Member of the Board for NumFOCUS, a non-profit in support of open-source scientific software.</p>
+      </div>
+
+      <div class="editor">
+        <%= image_tag "editors/jason.jpg", :class => "avatar left", :width => 100 %>
+        <h3><a href="http://www.jasonclark.info">Jason Clark (@jasonclark)</a>, Editor: Information Sciences, Semantic Web</h3>
+        <p>Associate Professor, Librarian, and Head of Archival Informatics and Special Collections at Montana State University (MSU) Library, specializing in software development, metadata and data modeling, linked and structured data, search engine optimization, and interface design. You can find him on ORCID at <a href="http://orcid.org/0000-0002-3588-6257" target="_blank">http://orcid.org/0000-0002-3588-6257</a> and as <a href="https://twitter.com/jaclark" target="_blank">@jaclark on Twitter</a>.</p>
+      </div>
+
+      <div class="editor">
+        <%= image_tag "editors/george.jpg", :class => "avatar left", :width => 100 %>
+        <h3><a href="http://virec-group.org/george-githinji">George Githinji (@biorelated)</a>, Editor: Bioinformatics</h3>
+        <p> Bioinformatician and <a href="http://virec-group.org/george-githinji/"> researcher </a> at the <a href="http://kemri-wellcome.org/about-us/">KEMRI-Wellcome Trust Research Programme</a> one of the Major Wellcome-Trust Overseas Programmes. George works with the <a href="http://virec-group.org">Virus Epidemiology and Control group </a> and develops bioinformatics methods for understanding virus transmission patterns and evolution. He undertook his education in Kenya and is one of East-Africa's open source software developers with an keen interest in bioinformatics and reproducible research.</p>
+      </div>
+
+      <div class="editor">
+        <%= image_tag "editors/melissa.png", :class => "avatar left", :width => 100 %>
+        <h3><a href="http://melissagymrek.com">Melissa Gymrek (@mgymrek)</a>, Editor: Bioinformatics</h3>
+         <p>Assistant professor in Computer Science and Engineering and Medicine at UC San Diego with a research background in population genetics and bioinformatics. Interested in best practices for reproducible and open computational science and in how to take advantage of online media to change the face of scientific publishing.</p>
+      </div>
+
+      <div class="editor">
+        <%= image_tag "editors/lindsey.png", :class => "avatar left", :width => 100 %>
+        <h3><a href="http://lindseyjh.ca/">Lindsey Heagy (@lheagy)</a>, Editor: Geoscience, geophysics</h3>
+  <p>Geophysicist in the <a href="https://gif.eos.ubc.ca">Geophysical Inversion Facility</a> at the <a href="https://www.ubc.ca/">University of British Columbia</a>.
+     Her research background is in computational geophysics and inverse problems. She contributes to geoscience-focused Python packages and develops open-source educational resources in the geosciences.
+  </p>
+      </div>
+
+      <div class="editor">
+        <%= image_tag "editors/katy.png", :class => "avatar left", :width => 100 %>
+        <h3><a href="http://katyhuff.github.io/">Kathryn Huff (@katyhuff)</a>, Editor: Nuclear Engineering, Energy Engineering</h3>
+        <p>Kathryn Huff is an Assistant Professor in Nuclear, Plasma, and Radiological Engineering at <a href="http://illinois.edu">the University of Illinois at Urbana-Champaign</a>. Her research focuses on modeling and simulation of advanced nuclear reactors and fuel cycles. She also advocates for best practices in open, reproducible scientific computing.</p>
+      </div>
+
+      <div class="editor">
+        <%= image_tag "editors/dan.png", :class => "avatar left", :width => 100 %>
+        <h3><a href="http://danielskatz.org/">Daniel S. Katz (@danielskatz)</a>, Editor: Computer Science</h3>
+        <p>Works on computer, computational, and data reseach at
+        <a href="http://www.ncsa.illinois.edu/">NCSA</a>,
+        <a href="https://www.lis.illinois.edu">GSLIS</a>,
+        and <a href="http://www.ece.illinois.edu">ECE</a> at
+        <a href="http://illinois.edu">the University of Illinois at Urbana-Champaign</a>,
+        and has a strong interest in studying common elements of how research is done by people using software and data.</p>
+      </div>
+
+      <div class="editor">
+        <%= image_tag "editors/thomas.jpg", :class => "avatar left", :width => 100 %>
+        <h3><a href="http://thomasleeper.com/">Thomas J. Leeper (@leeper)</a>, Editor: Social Sciences</h3>
+        <p>A survey and experimental methodologist currently working as Associate Professor in Political Behaviour at the <a href="http://www.lse.ac.uk/" target="_blank">London School of Economics and Political Science</a>. His research focuses on the effects of information on public opinion, as well as techniques and tools for analyzing quantitative survey and experimental data. He has published more than thirty R packages on CRAN, and has authored and contributed to numerous other open source projects.</p>
+      </div>
+
+      <div class="editor">
+        <%= image_tag "editors/chris.png", :class => "avatar left", :width => 100 %>
+        <h3><a href="http://www.cmadan.com">Christopher R. Madan (@cMadan)</a>, Editor: Psychology and Neuroimaging</h3>
+        <p>Cognitive psychologist and neuroscientist. Postdoctoral research fellow in the
+        <a href="http://www.bc.edu/schools/cas/psych.html">Department of Psychology</a> at
+        <a href="http://www.bc.edu">Boston College</a>.
+        Studying human memory and decision making using cognitive psychology and neuroimaging approaches,
+        and developing novel computational methods along the way.</p>
+      </div>
+
+      <div class="editor">
+        <%= image_tag "editors/abby.jpg", :class => "avatar left", :width => 100 %>
+        <h3><a href="http://acabunoc.github.io/">Abigail Cabunoc Mayes (@acabunoc)</a>, Editor: Open Science</h3>
+        <p>Lead Developer at the <a href="https://mozillascience.org/">Mozilla Science Lab</a>. Abby has led development on various open source projects for science including Contributorship Badges for Science and WormBase. With a background in bioinformatics and computer science, she builds tools that use the web to move science forward.</p>
+      </div>
+
+      <div class="editor">
+        <%= image_tag "editors/kevin.png", :class => "avatar left", :width => 100 %>
+        <h3><a href="http://biomech.media.mit.edu/kevin-m-moerman/">Kevin M. Moerman (@Kevin-Mattheus-Moerman)</a> Editor: Image-based bioengineering, and soft tissue biomechanics</h3>
+        <p>Biomechanical and design engineer. Program manager for mechanical interfaces at <a href="http://www.media.mit.edu/">MIT Media lab</a> department of <a href="http://biomech.media.mit.edu/">Biomechatronics</a>. Developing computational methods for prosthetic device design. <a href="http://www.gibboncode.org/">GIBBON</a> code developer.</p>
+      </div>
+
+      <div class="editor">
+        <%= image_tag "editors/kyle.jpg", :class => "avatar left", :width => 100 %>
+        <h3><a href="http://kyleniemeyer.com">Kyle Niemeyer (@kyleniemeyer)</a>, Editor: Computational Combustion and Fluid Dynamics</h3>
+        <p>Mechanical engineer in the <a href="http://mime.oregonstate.edu/">School of Mechanical, Industrial, and Manufacturing Engineering</a> at <a href="http://oregonstate.edu/">Oregon State University</a>. Computational researcher in combustion, fluid dynamics, and chemical kinetics, with an interest in numerical methods and GPU computing strategies.</p>
+      </div>
+
+      <div class="editor">
+        <%= image_tag "editors/pjotr.jpg", :class => "avatar left", :width => 100 %>
+        <h3><a href="http://thebird.nl/">Pjotr Prins (@pjotrp)</a>, Editor: Bioinformatics, Reproducible Research, Software Deployment and High Performance Computing</h3>
+        <p>
+          Bioinformatician at large and director of <a href="http://genenetwork.org/">Genenetwork.org</a> and a visiting research fellow of <a href="https://www.uthsc.edu/neuroscience/faculty/r_williams.php">The University of Tennessee Health Science Center</a> and the Personal genomics and bioinformatics Department of Human Genetics of <a href="http://www.umcutrecht.nl/nl/Ziekenhuis/Zorgverleners/Cuppen-EPJG"> the University Medical Centre Utrecht</a>. Writing software is Pjotr's core business in academia.  He loves programming languages and he is involved in a wide range of free and open source software <a href="https://github.com/pjotrp">projects</a>.  He guides students to write software and, every year, he is a mentor and organisation administrator in the <a href="https://summerofcode.withgoogle.com/">Google Summer of Code</a>.
+        </p>
+      </div>
+
+      <div class="editor">
+        <%= image_tag "editors/karthik.png", :class => "avatar left", :width => 100 %>
+        <h3><a href="http://karthik.io/">Karthik Ram (@karthik)</a>, Editor: Biodiversity Informatics and Data Science</h3>
+        <p>A quantitative ecologist and data scientist at <a href="http://bids.berkeley.edu/">UC Berkeley' Institute for Data Science</a>, his research focuses on food web dynamics, open science, open data, and reproducible research.</p>
+      </div>
+
+      <div class="editor">
+        <%= image_tag "editors/ariel.jpg", :class => "avatar left", :width => 100 %>
+        <h3><a href="http://arokem.org/">Ariel Rokem (@arokem)</a>, Editor: Neuroscience, machine learning, computational social science</h3>
+        <p>Trained in cognitive neuroscience (PhD: UC Berkeley, 2010) and computational neuroimaging (Postdoc, Stanford, 2011-2015), Ariel Rokem is now a data scientist at the University of Washington eScience Institute, where he continues to develop software for the analysis of human neuroimaging data, develops tools for reproducible and open research practices, and collaborates with researchers from a variety of fields to advance data-intensive research.</p>
+      </div>
+
+      <div class="editor">
+        <%= image_tag "editors/tracy.jpg", :class => "avatar left", :width => 100 %>
+        <h3><a href="http://idyll.org/~tracyt/">Tracy Teal (@tracykteal)</a>, Editor: Bioinformatics</h3>
+        <p>Executive Director of Data Carpentry and Adjunct Professor in the BEACON Center for the Study of Evolution in Action at Michigan State University. Her research background in is microbial metagenomics and bioinformatics, and she has been a developer and contributor to several open source bioinformatics projects. She also focuses on best practices in data analysis software development.</p>
+      </div>
+
+      <div class="editor">
+        <%= image_tag "editors/roman.jpg", :class => "avatar left", :width => 100 %>
+	      <h3><a href="http://blogs.nopcode.org/brainstorm/">Roman Valls Guimera (@brainstorm)</a>, Editor: Bioinformatics, Computer Science</h3>
+	      <p>
+	  Research software engineer working at the <a href="https://umccr.github.io/">UMCCR</a> in Melbourne, Australia.
+	  Likes to tap into many fields of science and computing including
+	  deployable and reproducible scientific software in both HPC and Cloud
+	  computing environments for scientific workflows and data analysis. In
+	  previous gigs enacted <a href="http://neurostars.org/">NeuroStars</a> a Q&amp;A site
+	  for its growing neuroscience community and also
+	  mentored different students via the Google Summer of Code program.
+	  More recently, self taught embedded systems design and RF engineering
+	  among other hobbies.
+	      </p>
+      </div>
+
+      <div class="editor">
+        <%= image_tag "editors/jake.jpg", :class => "avatar left", :width => 100 %>
+        <h3><a href="http://vanderplas.com">Jake Vanderplas (@jakevdp)</a>, Editor: Astronomy and Machine Learning</h3>
+        <p>Astronomer exploring the role of data science in academia at <a href="http://escience.washington.edu/">University of Washington's eScience Institute</a>. Core contributor to <a href="http://scikit-learn.org/">scikit-learn</a> and other science-focused Python packages.</p>
+      </div>
+
+      <div class="main" id="costs">
+        <h1>Cost and Sustainability Model</h1>
+        <p>The Journal of Open Source Software is an open access journal <em>committed to running at minimal costs, with zero publication fees (<a href="https://en.wikipedia.org/wiki/Article_processing_charge">article processing charges</a>) or subscription fees</em>.</p>
+  <p>Under the NumFOCUS nonprofit umbrella, JOSS is now eligible to seek grants for sustaining its future. With an entirely volunteer team, JOSS is seeking to sustain its operations via donations and grants, keeping its low cost of operation and free service for authors.</p>
+
+        <p>In the spirit of transparency, below is an outline of our current running costs:</p>
+
+        <ul>
+          <li>Annual Crossref <a href="http://www.crossref.org/02publishers/20pub_fees.html">membership</a>: $275 / year</li>
+          <li>JOSS paper DOIs: $1 / accepted paper</li>
+          <li>JOSS website hosting (Heroku): $19 / month</li>
+        </ul>
+
+        <p>Assuming a publication rate of 200 papers per year this works out at ~$3.50 per paper ((19*12) + 200 + 275) / 200 .</p>
+      </div>
+
+      <div class="main" id="content_license">
+        <h1>Content Licensing</h1>
+        <p><a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons Licence" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/80x15.png" /></a> Copyright of JOSS papers is retained by submitting authors and accepted papers are subject to a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.</p>
+        <p>Any code snippets included in JOSS papers are subject to the <a href="https://opensource.org/licenses/MIT" target="_blank">MIT license</a> regardless of the license of the submitted software package under review.</p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/home/markdown.md
+++ b/app/views/home/markdown.md
@@ -1,0 +1,20 @@
+<div class="about-page columns">
+  <nav class="menu one-fourth column">
+    <a class="menu-item selected" href="#about">About</a>
+    <a class="menu-item" href="#code_of_conduct">Code of Conduct</a>
+    <a class="menu-item" href="#osi">Open Source Initiative</a>
+    <a class="menu-item" href="#author_guidelines">Author Guidelines</a>
+    <a class="menu-item" href="#reviewer_guidelines">Reviewer Guidelines</a>
+    <a class="menu-item" href="#editorial_board">Editorial Board</a>
+    <a class="menu-item" href="#costs">Cost and Sustainability Model</a>
+    <a class="menu-item" href="#content_license">Content Licensing</a>
+  </nav>
+
+  <div class="three-fourths column">
+    <div class="main" id="about">
+
+# Gekko
+
+    </div>
+  </div>
+</div>

--- a/config/initializers/markdown_handler.rb
+++ b/config/initializers/markdown_handler.rb
@@ -1,0 +1,1 @@
+ActionView::Template.register_template_handler :md, MarkdownHandler

--- a/lib/markdown_handler.rb
+++ b/lib/markdown_handler.rb
@@ -1,0 +1,18 @@
+class MarkdownHandler
+  class << self
+    def call(template)
+      compiled_source = erb.call(template)
+      "MarkdownHandler.render(begin;#{compiled_source};end)"
+    end
+
+    def render(text)
+      CommonMarker.render_html(text).html_safe
+    end
+
+    private
+
+    def erb
+      @erb ||= ActionView::Template.registered_template_handler(:erb)
+    end
+  end
+end


### PR DESCRIPTION
👋 @kyleniemeyer. A while back we talked about moving the views for the JOSS application to Markdown templates. I spent some time investigating this and I wanted to share where I got to and get your feedback.

Overall I'm somewhat negative about this approach. The main reason being that it's simply not realistic to remove all HTML from these views and keep a rich design, for example these things are going to be hard/very hard/impossible to remove:

- ['Callout text'](https://github.com/openjournals/joss/compare/markdown-all-the-things?expand=1#diff-4ccfeac7111276ca72deb2c4de61d42bR36)
- [Menus](https://github.com/openjournals/joss/compare/markdown-all-the-things?expand=1#diff-4ccfeac7111276ca72deb2c4de61d42bR1)
- [Images](https://github.com/openjournals/joss/compare/markdown-all-the-things?expand=1#diff-4ccfeac7111276ca72deb2c4de61d42bR46) need to run through the Rails asset pipeline and can't be simple Markdown image tags

Note, I started trying to migrate the 'about' page first and stopped [around here](https://github.com/openjournals/joss/compare/markdown-all-the-things?expand=1#diff-4ccfeac7111276ca72deb2c4de61d42bR147). 

What are your thoughts? IMHO having hybrid views with some HTML and some Markdown is _more confusing/weird_ than having plain ol' HTML.
