### PR TITLE
Adding note about complete affiliation

### DIFF
--- a/docs/submitting.md
+++ b/docs/submitting.md
@@ -42,7 +42,7 @@ JOSS welcomes submissions from broadly diverse research areas. For this reason, 
 
 Your paper should include:
 
-- A list of the authors of the software and their affiliations, using the correct format (see the example below).
+- A list of the authors of the software and their affiliations, using the correct format (see the example below). The affiliations should be complete, including department (when appropriate), institution, city, state, and country (or similar). 
 - A summary describing the high-level functionality and purpose of the software for a diverse, *non-specialist audience*.
 - A clear *Statement of Need* that illustrates the research purpose of the software.
 - A list of key references, including to other software addressing related needs.
@@ -75,7 +75,7 @@ authors:
   - name: Author Without ORCID
     affiliation: 2
 affiliations:
- - name: Lyman Spitzer, Jr. Fellow, Princeton University
+ - name: Lyman Spitzer, Jr. Fellow, Princeton University, Princeton, NJ USA
    index: 1
  - name: Institution 2
    index: 2


### PR DESCRIPTION
For the paper affiliation, I wasn't aware that anything beyond the University was required, as the [current example](https://joss.readthedocs.io/en/latest/submitting.html?highlight=affiliation#example-paper-and-bibliography) has primarily the institution (and that the author is a fellow) and I've submit about ~6 papers with no affiliation beyond Stanford University. However I learned in [this review](https://github.com/openjournals/joss-reviews/issues/1578#issuecomment-524730430) that the expectation is to have a complete department, institution, state, and country. I didn't find this anywhere in documentation or examples, so if the writer of the paper is expected to have it, he/she needs to have it clearly stated. This PR will do that - updating the example to include it, and adding the note in the list of required elements.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>