### PR TITLE
[WIP] Stubbing out docs for paper preparation

### DIFF
--- a/docs/preparing_your_paper.md
+++ b/docs/preparing_your_paper.md
@@ -1,0 +1,34 @@
+Preparing your paper
+==========================
+
+## Basics
+
+- How the paper is being produced (Pandoc etc.)
+- How authors can test their submission (what Pandoc command to run)
+  - https://gist.github.com/arfon/09a11047de1c972e37f77e95d2c10efa
+- Iterating with Whedon
+
+## Example paper
+
+- Basic paper structure
+- adrn paper
+
+## Citations
+
+- Show how to create them.
+- Multiple citations inline
+- APA ...
+
+## Figures
+
+- Supported types
+- How to link to them (RAW urls for GitHub)
+- Captions
+- Figure placement (good luck!)
+
+## Special cases
+
+- Multiple authors
+- Corresponding authors
+
+## FAQ?


### PR DESCRIPTION
I'd like to write some better documentation to help authors preparing JOSS papers. For most authors this is a pretty straightforward process, but when it goes wrong, or authors have more specialist needs for their papers, we don't have very good documentation to support them.

I'd be interested to hear from @openjournals/joss-editors what they think we should try and capture here based on their experiences.