### PR TITLE
Change open graph type

### DIFF
--- a/app/views/papers/show.html.erb
+++ b/app/views/papers/show.html.erb
@@ -35,7 +35,7 @@
   <script async src="https://badge.dimensions.ai/badge.js" charset="utf-8"></script>
 
   <!-- facebook open graph tags -->
-  <meta property="og:type" content="website" />
+  <meta property="og:type" content="article" />
   <meta property="og:url" content="<%= Rails.application.settings['url'] %>" />
   <meta property="og:site_name" content="<%= Rails.application.settings['name'] %>" />
   <meta property="og:title" content="<%= @paper.title %>" />


### PR DESCRIPTION
This PR changes the `og:type` meta tag to `article` (currently `website`) in the Paper's show page to help indexing by bibliographic tools.

Re: #641 