### PR TITLE
Replace COI.md link w/ link to COI on RTD

### DIFF
--- a/docs/review_checklist.md
+++ b/docs/review_checklist.md
@@ -10,7 +10,7 @@ Below is an example of the review checklist for the [Yellowbrick JOSS submission
 ```
 ### Conflict of interest
 
-- As the reviewer I confirm that I have read the [JOSS conflict of interest policy](https://github.com/openjournals/joss/blob/master/COI.md) and that there are no conflicts of interest for me to review this work.
+- As the reviewer I confirm that I have read the [JOSS conflict of interest policy](https://joss.readthedocs.io/en/latest/reviewer_guidelines.html#joss-conflict-of-interest-policy) and that there are no conflicts of interest for me to review this work.
 
 ### Code of Conduct
 

--- a/docs/review_checklist.md
+++ b/docs/review_checklist.md
@@ -10,7 +10,7 @@ Below is an example of the review checklist for the [Yellowbrick JOSS submission
 ```
 ### Conflict of interest
 
-- As the reviewer I confirm that I have read the [JOSS conflict of interest policy](https://joss.readthedocs.io/en/latest/reviewer_guidelines.html#joss-conflict-of-interest-policy) and that there are no conflicts of interest for me to review this work.
+- As the reviewer I confirm that I have read the [JOSS conflict of interest policy](reviewer_guidelines.html#joss-conflict-of-interest-policy) and that there are no conflicts of interest for me to review this work.
 
 ### Code of Conduct
 


### PR DESCRIPTION
- The read-the-docs link to COI.md on github was broken.
- The `.md` file extension was being stripped leading to a 404 error.
- Replace the link to GH markdown with the COI as documented on the joss read-the-docs site

I'm not familiar with publishing to read-the-docs so there may be a better/obvious alternate fix.