### PR TITLE
Adding editor invite API

### DIFF
--- a/app/controllers/dispatch_controller.rb
+++ b/app/controllers/dispatch_controller.rb
@@ -4,7 +4,9 @@ class DispatchController < ApplicationController
   include DispatchHelper
   include SettingsHelper
 
-  protect_from_forgery except: [ :api_start_review, :api_deposit, :api_assign_editor, :api_assign_reviewers, :api_reject, :api_withdraw ]
+  protect_from_forgery except: [  :api_assign_editor, :api_assign_reviewers,
+                                  :api_deposit, :api_editor_invite, :api_reject,
+                                  :api_start_review, :api_withdraw ]
   respond_to :json
 
   def github_recevier
@@ -48,6 +50,20 @@ class DispatchController < ApplicationController
       editor = Editor.find_by_login(params[:editor])
       return head :unprocessable_entity unless paper && editor
       paper.set_editor(editor)
+    else
+      head :forbidden
+    end
+  end
+
+  def api_editor_invite
+    if params[:secret] == ENV['WHEDON_SECRET']
+      paper = Paper.find_by_meta_review_issue_id(params[:id])
+      return head :unprocessable_entity unless paper
+      if paper.invite_editor(params[:editor])
+        head :no_content
+      else
+        head :unprocessable_entity
+      end
     else
       head :forbidden
     end

--- a/app/mailers/notifications.rb
+++ b/app/mailers/notifications.rb
@@ -7,6 +7,11 @@ class Notifications < ApplicationMailer
     mail(to: EDITOR_EMAILS, subject: "New submission: #{paper.title}")
   end
 
+  def editor_invite_email(paper, editor)
+    @paper = paper
+    mail(to: editor.email, subject: "JOSS editorial invite: #{paper.title}")
+  end
+
   def author_submission_email(paper)
     @url  = "#{Rails.application.settings["url"]}/papers/#{paper.sha}"
     @paper = paper

--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -145,6 +145,11 @@ class Paper < ActiveRecord::Base
     accepted? || retracted?
   end
 
+  def invite_editor(editor_handle)
+    return false unless editor = Editor.find_by_login(editor_handle)
+    Notifications.editor_invite_email(self, editor).deliver_now
+  end
+
   def scholar_title
     return nil unless published?
     metadata['paper']['title']

--- a/app/views/notifications/author_submission_email.html.erb
+++ b/app/views/notifications/author_submission_email.html.erb
@@ -1,8 +1,8 @@
 Hello there, thanks for your submission to <em><%= Rails.application.settings['abbreviation'] %></em>.
-
+<br />
 Your paper, <em>'<%= @paper.title %>'</em>, is currently awaiting triage by our managing editor. This generally takes between 24 and 72 hours and until then, your paper won't show up in the https://github.com/<%= Rails.application.settings['reviews'] %> repository.
-
+<br />
 You can view the latest status of your paper here: <%= @url %>
-
-Many thanks
+<br />
+Many thanks<br />
 The <%= Rails.application.settings['abbreviation'] %> editorial robot.

--- a/app/views/notifications/editor_invite_email.html.erb
+++ b/app/views/notifications/editor_invite_email.html.erb
@@ -1,6 +1,6 @@
 Hello there, you've just been invited to edit the <%= Rails.application.settings['abbreviation'] %> paper <em>'<%= @paper.title %>'</em>.
-
+<br />
 Please visit the <a href='<%= @paper.meta_review_url %>'>pre-review issue</a> in the next three working days to either accept or decline this invitation.
-
-Thanks!
+<br />
+Thanks!<br />
 The <%= Rails.application.settings['abbreviation'] %> editorial robot.

--- a/app/views/notifications/editor_invite_email.html.erb
+++ b/app/views/notifications/editor_invite_email.html.erb
@@ -1,0 +1,6 @@
+Hello there, you've just been invited to edit the <%= Rails.application.settings['abbreviation'] %> paper <em>'<%= @paper.title %>'</em>.
+
+Please visit the <a href='<%= @paper.meta_review_url %>'>pre-review issue</a> in the next three working days to either accept or decline this invitation.
+
+Thanks!
+The <%= Rails.application.settings['abbreviation'] %> editorial robot.

--- a/app/views/notifications/editor_invite_email.text.erb
+++ b/app/views/notifications/editor_invite_email.text.erb
@@ -1,0 +1,6 @@
+Hello there, you've just been invited to edit the <%= Rails.application.settings['abbreviation'] %> paper '<%= @paper.title %>'.
+
+Please visit the pre-review issue (<%= @paper.meta_review_url %>) in the next three working days to either accept or decline this invitation.
+
+Thanks!
+The <%= Rails.application.settings['abbreviation'] %> editorial robot.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Rails.application.routes.draw do
 
   get '/blog' => redirect("http://blog.joss.theoj.org"), as: :blog
   # API methods
+  post '/papers/api_editor_invite', to: 'dispatch#api_editor_invite'
   post '/papers/api_start_review', to: 'dispatch#api_start_review'
   post '/papers/api_deposit', to: 'dispatch#api_deposit'
   post '/papers/api_assign_editor', to: 'dispatch#api_assign_editor'

--- a/spec/controllers/dispatch_controller_spec.rb
+++ b/spec/controllers/dispatch_controller_spec.rb
@@ -283,6 +283,31 @@ describe DispatchController, type: :controller do
     end
   end
 
+  describe "POST #api_editor_invite" do
+    ENV["WHEDON_SECRET"] = "mooo"
+
+    it "with no API key" do
+      post :api_editor_invite
+      expect(response).to be_forbidden
+    end
+
+    it "with the correct API key and valid editor" do
+      editor = create(:editor, login: "jimmy")
+      paper = create(:review_pending_paper, state: "review_pending", meta_review_issue_id: 1234)
+      post_params = { secret: "mooo", id: 1234, editor: "jimmy" }
+
+      expect { post :api_editor_invite, params: post_params }.to change { ActionMailer::Base.deliveries.count }.by(1)
+    end
+
+    it "with the correct API key and invalid editor" do
+      paper = create(:review_pending_paper, state: "review_pending", meta_review_issue_id: 1234)
+      post_params = { secret: "mooo", id: 1234, editor: "not-editor" }
+      post :api_editor_invite, params: post_params
+
+      expect(response).to be_unprocessable
+    end
+  end
+
   describe "POST #api_assign_reviewers" do
     ENV["WHEDON_SECRET"] = "mooo"
 


### PR DESCRIPTION
Adding API endpoint for Whedon to communicate with. Supports https://github.com/openjournals/whedon-api/pull/82