### PR TITLE
Update deprecated method

### DIFF
--- a/spec/controllers/dispatch_controller_spec.rb
+++ b/spec/controllers/dispatch_controller_spec.rb
@@ -252,7 +252,7 @@ describe DispatchController, :type => :controller do
                                         :editor => "jimmy"
                                         }
 
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(paper.reload.editor).to eql(editor)
     end
 
@@ -300,7 +300,7 @@ describe DispatchController, :type => :controller do
                                           :reviewers => "joey, dave"
                                           }
 
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(paper.reload.reviewers).to eql(["@joey", "@dave"])
     end
 
@@ -340,7 +340,7 @@ describe DispatchController, :type => :controller do
                                   :title => "Foo, bar, baz",
                                   :metadata => encoded_metadata
                                   }
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(paper.reload.state).to eql('accepted')
       expect(paper.metadata['paper']['reviewers']).to eql(["@jim", "@bob"])
     end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -6,7 +6,7 @@ describe HomeController, :type => :controller do
   describe "GET #index" do
     it "should render home page" do
       get :index, :format => :html
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(response.body).to match /The Journal of Open Source Software/
     end
   end
@@ -17,7 +17,7 @@ describe HomeController, :type => :controller do
       allow(controller).to receive_message_chain(:current_user).and_return(user)
 
       get :index, :format => :html
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(response.body).to match /you need to add your email address and GitHub handle/
     end
 
@@ -26,7 +26,7 @@ describe HomeController, :type => :controller do
       allow(controller).to receive_message_chain(:current_user).and_return(user)
 
       get :index, :format => :html
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(response.body).to match /you need to add your email address and GitHub handle/
     end
   end
@@ -34,7 +34,7 @@ describe HomeController, :type => :controller do
   describe "GET #about" do
     it "should render about page" do
       get :about, :format => :html
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(response.body).to match /Don't we have enough journals already?/
     end
   end
@@ -46,7 +46,7 @@ describe HomeController, :type => :controller do
 
       # FIXME: Fix this test
       # get :profile, :format => :html
-      # expect(response).to be_success
+      # expect(response).to be_successful
       # expect(response.body).not_to match /Please update your profile before continuing/
     end
   end

--- a/spec/controllers/papers_controller_spec.rb
+++ b/spec/controllers/papers_controller_spec.rb
@@ -10,7 +10,7 @@ describe PapersController, :type => :controller do
   describe "GET #index" do
     it "should render all visible papers" do
       get :index, :format => :html
-      expect(response).to be_success
+      expect(response).to be_successful
     end
   end
 
@@ -224,14 +224,14 @@ describe PapersController, :type => :controller do
   describe "GET Atom feeds" do
     it "returns an Atom feed for #index" do
       get :index, :format => "atom"
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(response).to render_template("papers/index")
       expect(response.content_type).to eq("application/atom+xml")
     end
 
     it "returns a valid Atom feed for #popular (published)" do
       get :popular, :format => "atom"
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(response).to render_template("papers/index")
       expect(response.content_type).to eq("application/atom+xml")
     end


### PR DESCRIPTION
`success?` has been deprecated in favor of `successful?`
This PR removes deprecation warnings from the test builds.