### PR TITLE
Show EiC information on pre-review issue

### DIFF
--- a/app/controllers/papers_controller.rb
+++ b/app/controllers/papers_controller.rb
@@ -159,7 +159,7 @@ class PapersController < ApplicationController
   def start_meta_review
     @paper = Paper.find_by_sha(params[:id])
 
-    if @paper.start_meta_review!(params[:editor])
+    if @paper.start_meta_review!(params[:editor], current_user.editor.login)
       flash[:notice] = "Review started"
       redirect_to paper_path(@paper)
     else

--- a/app/controllers/papers_controller.rb
+++ b/app/controllers/papers_controller.rb
@@ -159,7 +159,7 @@ class PapersController < ApplicationController
   def start_meta_review
     @paper = Paper.find_by_sha(params[:id])
 
-    if @paper.start_meta_review!(params[:editor], current_user.editor.full_name)
+    if @paper.start_meta_review!(params[:editor], current_user.editor)
       flash[:notice] = "Review started"
       redirect_to paper_path(@paper)
     else

--- a/app/controllers/papers_controller.rb
+++ b/app/controllers/papers_controller.rb
@@ -159,7 +159,7 @@ class PapersController < ApplicationController
   def start_meta_review
     @paper = Paper.find_by_sha(params[:id])
 
-    if @paper.start_meta_review!(params[:editor], current_user.editor.login)
+    if @paper.start_meta_review!(params[:editor], current_user.editor.full_name)
       flash[:notice] = "Review started"
       redirect_to paper_path(@paper)
     else

--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -330,11 +330,11 @@ class Paper < ActiveRecord::Base
     self.update_attribute(:review_issue_id, issue_number)
   end
 
-  def meta_review_body(editor)
+  def meta_review_body(editor, eic)
     if editor.strip.empty?
-      locals = { paper: self, suggested_editor: "Pending" }
+      locals = { paper: self, suggested_editor: "Pending", eic: eic }
     else
-      locals = { paper: self, suggested_editor: "#{editor}" }
+      locals = { paper: self, suggested_editor: "#{editor}", eic: eic }
     end
     ApplicationController.render(
       template: 'shared/meta_view_body',
@@ -344,13 +344,14 @@ class Paper < ActiveRecord::Base
   end
 
   # Create a review meta-issue for assigning reviewers
-  def create_meta_review_issue(editor_handle)
+  def create_meta_review_issue(editor_handle, eic_handle)
     return false if meta_review_issue_id
 
     issue = GITHUB.create_issue(Rails.application.settings["reviews"],
                                 "[PRE REVIEW]: #{self.title}",
-                                meta_review_body(editor_handle),
-                                { labels: "pre-review" })
+                                meta_review_body(editor_handle, eic_handle),
+                                { labels: "pre-review",
+                                  assignees: [eic_handle] })
 
     set_meta_review_issue(issue.number)
   end

--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -330,11 +330,11 @@ class Paper < ActiveRecord::Base
     self.update_attribute(:review_issue_id, issue_number)
   end
 
-  def meta_review_body(editor, eic)
+  def meta_review_body(editor, eic_name)
     if editor.strip.empty?
-      locals = { paper: self, suggested_editor: "Pending", eic: eic }
+      locals = { paper: self, suggested_editor: "Pending", eic_name: eic_name }
     else
-      locals = { paper: self, suggested_editor: "#{editor}", eic: eic }
+      locals = { paper: self, suggested_editor: "#{editor}", eic_name: eic_name }
     end
     ApplicationController.render(
       template: 'shared/meta_view_body',
@@ -344,14 +344,13 @@ class Paper < ActiveRecord::Base
   end
 
   # Create a review meta-issue for assigning reviewers
-  def create_meta_review_issue(editor_handle, eic_handle)
+  def create_meta_review_issue(editor_handle, eic_name)
     return false if meta_review_issue_id
 
     issue = GITHUB.create_issue(Rails.application.settings["reviews"],
                                 "[PRE REVIEW]: #{self.title}",
-                                meta_review_body(editor_handle, eic_handle),
-                                { labels: "pre-review",
-                                  assignees: [eic_handle] })
+                                meta_review_body(editor_handle, eic_name),
+                                { labels: "pre-review" })
 
     set_meta_review_issue(issue.number)
   end

--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -11,6 +11,10 @@ class Paper < ActiveRecord::Base
               foreign_key: "user_id"
 
   belongs_to  :editor, optional: true
