### PR TITLE
Minor update to accept/publish handoff between editors and EiCs

### DIFF
--- a/docs/editing.md
+++ b/docs/editing.md
@@ -81,9 +81,9 @@ Pre-publication steps:
 - Check the archive deposit has the correct metadata (title and author list), and request the author edit it if it doesn’t match the paper.
 - Run `@whedon set <doi> as archive`.
 - Run `@whedon set <v1.x.x> as version` if the version was updated.
-- Ping the `@openjournals/joss-eics` team on the review thread letting them know the paper is ready for final processing.
+- Run `@whedon accept` to generate the final proofs and have Whedon notify the `@openjournals/joss-eics` team that the paper is ready for final processing.
 
-At that point, the EiC/AEiC will take over to make final checks and publish the paper.
+At this point, the EiC/AEiC will take over to make final checks and publish the paper.
 
 It’s also a good idea to ask the authors to check the proof. We’ve had a few papers request a post-publication change of author list, for example—this requires a manual download/compile/deposit cycle and should be a rare event.
 

--- a/docs/editing.md
+++ b/docs/editing.md
@@ -81,7 +81,7 @@ Pre-publication steps:
 - Check the archive deposit has the correct metadata (title and author list), and request the author edit it if it doesn’t match the paper.
 - Run `@whedon set <doi> as archive`.
 - Run `@whedon set <v1.x.x> as version` if the version was updated.
-- Run `@whedon accept` to generate the final proofs and have Whedon notify the `@openjournals/joss-eics` team that the paper is ready for final processing.
+- Run `@whedon accept` to generate the final proofs, which has Whedon notify the `@openjournals/joss-eics` team that the paper is ready for final processing.
 
 At this point, the EiC/AEiC will take over to make final checks and publish the paper.
 


### PR DESCRIPTION
We (@openjournals/joss-eics) would like to make the process of handing off papers between editors more reliable, explicit, and straightforward. Here's one potential solution to this:

Currently an editor needs to do the following when accepting a paper:

- Run `@whedon generate pdf` to check the final paper etc.
- (Possibly) run `@whedon accept`
- Mention the `@openjournals/eics` team to let them know that the paper is ready to be published.

I'm proposing that we slightly re-purpose this workflow and introduce an extra GitHub label to help EiCs keep track of papers that are `accepted` but not yet `published`.

**Proposed updated workflow**

- Editor runs `@whedon generate pdf` to check the PDF proof with the author etc.
- When editor is ready to hand off the paper to `@openjournals/eics` then run `@whedon accept` which would apply the `accepted` label _and_ automatically notify `@openjournals/eics`
- When the EiC runs `@whedon accept deposit=true` Whedon applies the `published` label and does all of Crossref deposit business.

This way, the EiC on rotation can keep an eye out for reviews labeled with `accepted` but not `published`.

**Some questions**

- Is this a useful change? What potential alternatives are there?
- Should the `@whedon accept` command from the editor actually apply the `accepted` label or should it be something more like `recommended-accept`?

