### PR TITLE
Proposed changes to checklist

### DIFF
--- a/app/views/content/github/_review_checklist.erb
+++ b/app/views/content/github/_review_checklist.erb
@@ -10,8 +10,7 @@
 
 - [ ] **Repository:** Is the source code for this software available at the <%= link_to "repository url", paper.repository_url, :target => "_blank" %>?
 - [ ] **License:** Does the repository contain a plain-text LICENSE file with the contents of an [OSI approved](https://opensource.org/licenses/alphabetical) software license?
-- [ ] **Version:** Does the release version given match the GitHub release (<%= paper.software_version %>)?
-- [ ] **Authorship:** Has the submitting author (<%= paper.submitting_author.github_username %>) made major contributions to the software? Does the full list of paper authors seem appropriate and complete?
+- [ ] **Contribution and authorship:** Based on the list of <%= link_to "contributors", paper.repository_url + "/graphs/contributors", :target => "_blank" %> to this project, can you confirm: 1) that the submitting author (<%= paper.submitting_author.github_username %>) made major contributions to the software?, and 2) That the full list of paper authors seems appropriate and complete?
 
 ### Functionality
 
@@ -25,11 +24,13 @@
 - [ ] **Installation instructions:** Is there a clearly-stated list of dependencies? Ideally these should be handled with an automated package management solution.
 - [ ] **Example usage:** Do the authors include examples of how to use the software (ideally to solve real-world analysis problems).
 - [ ] **Functionality documentation:** Is the core functionality of the software documented to a satisfactory level (e.g., API method documentation)?
-- [ ] **Automated tests:** Are there automated tests or manual steps described so that the function of the software can be verified?
+- [ ] **Automated tests:** Are there automated tests or manual steps described so that the functionality of the software can be verified?
 - [ ] **Community guidelines:** Are there clear guidelines for third parties wishing to 1) Contribute to the software 2) Report issues or problems with the software 3) Seek support
 
 ### Software paper
 
-- [ ] **Authors:** Does the `paper.md` file include a list of authors with their affiliations?
+- [ ] **Summary:** Has a clear description of the high-level functionality and purpose of the software for a diverse, non-specialist audience been provided?
 - [ ] **A statement of need:** Do the authors clearly state what problems the software is designed to solve and who the target audience is?
+- [ ] **State of the art:** Are key relevant or alternative approaches cited and briefly discussed?
+- [ ] **Quality of writing:** Is the paper well written (i.e. such that it does not require editing for structure, language, and writing quality)?
 - [ ] **References:** Do all archival references that should have a DOI list one (e.g., papers, datasets, software)?


### PR DESCRIPTION
I did the following: 

1. Added additional requirements for paper. 
2. Removed version tick box.
3. Updated the text about authorship and contributions. I attempted to use the following to link to the project contributors: 
```Ruby
<%= link_to “contributors”, paper.repository_url + “/graphs/contributors”, :target => “_blank” %>
```
I also merged the authorship point from the paper section with this point. 
4. I removed the question about authors/affiliations. I propose we let Whedon check for affiliations instead, perhaps based on ORCID, and to list missing affiliations if any. It feels odd to ask the reviewers to check the affiliations, i.e. they'd need to google the authors and check where they work. Not sure if that is their job. 

I feel perhaps the References point (asking about DOI's) can be removed too since Whedon checks that at the end. But perhaps we want to start the DOI discussion earlier on in the review process so I left it for now. 