+  belongs_to  :eic,
+              class_name: 'Editor',
+              optional: true,
+              foreign_key: "eic_id"
 
   include AASM
 
@@ -359,20 +363,25 @@ class Paper < ActiveRecord::Base
   end
 
   # Create a review meta-issue for assigning reviewers
-  def create_meta_review_issue(editor_handle, eic_name)
+  def create_meta_review_issue(editor_handle, eic)
     return false if meta_review_issue_id
 
     issue = GITHUB.create_issue(Rails.application.settings["reviews"],
                                 "[PRE REVIEW]: #{self.title}",
-                                meta_review_body(editor_handle, eic_name),
+                                meta_review_body(editor_handle, eic.full_name),
                                 { labels: "pre-review" })
 
     set_meta_review_issue(issue.number)
+    set_meta_eic(eic)
   end
 
   # Update the Paper meta_review_issue_id field
   def set_meta_review_issue(issue_number)
     self.update_attribute(:meta_review_issue_id, issue_number)
+  end
+
+  def set_meta_eic(eic)
+    self.update_attribute(:eic_id, eic.id)
   end
 
   def meta_review_url

--- a/app/views/shared/meta_view_body.text.erb
+++ b/app/views/shared/meta_view_body.text.erb
@@ -3,7 +3,7 @@
 **Version:** <%= paper.software_version %>
 **Editor:** Pending
 **Reviewer:** Pending
-**Managing EiC:** @<%= eic %>
+**Managing EiC:** <%= eic_name %>
 
 **Author instructions**
 

--- a/app/views/shared/meta_view_body.text.erb
+++ b/app/views/shared/meta_view_body.text.erb
@@ -3,6 +3,7 @@
 **Version:** <%= paper.software_version %>
 **Editor:** Pending
 **Reviewer:** Pending
+**Managing EiC:** @<%= eic %>
 
 **Author instructions**
 

--- a/db/migrate/20200206205751_add_managing_editor_to_paper.rb
+++ b/db/migrate/20200206205751_add_managing_editor_to_paper.rb
@@ -1,0 +1,6 @@
+class AddManagingEditorToPaper < ActiveRecord::Migration[6.0]
+  def change
+    add_column :papers, :eic_id, :integer
+    add_index :papers, :eic_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_28_003647) do
+ActiveRecord::Schema.define(version: 2020_02_06_205751) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -61,7 +61,9 @@ ActiveRecord::Schema.define(version: 2019_09_28_003647) do
     t.text "metadata"
     t.text "retraction_notice"
     t.boolean "archived", default: false
+    t.integer "eic_id"
     t.index ["editor_id"], name: "index_papers_on_editor_id"
+    t.index ["eic_id"], name: "index_papers_on_eic_id"
     t.index ["labels"], name: "index_papers_on_labels", using: :gin
     t.index ["last_activity"], name: "index_papers_on_last_activity"
     t.index ["reviewers"], name: "index_papers_on_reviewers", using: :gin

--- a/lib/tasks/utils.rake
+++ b/lib/tasks/utils.rake
@@ -12,10 +12,11 @@ namespace :utils do
     ARFON_WEEKS_2019 = [1, 4, 8, 12, 16, 20, 24, 28, 32, 36]
     KEVIN_WEEKS_2019 = [37, 42, 47]
 
-    KRISTEN_WEEKS_2020 = [1, 6]
-    DAN_WEEKS_2020 = [2]
     KYLE_WEEKS_2020 = [3]
     LORENA_WEEKS_2020 = [4]
+    DAN_WEEKS_2020 = [2]
+    KRISTEN_WEEKS_2020 = [1, 6]
+    ARFON_WEEKS_2020 = []
     KEVIN_WEEKS_2020 = [5]
 
     papers_before_2019 = Paper.where('created_at < ?', '2019-01-01')

--- a/lib/tasks/utils.rake
+++ b/lib/tasks/utils.rake
@@ -10,7 +10,7 @@ namespace :utils do
     DAN_WEEKS_2019 = [5, 9, 13, 17, 21, 25, 29, 33, 39, 44, 49]
     KRISTEN_WEEKS_2019 = [38, 43, 48]
     ARFON_WEEKS_2019 = [1, 4, 8, 12, 16, 20, 24, 28, 32, 36]
-    KEVIN_WEEKS_2019 = [37, 42, 47]
+    KEVIN_WEEKS_2019 = [37, 42, 47, 52]
 
     KYLE_WEEKS_2020 = [3]
     LORENA_WEEKS_2020 = [4]

