### PR TITLE
Updating suggested editor flow

### DIFF
--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -332,9 +332,9 @@ class Paper < ActiveRecord::Base
 
   def meta_review_body(editor)
     if editor.strip.empty?
-      locals = { paper: self, editor: "Pending" }
+      locals = { paper: self, suggested_editor: "Pending" }
     else
-      locals = { paper: self, editor: "#{editor}" }
+      locals = { paper: self, suggested_editor: "#{editor}" }
     end
     ApplicationController.render(
       template: 'shared/meta_view_body',
@@ -345,30 +345,12 @@ class Paper < ActiveRecord::Base
 
   # Create a review meta-issue for assigning reviewers
   def create_meta_review_issue(editor_handle)
-    if editor_handle
-      striped_handle = editor_handle.gsub('@', '')
-    else
-      striped_handle = editor_handle
-    end
-
     return false if meta_review_issue_id
-
-    # If an editor handle has been passed then look up the editor
-    if !editor_handle.blank?
-      if editor = Editor.find_by_login(striped_handle)
-        set_editor(editor)
-      else
-        # If we've been passed an editor handle but can't find the editor we
-        # should fail here.
-        return false
-      end
-    end
 
     issue = GITHUB.create_issue(Rails.application.settings["reviews"],
                                 "[PRE REVIEW]: #{self.title}",
                                 meta_review_body(editor_handle),
-                                { assignee: striped_handle,
-                                  labels: "pre-review" })
+                                { labels: "pre-review" })
 
     set_meta_review_issue(issue.number)
   end

--- a/app/views/shared/meta_view_body.text.erb
+++ b/app/views/shared/meta_view_body.text.erb
@@ -10,9 +10,9 @@
 <% if suggested_editor == "Pending" %>
 Thanks for submitting your paper to <%= abbreviation %> <%= paper.submitting_author.github_username %>. **Currently, there isn't an <%= abbreviation %> editor assigned** to your paper.
 <% else %>
-Thanks for submitting your paper to <%= abbreviation %> <%= paper.submitting_author.github_username %>. **Currently, there isn't an <%= abbreviation %> editor assigned** to your paper although <%= suggested_editor %> has been suggested as a potential handling editor.
+Thanks for submitting your paper to <%= abbreviation %> <%= paper.submitting_author.github_username %>. **Currently, there isn't an <%= abbreviation %> editor assigned** to your paper.
 
-:wave: <%= suggested_editor %> would you be able to handle this submission for <%= abbreviation %>?
+The author's suggestion for the handling editor is <%= suggested_editor %>.
 <% end %>
 
 <%= paper.submitting_author.github_username %> if you have any suggestions for potential reviewers then please mention them here in this thread (without tagging them with an @). In addition, [this list of people](<%= reviewers %>) have already agreed to review for <%= abbreviation %> and may be suitable for this submission (please start at the bottom of the list).

--- a/app/views/shared/meta_view_body.text.erb
+++ b/app/views/shared/meta_view_body.text.erb
@@ -1,17 +1,18 @@
 **Submitting author:** <%= paper.submitting_author.github_username %> (<%= link_to paper.submitting_author.name, paper.submitting_author.orcid_url %>)
 **Repository:** <a href="<%= paper.repository_url %>" target ="_blank"><%= paper.repository_url %></a>
 **Version:** <%= paper.software_version %>
-**Editor:** <%= editor %>
+**Editor:** Pending
 **Reviewer:** Pending
 
 **Author instructions**
 
-<% unless editor == 'Pending' %>
 <%- abbreviation, reviewers = Rails.application.settings.values_at("abbreviation", "reviewers") %>
-Thanks for submitting your paper to <%= abbreviation %> <%= paper.submitting_author.github_username %>. The <%= abbreviation %> editor <%= editor %>, will work with you on this issue to find a reviewer for your submission before creating the main review issue.
-<% else %>
-<%- abbreviation, reviewers = Rails.application.settings.values_at("abbreviation", "reviewers") %>
+<% if suggested_editor == "Pending" %>
 Thanks for submitting your paper to <%= abbreviation %> <%= paper.submitting_author.github_username %>. **Currently, there isn't an <%= abbreviation %> editor assigned** to your paper.
+<% else %>
+Thanks for submitting your paper to <%= abbreviation %> <%= paper.submitting_author.github_username %>. **Currently, there isn't an <%= abbreviation %> editor assigned** to your paper although <%= suggested_editor %> has been suggested as a potential handling editor.
+
+:wave: <%= suggested_editor %> would you be able to handle this submission for <%= abbreviation %>?
 <% end %>
 
 <%= paper.submitting_author.github_username %> if you have any suggestions for potential reviewers then please mention them here in this thread (without tagging them with an @). In addition, [this list of people](<%= reviewers %>) have already agreed to review for <%= abbreviation %> and may be suitable for this submission (please start at the bottom of the list).

--- a/spec/models/paper_spec.rb
+++ b/spec/models/paper_spec.rb
@@ -222,7 +222,7 @@ describe Paper do
         is_expected.to match /#{Rails.application.settings['reviewers']}/
       end
 
-      it { is_expected.to match "@joss_editor has been suggested as a potential handling editor" }
+      it { is_expected.to match "The author's suggestion for the handling editor is @joss_editor" }
     end
 
     context "with no editor" do

--- a/spec/models/paper_spec.rb
+++ b/spec/models/paper_spec.rb
@@ -121,7 +121,7 @@ describe Paper do
 
       paper.start_meta_review('arfon')
       expect(paper.state).to eq('review_pending')
-      expect(paper.editor).to eq(editor)
+      expect(paper.editor).to be(nil)
     end
 
     it "should then allow for the paper to be moved into the under_review state" do
@@ -222,7 +222,7 @@ describe Paper do
         is_expected.to match /#{Rails.application.settings['reviewers']}/
       end
 
-      it { is_expected.to match "The JOSS editor @joss_editor, will work with you on this issue" }
+      it { is_expected.to match "@joss_editor has been suggested as a potential handling editor" }
     end
 
     context "with no editor" do


### PR DESCRIPTION
This is a small update to the submission flow when authors suggest the handling editor on the JOSS submission form. Currently an EiC has to decide between:

1. Accepting the author's suggestion and then automatically assigning the JOSS editor before they have had a chance to say yes/no?
2. Ignoring the author suggestion.

With this update, suggestions by submitting authors are _just that_. Even if the EiC keeps this suggestion on the JOSS dashboard, it will only show up in the reviews repository as a small amount of additional language from Whedon:

```
:wave: @joss_editor would you be able to handle this submission for JOSS?
```

<img width="753" alt="Screen Shot 2020-01-12 at 11 56 21 AM" src="https://user-images.githubusercontent.com/4483/72222429-9acd3c80-3532-11ea-8fd2-a2069ff70b79.png">

@openjournals/joss-eics 