### PR TITLE
Show complete title of paper on mouse over

### DIFF
--- a/app/views/home/reviews.html.erb
+++ b/app/views/home/reviews.html.erb
@@ -31,7 +31,7 @@
     <tbody>
       <% @papers.each do |paper| %>
       <tr>
-        <td><%= link_to truncate(paper.title, :length => 50), paper_url(paper) %> <%= pretty_labels_for(paper) %></td>
+        <td><%= link_to truncate(paper.title, :length => 50), paper_url(paper), title: paper.title %> <%= pretty_labels_for(paper) %></td>
         <td class="text-center"><%= link_to truncate("#{paper.meta_review_issue_id}", :length => 60), paper.meta_review_url  %> / <%= link_to truncate("#{paper.review_issue_id}", :length => 60), paper.review_url  %></td>
         <td><pre><%= paper.state %></pre></td>
         <td><%= linked_reviewers(paper) %></td>


### PR DESCRIPTION
The title of the paper is truncated in the dashboard tables but in some cases I want to read the complete title without clicking on it. This PR just adds the title of the paper to the link so it shows when mouse is over it:

![title](https://user-images.githubusercontent.com/6528/63022959-5450b480-bea4-11e9-9912-d154c98ab594.png)
