### PR TITLE
Pad paper details with lists

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -324,6 +324,12 @@
   .list-paper > .details > .paper-title {
     font-size: 16px;
   }
+
+  .list-paper > .details > ul, ol {
+    padding-left: 40px;
+    margin-top: 13px;
+    margin-bottom: 13px;
+  }
 }
 
 .main {


### PR DESCRIPTION
fixes #292 

I couldn't get the DB running, so I couldn't actually test this locally. I made this change in-browser and they seemed to get this behavior:
![image](https://user-images.githubusercontent.com/2541209/39571944-279660d6-4e82-11e8-993f-74f5585cc7e3.png)

