### PR TITLE
Fixes PDF size error

### DIFF
--- a/app/assets/javascripts/papers.coffee
+++ b/app/assets/javascripts/papers.coffee
@@ -30,4 +30,5 @@ $ ->
   $("form#new_paper").submit ->
     e.preventDefault()
 
-  clipboard = new Clipboard('.clippy')
+  if (typeof Clipboard != 'undefined')
+    clipboard = new Clipboard('.clippy')

--- a/app/assets/javascripts/papers.coffee
+++ b/app/assets/javascripts/papers.coffee
@@ -12,23 +12,22 @@ authorCheck = ->
     $("#author-submit").addClass('disabled')
     $("#author-submit").prop('disabled', true)
 
+setPaperSize = ->
+  if($("#joss-paper").length > 0)
+    paper = $('#joss-paper')
+    width = paper.width()
+    height = width * 1.41421
+    paper.css('height', height)
+
 $(document).on 'change', '.pre-check', authorCheck
 
+$(window).resize ->
+  setPaperSize()
+
 $ ->
+  setPaperSize()
+
   $("form#new_paper").submit ->
     e.preventDefault()
 
   clipboard = new Clipboard('.clippy')
-
-  if($("#joss-paper").length > 0)
-    paper = $('#joss-paper')
-    width = paper.width()
-    height = width * 1.41421
-    paper.css('height', height)
-
-$(window).resize ->
-  if($("#joss-paper").length > 0)
-    paper = $('#joss-paper')
-    width = paper.width()
-    height = width * 1.41421
-    paper.css('height', height)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -220,12 +220,12 @@ Editor.create(
   first_name: "Kevin M.",
   last_name: "Moerman",
   login: "Kevin-Mattheus-Moerman",
-  email: "kmoerman@mit.edu",
+  email: "kevin.moerman@nuigalway.ie",
   avatar_url: "/assets/editors/kevin-0259234e0f286791f360a601ebd7ef3bc0e9f5d95c853121c24d540bbb795f60.png",
   categories: ["Computational mechanics, Biomechanics, Finite Element Analysis, Meshing, Design Optimization, Inverse Analysis, Image-based Modelling"],
   url: "https://kevinmoerman.org/",
   description: <<-STR.strip_heredoc()
-    Computational mechanics and design engineer at NUI Galway, research affiliate <a href="http://www.media.mit.edu/">MIT Media's lab</a>. Developer for the <a href="http://www.gibboncode.org/">GIBBON</a> project.
+    Lecturer Biomedical Engineering <a href="https://www.nuigalway.ie/our-research/people/engineering-and-informatics/kevinmoerman/">, College of Engineering & Informatics NUI Galway</a>, Research Affiliate MIT Media lab, Senior Member IEEE, Developer for the <a href="http://www.gibboncode.org/">GIBBON</a> computational biomechanics project.
   STR
 )
 


### PR DESCRIPTION
The javascript for the paper view is not fully run when Clipboard failed to load. This PR refactors the `papers.cofee` code to simplify and check for ReferenceError.
This should fix #573.