### PR TITLE
Lookup editor by login

### DIFF
--- a/app/controllers/editors_controller.rb
+++ b/app/controllers/editors_controller.rb
@@ -1,5 +1,5 @@
 class EditorsController < ApplicationController
-  before_action :require_admin_user
+  before_action :require_admin_user, except: [:lookup]
   before_action :set_editor, only: [:show, :edit, :update, :destroy]
 
   def index
@@ -11,6 +11,20 @@ class EditorsController < ApplicationController
 
   def new
     @editor = Editor.new
+  end
+
+  def lookup
+    editor = Editor.find_by_login(params[:login])
+    if editor.url
+      url = editor.url
+    else
+      url = "https://github.com/#{params[:login]}"
+    end
+
+    response = {  name: "#{editor.first_name} #{editor.last_name}",
+                  url: url }
+
+    render json: response.to_json
   end
 
   def edit

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
     end
   end
 
+  get '/editors/lookup/:login', to: "editors#lookup"
   get '/papers/lookup/:id', to: "papers#lookup"
   get '/papers/in/:language', to: "papers#filter", as: 'papers_by_language'
   get '/papers/by/:author', to: "papers#filter", as: 'papers_by_author'

--- a/spec/controllers/editors_controller_spec.rb
+++ b/spec/controllers/editors_controller_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe EditorsController, type: :controller do
     it "should allow the lookup of an editor" do
       editor = create(:editor)
       get :lookup, params: {login: editor.login }
-      expect(JSON.parse(response.body)['name']).to eq('foo')
-      expect(JSON.parse(response.body)['url']).to eq('foo')
+      expect(JSON.parse(response.body)['name']).to eq('Person McEditor')
+      expect(JSON.parse(response.body)['url']).to eq('http://placekitten.com')
     end
   end
 

--- a/spec/controllers/editors_controller_spec.rb
+++ b/spec/controllers/editors_controller_spec.rb
@@ -13,6 +13,13 @@ RSpec.describe EditorsController, type: :controller do
       get :index
       expect(response).to redirect_to %r(test.host/auth/orcid)
     end
+
+    it "should allow the lookup of an editor" do
+      editor = create(:editor)
+      get :lookup, params: {login: editor.login }
+      expect(JSON.parse(response.body)['name']).to eq('foo')
+      expect(JSON.parse(response.body)['url']).to eq('foo')
+    end
   end
 
   context "when logged in as a non-admin user" do


### PR DESCRIPTION
Adding a simple editor lookup URL for extending the metadata in JOSS papers.