### PR TITLE
Email authors on submission

### DIFF
--- a/app/mailers/notifications.rb
+++ b/app/mailers/notifications.rb
@@ -7,6 +7,12 @@ class Notifications < ApplicationMailer
     mail(:to => EDITOR_EMAILS, :subject => "New submission: #{paper.title}")
   end
 
+  def author_submission_email(paper)
+    @url  = "#{Rails.application.settings["url"]}/papers/#{paper.sha}"
+    @paper = paper
+    mail(:to => paper.submitting_author.email, :subject => "Thanks for your submission: #{paper.title}")
+  end
+
   def editor_weekly_email(editor, pending_issues, assigned_issues, recently_closed_issues)
     @pending_issues = pending_issues
     @assigned_issues = assigned_issues

--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -70,7 +70,7 @@ class Paper < ActiveRecord::Base
   scope :everything, lambda { where('state NOT IN (?)', ['rejected', 'withdrawn']) }
 
   before_create :set_sha, :set_last_activity
-  after_create :notify_editors
+  after_create :notify_editors, :notify_author
 
   validates_presence_of :title
   validates_presence_of :repository_url, :message => "^Repository address can't be blank"
@@ -80,6 +80,10 @@ class Paper < ActiveRecord::Base
 
   def notify_editors
     Notifications.submission_email(self).deliver_now
+  end
+
+  def notify_author
+    Notifications.author_submission_email(self).deliver_now
   end
 
   def self.featured

--- a/app/views/home/profile.html.erb
+++ b/app/views/home/profile.html.erb
@@ -23,7 +23,34 @@
   <div id ="row" class="paper-list">
     <% if @current_user.papers.any? %>
       <h2>Your papers</h2>
-      <%= render :partial => "papers/list", :locals => { :papers => @current_user.papers } %>
+      <% @current_user.papers.each do |paper| %>
+      <div class="paper-card">
+        <div class="row">
+          <div class="col-lg-9">
+            <%= pretty_status_badge(paper) %> <%= time_words(paper) %>
+            <h2 class="paper-title"><%= link_to paper.title, paper_path(paper) %>
+              <!-- <span class="badge-lang">Python</span>-->
+            </h2>
+            <%# formatted_body(paper, 400) %>
+          </div>
+          <div class="col-lg-3 paper-meta">
+            <div class="submitted_by">
+              <%= link_to submittor_github(paper), :target => "_blank" do %>
+              <%= image_tag submittor_avatar(paper), size: "24x24" %>
+              <%= paper.submitting_author.pretty_github_username %>
+              <% end %>
+            </div>
+            <div class="doi">
+              <% if paper.pretty_doi == "DOI pending" %>
+              <%= image_tag 'doi.svg' %><%= link_to "Pending", paper_path(paper) %>
+              <% else %>
+              <%= image_tag 'doi.svg' %><%= link_to paper.doi, paper_path(paper) %>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      </div>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/notifications/author_submission_email.html.erb
+++ b/app/views/notifications/author_submission_email.html.erb
@@ -1,0 +1,8 @@
+Hello there, thanks for your submission to <em><%= Rails.application.settings['abbreviation'] %></em>.
+
+Your paper, <em>'<%= @paper.title %>'</em>, is currently awaiting triage by our managing editor. This generally takes between 24 and 72 hours and until then, your paper won't show up in the https://github.com/<%= Rails.application.settings['reviews'] %> repository.
+
+You can view the latest status of your paper here: <%= @url %>
+
+Many thanks
+The <%= Rails.application.settings['abbreviation'] %> editorial robot.

--- a/app/views/notifications/author_submission_email.text.erb
+++ b/app/views/notifications/author_submission_email.text.erb
@@ -1,0 +1,8 @@
+Hello there, thanks for your submission to <%= Rails.application.settings['abbreviation'] %>.
+
+Your paper, '<%= @paper.title %>', is currently awaiting triage by our managing editor. This generally takes between 24 and 72 hours and until then, your paper won't show up in the https://github.com/<%= Rails.application.settings['reviews'] %> repository.
+
+You can view the latest status of your paper here: <%= @url %>
+
+Many thanks
+The <%= Rails.application.settings['abbreviation'] %> editorial robot.

--- a/docs/submitting.md
+++ b/docs/submitting.md
@@ -192,7 +192,7 @@ Note that the paper ends with a References heading, and the references are built
 Submission then is as simple as:
 
 - Filling in the [short submission form](http://joss.theoj.org/papers/new)
-- Waiting for reviewers to be assigned over in the JOSS reviews repository: https://github.com/openjournals/joss-reviews
+- Waiting for the managing editor to start a pre-review issue over in the JOSS reviews repository: https://github.com/openjournals/joss-reviews
 
 ## Submission requirements
 

--- a/spec/factories/papers_factory.rb
+++ b/spec/factories/papers_factory.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     repository_url    'http://github.com/arfon/fidgit'
     archive_doi       'https://doi.org/10.0001/zenodo.12345'
     software_version  'v1.0.0'
+    submitting_author { create(:user) }
 
     created_at  { Time.now }
     updated_at  { Time.now }

--- a/spec/mailers/notifications_spec.rb
+++ b/spec/mailers/notifications_spec.rb
@@ -7,4 +7,11 @@ describe Notifications, :type => :mailer do
 
     expect(mail.subject).to match /Nice paper/
   end
+
+  it "should tell the submitting author to chill out" do
+    paper = create(:paper, :title => "Nice paper!")
+    mail = Notifications.author_submission_email(paper)
+
+    expect(mail.text_part.body).to match /is currently awaiting triage by our managing editor/
+  end
 end

--- a/spec/models/paper_spec.rb
+++ b/spec/models/paper_spec.rb
@@ -121,10 +121,10 @@ describe Paper do
     end
   end
 
-  it "should email the editor when submitted" do
+  it "should email the editor AND submitting author when submitted" do
     paper = build(:paper)
 
-    expect {paper.save}.to change { ActionMailer::Base.deliveries.count }.by(1)
+    expect {paper.save}.to change { ActionMailer::Base.deliveries.count }.by(2)
   end
 
   it "should be able to be withdrawn at any time" do


### PR DESCRIPTION
Currently when an author submits they don't really receive any kind of notification that their submission was successful which can lead to confusion and duplicate submissions.

This PR adds a simple email to the author telling them that their paper has been submitted and that it's awaiting triage by the managing editor. 

There's also a small bug fix that stopped papers awaiting triage from showing up on the user profile.

/ cc https://github.com/openjournals/joss/pull/566