### PR TITLE
[WIP] Add authors information to accepted papers pages

### DIFF
--- a/db/migrate/20181019161622_add_authors_column.rb
+++ b/db/migrate/20181019161622_add_authors_column.rb
@@ -1,5 +1,5 @@
 class AddAuthorsColumn < ActiveRecord::Migration[5.1]
   def change
-    add_column :papers, :authors:, :text
+    add_column :papers, :authors, :text
   end
 end

--- a/db/migrate/20181019161622_add_authors_column.rb
+++ b/db/migrate/20181019161622_add_authors_column.rb
@@ -1,0 +1,5 @@
+class AddAuthorsColumn < ActiveRecord::Migration[5.1]
+  def change
+    add_column :papers, :authors:, :text
+  end
+end


### PR DESCRIPTION
This PR is WIP to add the ORCID/author names as suggested in #434. @arfon suggested there be a new column in the `papers` table to store the authors from the Markdown paper header. I'm not sure where the `paper.md` is read, or how the `params` hash is filled with, e.g., the `citation_string`. There also already appears to be an `authors` key in this hash, e.g., https://github.com/openjournals/joss/blob/30f70cd53961521da272ab6d28e027c3c201c1c0/app/controllers/papers_controller.rb#L115 So, my question is, how do I get the data to serialize it, and how do I put that into the database? Thanks 😄 