### PR TITLE
Specify that links to issues should be in comments

### DIFF
--- a/app/views/shared/review_body.erb
+++ b/app/views/shared/review_body.erb
@@ -18,7 +18,7 @@ Markdown: [![status](<%= url %>/papers/<%= paper.sha %>/status.svg)](<%= url %>/
 ```
 **Reviewers and authors**:
 
-Please avoid lengthy details of difficulties in the review thread. Instead, please create a new issue in the <a href="<%= paper.repository_url %>" target="_blank">target repository</a> and link to those issues (especially acceptance-blockers) in the review thread below. (For completists: if the target issue tracker is also on GitHub, linking the review thread in the issue or vice versa will create corresponding breadcrumb trails in the link target.)
+Please avoid lengthy details of difficulties in the review thread. Instead, please create a new issue in the <a href="<%= paper.repository_url %>" target="_blank">target repository</a> and link to those issues (especially acceptance-blockers) by leaving a comment in the review thread below. (For completists: if the target issue tracker is also on GitHub, linking the review thread in the issue or vice versa will create corresponding breadcrumb trails in the link target.)
 
 ## Reviewer instructions & questions
 

--- a/app/views/shared/review_body.erb
+++ b/app/views/shared/review_body.erb
@@ -18,7 +18,7 @@ Markdown: [![status](<%= url %>/papers/<%= paper.sha %>/status.svg)](<%= url %>/
 ```
 **Reviewers and authors**:
 
-Please avoid lengthy details of difficulties in the review thread. Instead, please create a new issue in the <a href="<%= paper.repository_url %>" target="_blank">target repository</a> and link to those issues (especially acceptance-blockers) by leaving a comment in the review thread below. (For completists: if the target issue tracker is also on GitHub, linking the review thread in the issue or vice versa will create corresponding breadcrumb trails in the link target.)
+Please avoid lengthy details of difficulties in the review thread. Instead, please create a new issue in the <a href="<%= paper.repository_url %>" target="_blank">target repository</a> and link to those issues (especially acceptance-blockers) by leaving comments in the review thread below. (For completists: if the target issue tracker is also on GitHub, linking the review thread in the issue or vice versa will create corresponding breadcrumb trails in the link target.)
 
 ## Reviewer instructions & questions
 


### PR DESCRIPTION
Just had a reviewer edit the issue body to include links to issues they raised on the target repository.
It seems they interpreted "review thread" as the checklist (which is right below those instructions). This PR clarifies that the links should be posted as comments on the review thread to avoid future misunderstandings.