--- a/lib/tasks/utils.rake
+++ b/lib/tasks/utils.rake
@@ -3,6 +3,65 @@ include Util::ConsoleExtensions
 
 namespace :utils do
 
+  desc "Populate EiCs"
+  task populate_eics: :environment do
+    KYLE_WEEKS_2019 = [2, 6, 10, 14, 18, 22, 26, 30, 34, 40, 45, 50]
+    LORENA_WEEKS_2019 = [3, 7, 11, 15, 19, 23, 27, 31, 35, 41, 46, 51]
+    DAN_WEEKS_2019 = [5, 9, 13, 17, 21, 25, 29, 33, 39, 44, 49]
+    KRISTEN_WEEKS_2019 = [38, 43, 48]
+    ARFON_WEEKS_2019 = [1, 4, 8, 12, 16, 20, 24, 28, 32, 36]
+    KEVIN_WEEKS_2019 = [37, 42, 47]
+
+    KRISTEN_WEEKS_2020 = [1, 6]
+    DAN_WEEKS_2020 = [2]
+    KYLE_WEEKS_2020 = [3]
+    LORENA_WEEKS_2020 = [4]
+    KEVIN_WEEKS_2020 = [5]
+
+    papers_before_2019 = Paper.where('created_at < ?', '2019-01-01')
+
+    papers_before_2019.each do |paper|
+      eic = Editor.find_by_login('arfon')
+      paper.set_meta_eic(eic)
+    end
+
+    papers_2019 = Paper.where('created_at BETWEEN ? AND ?', '2019-01-01', '2019-12-31')
+
+    def whos_week_2019(week)
+      return Editor.find_by_login('kyleniemeyer') if KYLE_WEEKS_2019.include?(week)
+      return Editor.find_by_login('labarba') if LORENA_WEEKS_2019.include?(week)
+      return Editor.find_by_login('danielskatz') if DAN_WEEKS_2019.include?(week)
+      return Editor.find_by_login('kthyng') if KRISTEN_WEEKS_2019.include?(week)
+      return Editor.find_by_login('arfon') if ARFON_WEEKS_2019.include?(week)
+      return Editor.find_by_login('Kevin-Mattheus-Moerman') if KEVIN_WEEKS_2019.include?(week)
+
+      raise
+    end
+
+    papers_2019.each do |paper|
+      week = Date.parse(paper.created_at.to_s).cweek
+      paper.set_meta_eic(whos_week_2019(week))
+    end
+
+    papers_2020 = Paper.where('created_at BETWEEN ? AND ?', '2020-01-01', '2020-12-31')
+
+    def whos_week_2020(week)
+      return Editor.find_by_login('kyleniemeyer') if KYLE_WEEKS_2020.include?(week)
+      return Editor.find_by_login('labarba') if LORENA_WEEKS_2020.include?(week)
+      return Editor.find_by_login('danielskatz') if DAN_WEEKS_2020.include?(week)
+      return Editor.find_by_login('kthyng') if KRISTEN_WEEKS_2020.include?(week)
+      return Editor.find_by_login('arfon') if ARFON_WEEKS_2020.include?(week)
+      return Editor.find_by_login('Kevin-Mattheus-Moerman') if KEVIN_WEEKS_2020.include?(week)
+
+      raise
+    end
+
+    papers_2020.each do |paper|
+      week = Date.parse(paper.created_at.to_s).cweek
+      paper.set_meta_eic(whos_week_2020(week))
+    end
+  end
+
   desc "Populate activities"
   task update_activities: :environment do
     Paper.all.each do |paper|

--- a/lib/tasks/utils.rake
+++ b/lib/tasks/utils.rake
@@ -36,7 +36,7 @@ namespace :utils do
       return Editor.find_by_login('arfon') if ARFON_WEEKS_2019.include?(week)
       return Editor.find_by_login('Kevin-Mattheus-Moerman') if KEVIN_WEEKS_2019.include?(week)
 
-      raise
+      raise "Can't find editor for #{week}"
     end
 
     papers_2019.each do |paper|

--- a/spec/controllers/papers_controller_spec.rb
+++ b/spec/controllers/papers_controller_spec.rb
@@ -29,11 +29,12 @@ describe PapersController, type: :controller do
     end
 
     it "LOGGED IN and with correct params" do
-      user = create(:admin_user)
+      admin_editor = create(:editor, login: "josseic")
+      admin_user = create(:admin_user, editor: admin_editor)
       editor = create(:editor, login: "josseditor")
       editing_user = create(:user, editor: editor)
 
