### PR TITLE
Add paper url to meta tags

### DIFF
--- a/app/views/papers/show.html.erb
+++ b/app/views/papers/show.html.erb
@@ -36,7 +36,7 @@
 
   <!-- facebook open graph tags -->
   <meta property="og:type" content="article" />
-  <meta property="og:url" content="<%= Rails.application.settings['url'] %>" />
+  <meta property="og:url" content="<%= @paper.seo_url %>" />
   <meta property="og:site_name" content="<%= Rails.application.settings['name'] %>" />
   <meta property="og:title" content="<%= @paper.title %>" />
   <meta property="og:description" content="<%= @paper.citation_string %>" />
@@ -48,7 +48,7 @@
   <meta name="twitter:site" content="<%= Rails.application.settings['twitter'] %>">
   <meta name="twitter:description" value="<%= @paper.citation_string %>" />
   <meta name="twitter:image" content="<%= Rails.application.settings['logo_url'] %>" />
-  <meta name="twitter:url" value="<%= Rails.application.settings['url'] %>" />
+  <meta name="twitter:url" value="<%= @paper.seo_url %>" />
   <meta name="twitter:label1" value="ISSN" />
   <meta name="twitter:data1" value="<%= Rails.application.settings['issn'] %>" />
 
@@ -64,7 +64,7 @@
   <meta name="citation_volume" content="<%= @paper.volume %>">
   <meta name="citation_issue" content="<%= @paper.issue %>">
   <meta name="citation_firstpage" content="<%= @paper.page %>">
-  <meta name="citation_abstract_html_url" content="<%= request.original_url %>">
+  <meta name="citation_abstract_html_url" content="<%= @paper.seo_url %>">
   <meta name="citation_pdf_url" content="<%= @paper.seo_pdf_url %>">
   <% end %>
 


### PR DESCRIPTION
Thi PR adds the seo url to the paper meta tags, so DOI for published papers, SHA otherwise
re: #641 
