### PR TITLE
Adding reviewer search to dashboard

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -17,6 +17,9 @@ class HomeController < ApplicationController
       @editor = Editor.first
     end
 
+    @reviewer = params[:reviewer].nil? ? "@arfon" : params[:reviewer]
+    @reviewer_papers = Paper.unscoped.where(":reviewer = ANY(reviewers)", reviewer: @reviewer).group_by_month(:accepted_at).count
+
     @accepted_papers = Paper.unscoped.visible.group_by_month(:accepted_at).count
     @editor_papers = Paper.unscoped.where(:editor => @editor).visible.group_by_month(:accepted_at).count
   end

--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -171,7 +171,7 @@ class Paper < ActiveRecord::Base
 
   # Update the paper with the reviewer GitHub handles
   def set_reviewers(reviewers)
-    reviewers = reviewers.split(',').each {|r| r.prepend('@') unless r.start_with?('@') }
+    reviewers = reviewers.split(',').each(&:strip!).each {|r| r.prepend('@') unless r.start_with?('@') }
     self.update_attribute(:reviewers, reviewers)
   end
 

--- a/app/views/home/dashboard.html.erb
+++ b/app/views/home/dashboard.html.erb
@@ -14,7 +14,7 @@
   { name: "Papers edited by #{@editor.login} by month", data: @editor_papers }
 ], height: "500px", colors: ["#8FBC8F"], :id => "editor", legend: false, library: { scales: { xAxes: [{ position: 'bottom' }], yAxes: [{ position: 'left', gridLines: { display: true, drawBorder: true }, ticks: { min: 0, max: 20, stepSize: 5}}, { position: 'right', gridLines: { display: false, drawBorder: true }, ticks: { min: 0, max: 20, stepSize: 5}}]}} %>
 
-<h2>Papers reviwed per month by <%= @reviewer %></h2>
+<h2>Papers reviewed per month by <%= @reviewer %></h2>
 
 <div style="font-weight: bolder; padding-left: 40px; float: left;">Search for reviewer (hit enter to search): <%= form_for("/dashboard", :html => { :method => 'GET', :style => "display: inline !important;" }) do |f| %><%= text_field_tag 'reviewer', @reviewer  %><% end %> </div>
 

--- a/app/views/home/dashboard.html.erb
+++ b/app/views/home/dashboard.html.erb
@@ -5,17 +5,24 @@
   { name: "Accepted papers by month", data: @accepted_papers }
 ], height: "500px", legend: false, library: { scales: { xAxes: [{ position: 'bottom' }], yAxes: [{ position: 'left', gridLines: { display: true, drawBorder: true }, ticks: { min: 0, max: 40, stepSize: 5}}, { position: 'right', gridLines: { display: false, drawBorder: true }, ticks: { min: 0, max: 40, stepSize: 5}}]}} %>
 
-<h2>Accepted papers by month by editor</h2>
+<h2>Accepted papers per month by editor</h2>
 
 <p style="font-weight: bolder; padding-left: 40px;">Select editor: <%= select_tag 'editors', options_from_collection_for_select(Editor.all, "login", "login", params[:editor].blank? ? current_user.editor.login : params[:editor]),
     :onchange => "top.location.href='/dashboard?editor=' + this.options[this.selectedIndex].value + '#editor';" %></p>
-
 
 <%= column_chart [
   { name: "Papers edited by #{@editor.login} by month", data: @editor_papers }
 ], height: "500px", colors: ["#8FBC8F"], :id => "editor", legend: false, library: { scales: { xAxes: [{ position: 'bottom' }], yAxes: [{ position: 'left', gridLines: { display: true, drawBorder: true }, ticks: { min: 0, max: 20, stepSize: 5}}, { position: 'right', gridLines: { display: false, drawBorder: true }, ticks: { min: 0, max: 20, stepSize: 5}}]}} %>
 
+<h2>Papers reviwed per month by <%= @reviewer %></h2>
 
+<div style="font-weight: bolder; padding-left: 40px; float: left;">Search for reviewer (hit enter to search): <%= form_for("/dashboard", :html => { :method => 'GET', :style => "display: inline !important;" }) do |f| %><%= text_field_tag 'reviewer', @reviewer  %><% end %> </div>
+
+<%= column_chart [
+  { name: "Papers reviewed by #{@reviewer} by month", data: @reviewer_papers }
+], height: "500px", colors: ["#FFA500"], :id => "reviewers", legend: false, library: { scales: { xAxes: [{ position: 'bottom' }], yAxes: [{ position: 'left', gridLines: { display: true, drawBorder: true }, ticks: { min: 0, max: 20, stepSize: 5}}, { position: 'right', gridLines: { display: false, drawBorder: true }, ticks: { min: 0, max: 20, stepSize: 5}}]}} %>
+
+<br /><br />
 
 <h2>Editor statistics</h2>
 <table class="editor-stats">

--- a/db/migrate/20180820150654_add_paper_indexes.rb
+++ b/db/migrate/20180820150654_add_paper_indexes.rb
@@ -1,0 +1,7 @@
+class AddPaperIndexes < ActiveRecord::Migration[5.1]
+  def change
+    add_index :editors, :user_id
+    add_index :papers, :editor_id
+    add_index :papers, :reviewers, using: 'gin'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180816192335) do
+ActiveRecord::Schema.define(version: 20180820150654) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 20180816192335) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id"
+    t.index ["user_id"], name: "index_editors_on_user_id"
   end
 
   create_table "papers", id: :serial, force: :cascade do |t|
@@ -54,6 +55,8 @@ ActiveRecord::Schema.define(version: 20180816192335) do
     t.string "kind"
     t.integer "editor_id"
     t.string "reviewers", default: [], array: true
+    t.index ["editor_id"], name: "index_papers_on_editor_id"
+    t.index ["reviewers"], name: "index_papers_on_reviewers", using: :gin
     t.index ["sha"], name: "index_papers_on_sha"
     t.index ["user_id"], name: "index_papers_on_user_id"
   end

--- a/spec/controllers/papers_controller_spec.rb
+++ b/spec/controllers/papers_controller_spec.rb
@@ -111,6 +111,22 @@ describe PapersController, :type => :controller do
       expect(editor.papers.count).to eq(1)
       expect(paper.reload.reviewers).to eq(['@mickey', '@minnie'])
     end
+
+    it "with the correct API key and multiple reviewers should strip whitespace" do
+      user = create(:user)
+      editor = create(:editor, :login => "mouse")
+      editing_user = create(:user, :editor => editor)
+
+      paper = create(:review_pending_paper, :state => "review_pending", :meta_review_issue_id => 1234, :user_id => user.id)
+      fake_issue = Object.new
+      allow(fake_issue).to receive(:number).and_return(1)
+      allow(GITHUB).to receive(:create_issue).and_return(fake_issue)
+
+      post :api_start_review, params: {:secret => "mooo", :id => 1234, :reviewers => "  white   ,space   ", :editor => "mouse"}
+      expect(response).to be_created
+      expect(editor.papers.count).to eq(1)
+      expect(paper.reload.reviewers).to eq(['@white', '@space'])
+    end
   end
 
   describe "POST #api_deposit" do


### PR DESCRIPTION
This PR adds a simple search form (and graph) to show reviewer stats for a single GitHub handle:

<img width="993" alt="screen shot 2018-08-20 at 2 11 14 pm" src="https://user-images.githubusercontent.com/4483/44358439-05379580-a483-11e8-9878-ffac84641c51.png">

/ cc @labarba 