-      allow(controller).to receive_message_chain(:current_user).and_return(editing_user)
+      allow(controller).to receive_message_chain(:current_user).and_return(admin_user)
 
       author = create(:user)
       paper = create(:paper, user_id: author.id)
@@ -45,6 +46,8 @@ describe PapersController, type: :controller do
       post :start_meta_review, params: {id: paper.sha, editor: "josseditor"}
 
       expect(response).to be_redirect
+      expect(paper.reload.state).to eq('review_pending')
+      expect(paper.reload.eic).to eq(admin_editor)
     end
   end
 

--- a/spec/controllers/papers_controller_spec.rb
+++ b/spec/controllers/papers_controller_spec.rb
@@ -33,7 +33,7 @@ describe PapersController, type: :controller do
       editor = create(:editor, login: "josseditor")
       editing_user = create(:user, editor: editor)
 
-      allow(controller).to receive_message_chain(:current_user).and_return(user)
+      allow(controller).to receive_message_chain(:current_user).and_return(editing_user)
 
       author = create(:user)
       paper = create(:paper, user_id: author.id)

--- a/spec/models/paper_spec.rb
+++ b/spec/models/paper_spec.rb
@@ -119,9 +119,10 @@ describe Paper do
       allow(fake_issue).to receive(:number).and_return(1)
       allow(GITHUB).to receive(:create_issue).and_return(fake_issue)
 
-      paper.start_meta_review('arfon', 'important-editor')
+      paper.start_meta_review!('arfon', editor)
       expect(paper.state).to eq('review_pending')
-      expect(paper.editor).to be(nil)
+      expect(paper.reload.editor).to be(nil)
+      expect(paper.reload.eic).to eq(editor)
     end
 
     it "should then allow for the paper to be moved into the under_review state" do

--- a/spec/models/paper_spec.rb
+++ b/spec/models/paper_spec.rb
@@ -206,12 +206,14 @@ describe Paper do
 
   describe "#meta_review_body" do
     let(:author) { create(:user) }
+
     let(:paper) do
       instance = build(:paper_with_sha, user_id: author.id)
       instance.save(validate: false)
       instance
     end
-    subject { paper.meta_review_body(editor, 'important-editor') }
+
+    subject { paper.meta_review_body(editor, 'Important Editor') }
 
     context "with an editor" do
       let(:editor) { "@joss_editor" }
@@ -220,7 +222,7 @@ describe Paper do
         is_expected.to match /#{paper.submitting_author.github_username}/
         is_expected.to match /#{paper.submitting_author.name}/
         is_expected.to match /#{Rails.application.settings['reviewers']}/
-        is_expected.to match /important-editor/
+        is_expected.to match /Important Editor/
       end
 
       it { is_expected.to match "The author's suggestion for the handling editor is @joss_editor" }

--- a/spec/models/paper_spec.rb
+++ b/spec/models/paper_spec.rb
@@ -119,7 +119,7 @@ describe Paper do
       allow(fake_issue).to receive(:number).and_return(1)
       allow(GITHUB).to receive(:create_issue).and_return(fake_issue)
 
-      paper.start_meta_review('arfon')
+      paper.start_meta_review('arfon', 'important-editor')
       expect(paper.state).to eq('review_pending')
       expect(paper.editor).to be(nil)
     end
@@ -211,7 +211,7 @@ describe Paper do
       instance.save(validate: false)
       instance
     end
-    subject { paper.meta_review_body(editor) }
+    subject { paper.meta_review_body(editor, 'important-editor') }
 
     context "with an editor" do
       let(:editor) { "@joss_editor" }
@@ -220,6 +220,7 @@ describe Paper do
         is_expected.to match /#{paper.submitting_author.github_username}/
         is_expected.to match /#{paper.submitting_author.name}/
         is_expected.to match /#{Rails.application.settings['reviewers']}/
+        is_expected.to match /important-editor/
       end
 
       it { is_expected.to match "The author's suggestion for the handling editor is @joss_editor" }


### PR DESCRIPTION
This is a small change to pre-review issues. Currently they don't show the identity of the EiC that created the pre-review issue on GitHub. With this change, we're adding an extra field to the metadata at the top of the pre-review issue to make it clear who moved the submission from the incoming dashboard to GitHub:

<img width="760" alt="Screen_Shot_2020-01-18_at_12_27_11_PM" src="https://user-images.githubusercontent.com/4483/72667832-f6de0800-39ed-11ea-96be-855b003f1259.png">

Fixes #527 

/ cc @openjournals/joss-eics 