### PR TITLE
Filtering tweaks

### DIFF
--- a/app/controllers/papers_controller.rb
+++ b/app/controllers/papers_controller.rb
@@ -74,6 +74,8 @@ class PapersController < ApplicationController
   end
 
   def filter
+    @papers = Paper.none.page(1)
+    @term = "Empty search term"
     if params['language']
       @papers = Paper.search(params['language'], fields: [:languages],
                   :page => params[:page],

--- a/app/controllers/papers_controller.rb
+++ b/app/controllers/papers_controller.rb
@@ -97,22 +97,6 @@ class PapersController < ApplicationController
     end
   end
 
-  def by_author
-    @papers = Paper.search(params['author'], fields: [:authors],
-                :page => params[:page],
-                :per_page => 10
-              )
-
-    @filtering = true
-    @authors = params['author']
-
-    respond_to do |format|
-      format.atom { render :template => 'papers/index' }
-      format.json { render :json => @papers }
-      format.html { render :template => 'papers/index' }
-    end
-  end
-
   def start_review
     @paper = Paper.find_by_sha(params[:id])
 

--- a/app/helpers/papers_helper.rb
+++ b/app/helpers/papers_helper.rb
@@ -29,7 +29,7 @@ module PapersHelper
 
   def author_link(author)
     name = "#{author['given_name']} #{author['last_name']}"
-    author_search_link = link_to name, filter_papers_path(:author => name)
+    author_search_link = link_to name, papers_by_author_path(:author => name)
 
     if author['orcid']
       orcid_link = link_to author['orcid'], "http://orcid.org/#{author['orcid']}", :target => "_blank"

--- a/app/views/papers/_list.html.erb
+++ b/app/views/papers/_list.html.erb
@@ -7,7 +7,7 @@
       <h2 class="paper-title"><%= link_to paper.title, paper_path(paper) %>
       </h2>
       <% paper.language_tags.each do |tag| %>
-      <span class="badge-lang"><%= link_to tag, filter_papers_path(:language => tag) %></span>
+      <span class="badge-lang"><%= link_to tag, papers_by_language_path(:language => tag) %></span>
       <% end %>
     </div>
     <div class="col-lg-3 paper-meta">

--- a/app/views/papers/show.html.erb
+++ b/app/views/papers/show.html.erb
@@ -92,7 +92,7 @@
       <div class="paper-meta">
         <h1><%= @paper.title %></h1>
         <% @paper.language_tags.each do |tag| %>
-        <span class="badge-lang"><%= link_to tag, filter_papers_path(:language => tag) %></span>
+        <span class="badge-lang"><%= link_to tag, papers_by_language_path(:language => tag) %></span>
         <% end %>
         <span class="small">Submitted <%= @paper.created_at.strftime('%d %B %Y') %></span>
         •

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,10 +18,11 @@ Rails.application.routes.draw do
   end
 
   get '/papers/lookup/:id', :to => "papers#lookup"
+  get '/papers/in/:language', to: "papers#filter", as: 'papers_by_language'
+  get '/papers/by/:author', to: "papers#filter", as: 'papers_by_author'
   get '/papers/:id/status.svg', :to => "papers#status", :format => "svg", :as => 'status_badge'
   get '/papers/:doi/status.svg', :to => "papers#status", :format => "svg", :constraints => { :doi => /10.21105\/joss\.\d{5}/}
   get '/papers/:doi', :to => "papers#show", :constraints => {:doi => /.*/}
-
 
   get '/dashboard/all', :to => "home#all"
   get '/dashboard/incoming', :to => "home#incoming"


### PR DESCRIPTION
This PR add some improvements to the author/lang filters:
- The `by_author` method is removed, because author filtering is done via the `papers#filter` method
- Added some default empty search term and results to avoid this current 500 crash: https://joss.theoj.org/papers/filter
- Added the `papers/in/:language` and `papers/by/:author` routes 