### PR TITLE
review_body: link to new site (joss.readthedocs.io)

### DIFF
--- a/app/views/shared/review_body.erb
+++ b/app/views/shared/review_body.erb
@@ -26,7 +26,7 @@ Please avoid lengthy details of difficulties in the review thread. Instead, plea
 1. Make sure you're logged in to your GitHub account
 2. Be sure to accept the invite at this URL: https://github.com/openjournals/joss-reviews/invitations
 
-The reviewer guidelines are available here: https://joss.theoj.org/about#reviewer_guidelines. Any questions/concerns please let <%= editor %> know.
+The reviewer guidelines are available here: https://joss.readthedocs.io/en/latest/reviewer_guidelines.html. Any questions/concerns please let <%= editor %> know.
 
 ✨ **Please try and complete your review in the next two weeks** ✨ 
 


### PR DESCRIPTION
@arfon I recall discussing running joss.readthedocs.io on our custom domain, but in lieu of implementing that, our issues should point to where the instructions actually reside.