### PR TITLE
Add example citation commands

### DIFF
--- a/docs/submitting.md
+++ b/docs/submitting.md
@@ -111,6 +111,11 @@ Citations to entries in paper.bib should be in
 [rMarkdown](http://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html)
 format.
 
+For a quick reference, the following citation commands can be used:
+- `@author:2001`  ->  "Author et al. (2001)"
+- `[@author:2001]` -> "(Author et al., 2001)"
+- `[@author1:2001; @author2:2001]` -> "(Author1 et al., 2001; Author2 et al., 2002)"
+
 # Figures
 
 Figures can be included like this: ![Example figure.](figure.png)


### PR DESCRIPTION
There are multiple citation commands that change the in-text format, and we should document these in an obvious place.