### PR TITLE
Add bootsnap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'aasm', '~> 4.1.0'
+gem 'bootsnap', require: false
 gem 'dotenv', '~> 2.2.1'
 gem 'github-markdown', '~> 0.6.9'
 gem 'honeybadger', '~> 3.2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -44,4 +44,5 @@ group :development do
   gem 'web-console', '~> 3.5.1'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
+  gem 'spring-commands-rspec', group: :development
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,6 +219,8 @@ GEM
       faraday (~> 0.8, < 0.10)
     spring (2.0.2)
       activesupport (>= 4.2)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -280,6 +282,7 @@ DEPENDENCIES
   sanitize (~> 4.5.0)
   sass-rails (~> 5.0.7)
   spring
+  spring-commands-rspec
   uglifier (= 4.0.1)
   unicorn (~> 5.3.1)
   web-console (~> 3.5.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,8 @@ GEM
     addressable (2.4.0)
     arel (8.0.0)
     bindex (0.5.0)
+    bootsnap (1.2.0)
+      msgpack (~> 1.0)
     builder (3.2.3)
     byebug (9.1.0)
     capybara (2.16.1)
@@ -104,6 +106,7 @@ GEM
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.10.3)
+    msgpack (1.2.4)
     multi_json (1.12.2)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
@@ -254,6 +257,7 @@ PLATFORMS
 
 DEPENDENCIES
   aasm (~> 4.1.0)
+  bootsnap
   capybara (~> 2.16.1)
   coffee-rails (~> 4.2.2)
   commonmarker (~> 0.17.7)

--- a/bin/rake
+++ b/bin/rake
@@ -1,4 +1,9 @@
 #!/usr/bin/env ruby
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
 require_relative '../config/boot'
 require 'rake'
 Rake.application.run

--- a/bin/rspec
+++ b/bin/rspec
@@ -4,6 +4,5 @@ begin
 rescue LoadError => e
   raise unless e.message.include?('spring')
 end
-APP_PATH = File.expand_path('../../config/application', __FILE__)
-require_relative '../config/boot'
-require 'rails/commands'
+require 'bundler/setup'
+load Gem.bin_path('rspec-core', 'rspec')

--- a/bin/spring
+++ b/bin/spring
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+
+# This file loads spring without using Bundler, in order to be fast.
+# It gets overwritten when you run the `spring binstub` command.
+
+unless defined?(Spring)
+  require 'rubygems'
+  require 'bundler'
+
+  lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
+  spring = lockfile.specs.detect { |spec| spec.name == "spring" }
+  if spring
+    Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
+    gem 'spring', spring.version
+    require 'spring/binstub'
+  end
+end

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,4 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
+require 'bootsnap/setup'


### PR DESCRIPTION
I was feeling impatient with specs, so I added [bootsnap](https://github.com/Shopify/bootsnap) for snappier boots.  I also noticed the spring binstubs weren't installed, but I wasn't sure if you were opposed -- I'll add them here if you're into it.

Running `$ time rspec 'spec/models/paper_spec.rb[1:1]'`

Before: `real    0m4.723s`

After: `real    0m2.079s`

With spring: `real    0m0.747s`
