### PR TITLE
Add two new sample papers

### DIFF
--- a/app/views/content/about/_submission_flow.html.erb
+++ b/app/views/content/about/_submission_flow.html.erb
@@ -6,6 +6,6 @@
 
 <ul>
   <li>Make software available in an open repository (GitHub, Bitbucket etc.) and include an <a href="https://opensource.org/licenses">OSI approved open source license</a></li>
-  <li>Author a short Markdown paper <code>paper.md</code> with a title, summary, author names, affiliations, and key references. See an example <a href="https://github.com/arfon/fidgit/tree/master/paper" target="_blank">here</a></li>
+  <li>Author a short Markdown paper <code>paper.md</code> with a title, summary, author names, affiliations, and key references. See an example <a href="https://github.com/sjspielman/phyphy/tree/master/paper" target="_blank">here</a> or <a href="https://github.com/ResidentMario/missingno/blob/master/paper.md" target="_blank">here</a></li>
   <li>Ideally we would also like you to create a metadata file and include it in your repository describing your software. <a href="https://gist.github.com/arfon/478b2ed49e11f984d6fb" target= "_blank">This script</a> automates the generation of this metadata.</li>
 </ul>


### PR DESCRIPTION
fixes #374 

both submissions are relatively recent (2017.12.05 and 2017.10.28)
https://github.com/openjournals/joss-reviews/issues/484
https://github.com/openjournals/joss-reviews/issues/443

One is much shorter, and the other includes various images.

One has a `paper/` directory, the other has `paper.bib` and `paper.md` in the root of the repository.

Hope this is useful!