### PR TITLE
Withdrawing papers

### DIFF
--- a/app/controllers/papers_controller.rb
+++ b/app/controllers/papers_controller.rb
@@ -1,5 +1,5 @@
 class PapersController < ApplicationController
-  before_filter :require_user, :only => %w(new create update)
+  before_filter :require_user, :only => %w(new create update withdraw)
   before_filter :require_complete_profile, :only => %w(create)
   before_filter :require_admin_user, :only => %w(start_meta_review archive reject)
   protect_from_forgery :except => [ :api_start_review ]
@@ -121,6 +121,22 @@ class PapersController < ApplicationController
       redirect_to paper_path(@paper)
     else
       flash[:error] = "Paper could not be rejected"
+      redirect_to paper_path(@paper)
+    end
+  end
+
+  def withdraw
+    @paper = Paper.find_by_sha(params[:id])
+
+    unless current_user.is_owner_of?(@paper) || current_user.admin?
+      redirect_to paper_path(@paper) and return
+    end
+
+    if @paper.withdraw!
+      flash[:notice] = "Paper withdrawn"
+      redirect_to paper_path(@paper)
+    else
+      flash[:error] = "Paper could not be withdrawn"
       redirect_to paper_path(@paper)
     end
   end

--- a/app/controllers/papers_controller.rb
+++ b/app/controllers/papers_controller.rb
@@ -1,7 +1,7 @@
 class PapersController < ApplicationController
   before_filter :require_user, :only => %w(new create update)
   before_filter :require_complete_profile, :only => %w(create)
-  before_filter :require_admin_user, :only => %w(start_meta_review archive)
+  before_filter :require_admin_user, :only => %w(start_meta_review archive reject)
   protect_from_forgery :except => [ :api_start_review ]
 
   def recent

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,10 @@ class User < ActiveRecord::Base
     end
   end
 
+  def is_owner_of?(paper)
+    paper.submitting_author == self
+  end
+
   def orcid_url
     "http://orcid.org/" + uid
   end

--- a/app/views/papers/_admin.html.erb
+++ b/app/views/papers/_admin.html.erb
@@ -6,6 +6,10 @@
   <%= link_to "View review issue &raquo;".html_safe, paper.review_url, :target => "_blank" %>
  <% end %>
 
+<% if (current_user == paper.submitting_author) || current_user.admin? %>
+  <%= button_to "Withdraw paper", withdraw_paper_path(paper), :data => { :confirm => "Are you sure?" }, :class => "btn btn-danger" %>
+<% end %>
+
 <% if current_user.admin? %>
   <% unless paper.meta_review_issue_id %>
     <%= form_tag start_meta_review_paper_url(paper) do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
       post 'start_review'
       post 'start_meta_review'
       post 'reject'
+      post 'withdraw'
     end
 
     collection do

--- a/spec/controllers/papers_controller_spec.rb
+++ b/spec/controllers/papers_controller_spec.rb
@@ -93,6 +93,38 @@ describe PapersController, :type => :controller do
     end
   end
 
+  describe "Paper withdrawing" do
+    it "should work for an administrator" do
+      user = create(:admin_user)
+      allow(controller).to receive_message_chain(:current_user).and_return(user)
+      submitted_paper = create(:paper, :state => 'submitted')
+
+      post :withdraw, :id => submitted_paper.sha
+      expect(response).to be_redirect # as it's rejected the paper
+      expect(Paper.withdrawn.count).to eq(1)
+    end
+
+    it "should fail for a user who doesn't own the paper" do
+      user = create(:user)
+      allow(controller).to receive_message_chain(:current_user).and_return(user)
+      submitted_paper = create(:paper, :state => 'submitted')
+
+      post :withdraw, :id => submitted_paper.sha
+      expect(response).to be_redirect
+      expect(Paper.withdrawn.count).to eq(0)
+    end
+
+    it "should work for a user who owns the paper" do
+      user = create(:user)
+      allow(controller).to receive_message_chain(:current_user).and_return(user)
+      submitted_paper = create(:paper, :state => 'submitted', :submitting_author => user)
+
+      post :withdraw, :id => submitted_paper.sha
+      expect(response).to be_redirect
+      expect(Paper.withdrawn.count).to eq(1)
+    end
+  end
+
   describe "POST #create" do
     it "LOGGED IN responds with success" do
       user = create(:user)

--- a/spec/controllers/papers_controller_spec.rb
+++ b/spec/controllers/papers_controller_spec.rb
@@ -71,6 +71,28 @@ describe PapersController, :type => :controller do
     end
   end
 
+  describe "Paper rejection" do
+    it "should work for an administrator" do
+      user = create(:admin_user)
+      allow(controller).to receive_message_chain(:current_user).and_return(user)
+      submitted_paper = create(:paper, :state => 'submitted')
+
+      post :reject, :id => submitted_paper.sha
+      expect(response).to be_redirect # as it's rejected the paper
+      expect(Paper.rejected.count).to eq(1)
+    end
+
+    it "should fail for a standard user" do
+      user = create(:user)
+      allow(controller).to receive_message_chain(:current_user).and_return(user)
+      submitted_paper = create(:paper, :state => 'submitted')
+
+      post :reject, :id => submitted_paper.sha
+      expect(response).to be_redirect # as it's rejected the paper
+      expect(Paper.rejected.count).to eq(0)
+    end
+  end
+
   describe "POST #create" do
     it "LOGGED IN responds with success" do
       user = create(:user)

--- a/spec/views/papers/show.html.erb_spec.rb
+++ b/spec/views/papers/show.html.erb_spec.rb
@@ -41,6 +41,28 @@ describe 'papers/show.html.erb' do
       expect(rendered).to have_selector("input[type=submit][value='Reject paper']")
     end
 
+    it "shows the withdraw button to paper owners" do
+      user = create(:user)
+      allow(view).to receive_message_chain(:current_user).and_return(user)
+
+      paper = create(:paper, :state => "submitted", :submitting_author => user)
+      assign(:paper, paper)
+
+      render :template => "papers/show.html.erb"
+      expect(rendered).to have_selector("input[type=submit][value='Withdraw paper']")
+    end
+
+    it "shows the withdraw button to admins" do
+      user = create(:user, :admin => true)
+      allow(view).to receive_message_chain(:current_user).and_return(user)
+
+      paper = create(:paper, :state => "submitted")
+      assign(:paper, paper)
+
+      render :template => "papers/show.html.erb"
+      expect(rendered).to have_selector("input[type=submit][value='Withdraw paper']")
+    end
+
     it "doesn't displays buttons when there's a GitHub issue" do
       user = create(:user, :admin => true)
       allow(view).to receive_message_chain(:current_user).and_return(user)


### PR DESCRIPTION
This PR does a couple of things:

1. Fixes a potential security issues whereby any user could (in theory) reject a submission
2. Adds the ability for a user to withdraw a paper (fixes #177)