### PR TITLE
Documenting single-function packages as out of scope.

### DIFF
--- a/docs/submitting.md
+++ b/docs/submitting.md
@@ -10,7 +10,7 @@ But please read these instructions carefully for a streamlined submission.
 - The software should have an **obvious** research application.
 - You should be a major contributor to the software you are submitting.
 - The software should be a significant contribution to the available open source software that either enables some new research challenges to be addressed or makes addressing research challenges significantly better (e.g., faster, easier, simpler).
-- The software should be feature-complete (no half-baked solutions) and designed for maintainable extension (not one-off modifications). **Minor ‘utility’ packages, including ‘thin’ API clients, are not acceptable**.
+- The software should be feature-complete (no half-baked solutions) and designed for maintainable extension (not one-off modifications). **Minor ‘utility’ packages, including ‘thin’ API clients, and single-function packages are not acceptable**.
 - Your paper (`paper.md` and BibTeX files, plus any figures) must be hosted in a Git-based repository, ideally together with your software.
 
 In addition, the software associated with your submission must:


### PR DESCRIPTION
While we're working on writing more extensive guidelines for authors, I figured we should make this small change which I believe is in line with current policy.

/ cc @openjournals/joss-eics 