### PR TITLE
Fix typo in review criteria documentation

### DIFF
--- a/docs/review_criteria.md
+++ b/docs/review_criteria.md
@@ -20,7 +20,7 @@ As outlined in the [submission guidelines provided to authors](submitting.html#w
 
 ### Software license
 
-There should be an [OSI approved](https://opensource.org/licenses/alphabetical) license included in the repository. Common licenses such as those listed on [Choose an open source license](https://choosealicense.com) are preferred. Note there should be an actual license file present in the repository not just a reference to the license.
+There should be an [OSI approved](https://opensource.org/licenses/alphabetical) license included in the repository. Common licenses such as those listed on [choosealicense.com](https://choosealicense.com) are preferred. Note there should be an actual license file present in the repository not just a reference to the license.
 
 > **Acceptable:** A plain-text LICENSE file with the contents of an OSI approved license<br />            
 > **Not acceptable:** A phrase such as 'MIT license' in a README file

--- a/docs/review_criteria.md
+++ b/docs/review_criteria.md
@@ -20,7 +20,7 @@ As outlined in the [submission guidelines provided to authors](submitting.html#w
 
 ### Software license
 
-There should be an [OSI approved](https://opensource.org/licenses/alphabetical) license included in the repository. Common licenses such as those listed on http://choosealicense.com are preferred. Note there should be an actual license file present in the repository not just a reference to the license.
+There should be an [OSI approved](https://opensource.org/licenses/alphabetical) license included in the repository. Common licenses such as those listed on [Choose an open source license](https://choosealicense.com) are preferred. Note there should be an actual license file present in the repository not just a reference to the license.
 
 > **Acceptable:** A plain-text LICENSE file with the contents of an OSI approved license<br />            
 > **Not acceptable:** A phrase such as 'MIT license' in a README file


### PR DESCRIPTION
The link under [Software license](https://joss.readthedocs.io/en/latest/review_criteria.html#software-license) to Choose an open source license is a dead link and this is a fix for it.


![screenshot_2018-12-29 review criteria joss documentation](https://user-images.githubusercontent.com/4144645/50536736-835e2400-0b68-11e9-88b6-569e4ce62714.png)

