### PR TITLE
API endpoint to reject papers

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,7 @@ Rails.application.routes.draw do
   post '/papers/api_deposit', to: 'dispatch#api_deposit'
   post '/papers/api_assign_editor', to: 'dispatch#api_assign_editor'
   post '/papers/api_assign_reviewers', to: 'dispatch#api_assign_reviewers'
+  put '/papers/api_reject', to: 'dispatch#api_reject'
   post '/dispatch', to: 'dispatch#github_recevier', format: 'json'
 
   root to: 'home#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,7 +52,7 @@ Rails.application.routes.draw do
   post '/papers/api_deposit', to: 'dispatch#api_deposit'
   post '/papers/api_assign_editor', to: 'dispatch#api_assign_editor'
   post '/papers/api_assign_reviewers', to: 'dispatch#api_assign_reviewers'
-  put '/papers/api_reject', to: 'dispatch#api_reject'
+  post '/papers/api_reject', to: 'dispatch#api_reject'
   post '/dispatch', to: 'dispatch#github_recevier', format: 'json'
 
   root to: 'home#index'

--- a/spec/controllers/dispatch_controller_spec.rb
+++ b/spec/controllers/dispatch_controller_spec.rb
@@ -322,15 +322,15 @@ describe DispatchController, type: :controller do
     ENV["WHEDON_SECRET"] = "mooo"
 
     it "with no API key" do
-      put :api_reject
+      post :api_reject
       expect(response).to be_forbidden
     end
 
     it "with the correct API key for a review_pending paper" do
       paper = create(:review_pending_paper, state: "review_pending", meta_review_issue_id: 1234)
 
-      put :api_reject, params: {secret: "mooo",
-                                id: 1234}
+      post :api_reject, params: { secret: "mooo",
+                                  id: 1234}
 
       expect(response).to be_successful
       expect(paper.reload.state).to eql("rejected")
@@ -339,8 +339,8 @@ describe DispatchController, type: :controller do
     it "with the correct API key for rejected paper" do
       paper = create(:rejected_paper, meta_review_issue_id: 1234)
 
-      put :api_reject, params: {secret: "mooo",
-                                id: 1234}
+      post :api_reject, params: { secret: "mooo",
+                                  id: 1234}
 
       expect(response).to be_successful
       expect(paper.reload.state).to eql("rejected")

--- a/spec/controllers/dispatch_controller_spec.rb
+++ b/spec/controllers/dispatch_controller_spec.rb
@@ -318,6 +318,35 @@ describe DispatchController, type: :controller do
     end
   end
 
+  describe "PUT #api_reject" do
+    ENV["WHEDON_SECRET"] = "mooo"
+
+    it "with no API key" do
+      put :api_reject
+      expect(response).to be_forbidden
+    end
+
+    it "with the correct API key for a review_pending paper" do
+      paper = create(:review_pending_paper, state: "review_pending", meta_review_issue_id: 1234)
+
+      put :api_reject, params: {secret: "mooo",
+                                id: 1234}
+
+      expect(response).to be_successful
+      expect(paper.reload.state).to eql("rejected")
+    end
+
+    it "with the correct API key for rejected paper" do
+      paper = create(:rejected_paper, meta_review_issue_id: 1234)
+
+      put :api_reject, params: {secret: "mooo",
+                                id: 1234}
+
+      expect(response).to be_successful
+      expect(paper.reload.state).to eql("rejected")
+    end
+  end
+
   describe "POST #api_deposit" do
     ENV["WHEDON_SECRET"] = "mooo"
 

--- a/spec/factories/papers_factory.rb
+++ b/spec/factories/papers_factory.rb
@@ -32,6 +32,10 @@ FactoryBot.define do
       state { 'submitted' }
     end
 
+    factory :rejected_paper do
+      state { 'rejected' }
+    end
+
     factory :retracted_paper do
       metadata { paper_metadata }
       state { 'retracted' }


### PR DESCRIPTION
This is a small addition to the JOSS API to support rejecting papers from Whedon.