### PR TITLE
Dashboard refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@
 # Ignore readthedocs build
 
 docs/_build
-latest.dump
+latest.dump*
 
 /public/packs
 /public/packs-test

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -16,8 +16,48 @@
   }
 }
 
+.my-statistics {
+
+  .col {
+    padding-right: 0px;
+  }
+
+  .banner {
+    border-bottom: 1px solid rgba(46, 41, 78, 0.5);
+  }
+
+  span {
+    font-size: 0.9em;
+    font-weight: bold;
+    margin-bottom: 0;
+
+    a {
+      font-weight: normal;
+    }
+  }
+
+  .stat {
+    .count {
+      font-size: 2.5em;
+      line-height: 1em;
+
+      .sub {
+        font-size: 0.2em;
+        line-height: 1em;
+        color: rgba(46, 41, 78, 0.5);
+      }
+    }
+
+    .message {
+      font-size: 0.8em;
+      color: rgba(46, 41, 78, 0.5);
+    }
+  }
+}
+
 table.dashboard-table{
   margin-top: 1em;
+  width: 100%;
   background-color: white;
   border-radius: .25em;
   padding: 1.5em 2em;
@@ -39,7 +79,7 @@ table.dashboard-table{
     }
   }
 
-  tbody {
+  tbody, tfoot {
     tr {
       td {
         padding: 1em 0em 1em 1em;

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -5,6 +5,12 @@ table.dashboard-table{
   padding: 1.5em 2em;
   box-shadow: 0 2px 8px 0 rgba(46,41,78,0.1);
 
+  @media only screen and (max-width: 900px) {
+     .mobile-hide{
+         display: none;
+     }
+   }
+
   thead {
     tr {
       th {

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -1,3 +1,21 @@
+.welcome {
+  font-size: 1em;
+  font-style: italic;
+  color: rgba(46, 41, 78, 0.50);
+}
+
+.hero-small {
+  &.dashboard {
+    margin-top: -0.5em;
+  }
+}
+
+.tabnav-tab {
+  @media screen and (max-width: 500px) {
+    text-align: center;
+  }
+}
+
 table.dashboard-table{
   margin-top: 1em;
   background-color: white;

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -8,7 +8,7 @@ table.dashboard-table{
   thead {
     tr {
       th {
-        padding: 1em 1.1em;
+        padding: 1em 0em 1em 1em;
       }
 
       border-bottom: 1px solid #efefef;
@@ -18,7 +18,7 @@ table.dashboard-table{
   tbody {
     tr {
       td {
-        padding: 1em 0.5em 1em 1.1em;
+        padding: 1em 0em 1em 1em;
         font-size: 1em;
         line-height: 1em;
 
@@ -51,22 +51,20 @@ table.dashboard-table{
           display: inline-block;
         }
 
-        h2 {
+        a.text-truncate {
             font-size: 1em;
+            line-height: 1.2em;
             margin-top: 0.5em;
             margin-bottom: 0.2em;
             padding-bottom: 0em;
             display: flex;
             align-items: center;
+            color: #2E294E;
+            transition: color .3s;
 
-            a {
-              transition: color .3s;
-              color: #2E294E;
-
-              &:hover {
-                  color: #007BFF;
-                  text-decoration: none;
-              }
+            &:hover {
+              color: #007BFF;
+              text-decoration: none;
             }
         }
       }

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -1,0 +1,78 @@
+table.dashboard-table{
+  margin-top: 1em;
+  background-color: white;
+  border-radius: .25em;
+  padding: 1.5em 2em;
+  box-shadow: 0 2px 8px 0 rgba(46,41,78,0.1);
+
+  thead {
+    tr {
+      th {
+        padding: 1em 1.1em;
+      }
+
+      border-bottom: 1px solid #efefef;
+    }
+  }
+
+  tbody {
+    tr {
+      td {
+        padding: 1em 0.5em 1em 1.1em;
+        font-size: 1em;
+        line-height: 1em;
+
+        &.state{
+          font-size: 0.9em;
+        }
+
+        img.avatar {
+          margin-right: .2em;
+          border-radius: 2em;
+        }
+
+        .activity-avatar {
+          padding-right: 0.2em;
+          float: left;
+          min-height: 2em;
+          display: inline-flex;
+          align-items: center;
+        }
+
+        .time {
+          font-size: 0.857em;
+          margin-bottom: 0;
+          padding-bottom: 0;
+          color: rgba(46, 41, 78, 0.50);
+        }
+
+        .comment-link {
+          font-size: 0.857em;
+          display: inline-block;
+        }
+
+        h2 {
+            font-size: 1em;
+            margin-top: 0.5em;
+            margin-bottom: 0.2em;
+            padding-bottom: 0em;
+            display: flex;
+            align-items: center;
+
+            a {
+              transition: color .3s;
+              color: #2E294E;
+
+              &:hover {
+                  color: #007BFF;
+                  text-decoration: none;
+              }
+            }
+        }
+      }
+    }
+    tr {
+      border-bottom: 1px solid #efefef;
+    }
+  }
+}

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -37,6 +37,7 @@ class HomeController < ApplicationController
                 )
     end
 
+    @editor = current_user.editor
     @active_tab = "incoming"
 
     render template: "home/reviews"

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -81,6 +81,8 @@ class HomeController < ApplicationController
       @order = "desc"
     end
 
+    @editor = current_user.editor
+
     @papers = Paper.unscoped.in_progress.order(last_activity: @order).paginate(
                 page: params[:page],
                 per_page: 20

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -43,11 +43,20 @@ class HomeController < ApplicationController
   end
 
   def reviews
+    case params[:order]
+    when "desc"
+      @order = "desc"
+    when "asc"
+      @order = "asc"
+    when nil
+      @order = "desc"
+    else
+      @order = "desc"
+    end
+
     if params[:editor]
       @active_tab = @editor = Editor.find_by_login(params[:editor])
-      sort_order = params[:order] ? params[:order] : 'desc'
-
-      @papers = Paper.unscoped.in_progress.where(editor: @editor).order(last_activity: sort_order).paginate(
+      @papers = Paper.unscoped.in_progress.where(editor: @editor).order(last_activity: @order).paginate(
                   page: params[:page],
                   per_page: 20
                 )
@@ -60,17 +69,22 @@ class HomeController < ApplicationController
   end
 
   def in_progress
-    if params[:order]
-      @papers = Paper.unscoped.in_progress.order(last_activity: params[:order]).paginate(
-                  page: params[:page],
-                  per_page: 20
-                )
+    case params[:order]
+    when "desc"
+      @order = "desc"
+    when "asc"
+      @order = "asc"
+    when nil
+      @order = "desc"
     else
-      @papers = Paper.in_progress.paginate(
-                  page: params[:page],
-                  per_page: 20
-                )
+      @order = "desc"
     end
+
+    @papers = Paper.unscoped.in_progress.order(last_activity: @order).paginate(
+                page: params[:page],
+                per_page: 20
+              )
+
     render template: "home/reviews"
   end
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -104,6 +104,8 @@ class HomeController < ApplicationController
               )
     end
 
+    @editor = current_user.editor
+    
     render template: "home/reviews"
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -41,4 +41,8 @@ module ApplicationHelper
   def name_and_tagline
     "#{setting(:name)} (#{setting(:abbreviation)}) is #{setting(:tagline)}".html_safe
   end
+
+  def avatar(username)
+    return "https://github.com/#{username.sub(/^@/, "")}.png"
+  end
 end

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -55,8 +55,10 @@ module HomeHelper
           non_whedon_activities = paper.activities['issues']['last_edits'].select {|user, time| user != "whedon"}
           return "No activity" if non_whedon_activities.empty?
           user, time = non_whedon_activities.first
-          concat(image_tag(avatar(user), size: "24x24", class: "avatar", title: user))
-          concat(content_tag(:span, "&nbsp; #{time_ago_in_words(time)} ago".html_safe, class: "time"))
+          concat(content_tag(:span, image_tag(avatar(user), size: "24x24", class: "avatar", title: user), class: "activity-avatar"))
+          concat(content_tag(:span, style: "") do
+            concat(content_tag(:span, "#{time_ago_in_words(time)} ago".html_safe, class: "time"))
+          end)
         else
           return "No activity"
         end

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -65,9 +65,9 @@ module HomeHelper
   def sort_icon(sort_order)
     capture do
       if sort_order == "desc"
-        concat(link_to octicon("chevron-down"), "#{request.path}?order=asc")
+        concat(link_to octicon("chevron-up"), "#{request.path}?order=asc")
       elsif sort_order == "asc"
-        concat(link_to octicon("chevron-up"), "#{request.path}?order=desc")
+        concat(link_to octicon("chevron-down"), "#{request.path}?order=desc")
       end
     end
   end

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -10,7 +10,7 @@ module HomeHelper
     end
 
     if ignored_count > 0
-      return "#{papers.count - ignored_count} + #{ignored_count} paused"
+      return "#{papers.count - ignored_count} <span class='small font-italic'>(+ #{ignored_count} paused)</span>".html_safe
     else
       return "#{papers.count}"
     end

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -41,8 +41,48 @@ module HomeHelper
   end
 
   def current_class?(test_path)
-    return 'nav-link active' if request.path == test_path
-    'nav-link'
+    return 'tabnav-tab selected' if request.path == test_path
+    'tabnav-tab'
+  end
+
+  def checklist_activity(paper)
+    return "No activity" if paper.activities.empty?
+    return "No activity" if paper.activities['issues']['commenters'].empty?
+
+    capture do
+      if !paper.activities['issues']['comments'].empty?
+        if paper.activities['issues']['last_edits'] && paper.activities['issues']['last_edits'].keys.any?
+          user, time = paper.activities['issues']['last_edits'].first
+          concat(image_tag(avatar(user), size: "24x24", class: "avatar", title: user))
+          concat(content_tag(:span, "&nbsp; #{time_ago_in_words(time)} ago".html_safe, class: "time"))
+        else
+          return "No activity"
+        end
+      end
+    end
+  end
+
+  def sort_icon(sort_order)
+    capture do
+      if sort_order == "desc"
+        concat(link_to octicon("chevron-down"), "#{request.path}?order=asc")
+      elsif sort_order == "asc"
+        concat(link_to octicon("chevron-up"), "#{request.path}?order=desc")
+      end
+    end
+  end
+
+  def comment_activity(paper)
+    return "No activity" if paper.activities.empty?
+    return "No activity" if paper.activities['issues']['commenters'].empty?
+    capture do
+      comment = paper.activities['issues']['comments'].first
+      concat(content_tag(:span, image_tag(avatar(comment['author']), size: "24x24", class: "avatar", title: comment['author']), class: "activity-avatar"))
+      concat(content_tag(:span, style: "") do
+        concat(content_tag(:span, "#{time_ago_in_words(comment['commented_at'])} ago".html_safe, class: "time"))
+        concat(content_tag(:span, "#{comment_link(comment)}".html_safe, class: "comment-link"))
+      end)
+    end
   end
 
   def card_activity(paper)
@@ -90,11 +130,15 @@ module HomeHelper
   end
 
   def comment_link(comment)
-    link_to("View comment &rarr;".html_safe, comment['comment_url'], target: "_blank")
+    link_to("View comment &raquo;".html_safe, comment['comment_url'], target: "_blank", title: comment['comment'])
+  end
+
+  def github_user_link(username)
+    "https://github.com/#{username.gsub('@', '')}"
   end
 
   def github_user(username)
-    link_to("@#{username}", "https://github.com/#{username.gsub('@', '')}")
+    link_to("@#{username}", github_user_link(username))
   end
 
   def activites_shortcut_for(paper)

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -45,6 +45,24 @@ module HomeHelper
     'tabnav-tab'
   end
 
+  def review_issue_links(paper)
+    capture do
+      if paper.meta_review_issue_id
+        concat(link_to paper.meta_review_issue_id, paper.meta_review_url)
+      else
+        concat("–")
+      end
+
+      concat(" / ")
+
+      if paper.review_issue_id
+        concat(link_to paper.review_issue_id, paper.review_url)
+      else
+        concat("–")
+      end
+    end
+  end
+
   def checklist_activity(paper)
     return "No activity" if paper.activities.empty?
     return "No activity" if paper.activities['issues']['commenters'].empty?

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -52,7 +52,9 @@ module HomeHelper
     capture do
       if !paper.activities['issues']['comments'].empty?
         if paper.activities['issues']['last_edits'] && paper.activities['issues']['last_edits'].keys.any?
-          user, time = paper.activities['issues']['last_edits'].first
+          non_whedon_activities = paper.activities['issues']['last_edits'].select {|user, time| user != "whedon"}
+          return "No activity" if non_whedon_activities.empty?
+          user, time = non_whedon_activities.first
           concat(image_tag(avatar(user), size: "24x24", class: "avatar", title: user))
           concat(content_tag(:span, "&nbsp; #{time_ago_in_words(time)} ago".html_safe, class: "time"))
         else

--- a/app/models/editor.rb
+++ b/app/models/editor.rb
@@ -19,9 +19,22 @@ class Editor < ActiveRecord::Base
   scope :topic, -> { where(kind: "topic") }
   scope :emeritus, -> { where(kind: "emeritus") }
   scope :active, -> { where(kind: ACTIVE_EDITOR_STATES) }
+  scope :since, -> (date) { where('created_at >= ?', date) }
 
   def category_list
     categories.join(", ")
+  end
+
+  def three_month_average
+    paper_count = self.papers.visible.since(3.months.ago).count
+    return sprintf("%.1f", paper_count / 3.0)
+  end
+
+  def self.global_three_month_average
+    editor_ids = Editor.active.where("created_at <= ?", 3.months.ago).collect {|e| e.id}
+    paper_count = Paper.visible.since(3.months.ago).where(editor_id: editor_ids).count
+
+    return sprintf("%.1f", paper_count / (3.0 * editor_ids.size))
   end
 
   def retired?

--- a/app/views/home/_menu.html.erb
+++ b/app/views/home/_menu.html.erb
@@ -1,0 +1,23 @@
+<div class="container">
+  <div class="btn-group" role="group" aria-label="Paper Status">
+    <%= link_to "/dashboard/#{current_user.editor.login}", class: current_class?("/dashboard/#{current_user.editor.login}") do %>
+    Your papers
+    <div class="count-badge"><%= raw current_user.editor.papers.in_progress.count %></div>
+    <% end %>
+    <%= link_to "/dashboard/incoming", class: current_class?("/dashboard/incoming") do %>
+    Papers with no editor
+    <div class="count-badge"><%= raw Paper.unscoped.in_progress.where(editor: nil).count %></div>
+    <% end %>
+    <%= link_to "/dashboard/in_progress", class: current_class?("/dashboard/in_progress") do %>
+    In progress papers
+    <div class="count-badge"><%= raw Paper.unscoped.in_progress.count %></div>
+    <% end %>
+    <%= link_to "/dashboard/all", class: current_class?("/dashboard/all") do %>
+    All papers
+    <div class="count-badge"><%= raw Paper.unscoped.all.count %></div>
+    <% end %>
+    <%= link_to "/dashboard", class: current_class?("/dashboard") do %>
+    <%= Rails.application.settings['abbreviation'] %> Statistics
+    <% end %>
+  </div>
+</div>

--- a/app/views/home/dashboard.html.erb
+++ b/app/views/home/dashboard.html.erb
@@ -1,98 +1,96 @@
-<div class="" style="margin: 0px 30px;">
-  <h2>Editor dashboard</h2>
-  <ul class="nav nav-pills nav-fill nav-justified" style="padding-bottom: 20px;">
-    <li class="nav-item">
-      <a class="<%= current_class?('/dashboard/incoming') %>" href="/dashboard/incoming">Papers with no editor</a>
-    </li>
-    <li class="nav-item">
-      <a class='<%= current_class?("/dashboard/#{current_user.editor.login}") %>' href="/dashboard/<%= current_user.editor.login %>">Your papers</a>
-    </li>
-    <li class="nav-item">
-      <a class="<%= current_class?('/dashboard/in_progress') %>" href="/dashboard/in_progress">In progress papers</a>
-    </li>
-    <li class="nav-item">
-      <a class="<%= current_class?('/dashboard/all') %>" href="/dashboard/all">All papers</a>
-    </li>
-    <li class="nav-item">
-      <a class="<%= current_class?('/dashboard') %>" href="/dashboard"><%= Rails.application.settings['abbreviation'] %> statistics</a>
-    </li>
-  </ul>
+<div class="container">
+    <div class="welcome">Welcome, <%= current_user.editor.full_name %></div>
+    <div class="hero-small dashboard">
+      <div class="hero-title">
+        <%= image_tag "icon_papers.svg", height: "32px" %><h1>Editor statistics</h1>
+      </div>
+    </div>
+</div>
 
-<h2>Published papers by month</h2>
+<%= render partial: "menu" %>
 
-<%= column_chart [
-  { name: "Accepted papers by month", data: @accepted_papers }
-], height: "500px", legend: false, library: { scales: { xAxes: [{ position: 'bottom' }], yAxes: [{ position: 'left', gridLines: { display: true, drawBorder: true }, ticks: { min: 0, max: 40, stepSize: 5}}, { position: 'right', gridLines: { display: false, drawBorder: true }, ticks: { min: 0, max: 40, stepSize: 5}}]}} %>
+<div class="container">
+  <table class="dashboard-table sortable">
+    <thead>
+      <tr>
+        <th scope="col" width="25%">Editor</th>
+        <th scope="col" width="10%">Assigned</th>
+        <th scope="col" class="text-center" width="15%">3M average</th>
+        <th scope="col" class="text-center" width="10%">Week</th>
+        <th scope="col" class="text-center" width="10%">Month</th>
+        <th scope="col" class="text-center" width="10%">Quarter</th>
+        <th scope="col" class="text-center" width="10%">Year</th>
+        <th scope="col" class="text-center" width="10%">All time</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% Editor.active.order('LOWER(login)').each do |editor| %>
+      <tr>
+        <td sorttable_customkey=<%= editor.login.downcase %>><%= image_tag(avatar(editor.login), size: "24x24", class: "avatar", title: editor.login) %> <%= link_to editor.login, "/dashboard/#{editor.login}" %><% if editor.retired? %> <em>(emeritus)</em><% end %></td>
+        <td sorttable_customkey=<%= count_without_ignored(Paper.in_progress.where(editor: editor)) %>><%= in_progress_for_editor(Paper.in_progress.where(editor: editor)) %></td>
+        <td class="text-center"><%= editor.three_month_average %></td>
+        <td class="text-center"><%= editor.papers.visible.since(1.week.ago).count %></td>
+        <td class="text-center"><%= editor.papers.visible.since(1.month.ago).count %></td>
+        <td class="text-center"><%= editor.papers.visible.since(3.months.ago).count %></td>
+        <td class="text-center"><%= editor.papers.visible.since(1.year.ago).count %></td>
+        <td class="text-center"><%= editor.papers.visible.since(100.year.ago).count %></td>
+      </tr>
+      <% end %>
+    </tbody>
+    <tfoot>
+      <% Editor.emeritus.order('LOWER(login)').each do |editor| %>
+      <tr class="<%= cycle('odd', 'even') -%>">
+        <td><%= image_tag(avatar(editor.login), size: "24x24", class: "avatar", title: editor.login) %> <%= link_to editor.login, "/dashboard/#{editor.login}" %><% if editor.retired? %> <em>(emeritus)</em><% end %></td>
+        <td><%= in_progress_for_editor(Paper.in_progress.where(editor: editor)) %></td>
+        <td class="text-center"><%= editor.three_month_average %></td>
+        <td class="text-center"><%= editor.papers.visible.since(1.week.ago).count %></td>
+        <td class="text-center"><%= editor.papers.visible.since(1.month.ago).count %></td>
+        <td class="text-center"><%= editor.papers.visible.since(3.months.ago).count %></td>
+        <td class="text-center"><%= editor.papers.visible.since(1.year.ago).count %></td>
+        <td class="text-center"><%= editor.papers.visible.since(100.year.ago).count %></td>
+      </tr>
+      <% end %>
+      <tr style="font-weight: bolder;">
+        <td>Totals</td>
+        <td><%= Paper.in_progress.count %></td>
+        <td class="text-center">–––</td>
+        <td class="text-center"><%= Paper.visible.since(1.week.ago).count %></td>
+        <td class="text-center"><%= Paper.visible.since(1.month.ago).count %></td>
+        <td class="text-center"><%= Paper.visible.since(3.months.ago).count %></td>
+        <td class="text-center"><%= Paper.visible.since(1.year.ago).count %></td>
+        <td class="text-center"><%= Paper.visible.since(100.year.ago).count %></td>
+      </tr>
+    </tfoot>
+  </table>
+</div>
 
-<h2>Accepted papers per month by editor</h2>
+<div class="container">
+  <div class="generic-content-item">
+    <h3>Published papers per month</h3>
 
-<p style="font-weight: bolder; padding-left: 40px;">Select editor: <%= select_tag 'editors', options_from_collection_for_select(Editor.all, "login", "login", params[:editor].blank? ? current_user.editor.login : params[:editor]),
-    onchange: "top.location.href='/dashboard?editor=' + this.options[this.selectedIndex].value + '#editor';" %></p>
+    <%= column_chart [
+      { name: "Accepted papers by month", data: @accepted_papers }
+    ], height: "500px", legend: false, library: { scales: { xAxes: [{ position: 'bottom' }], yAxes: [{ position: 'left', gridLines: { display: true, drawBorder: true }, ticks: { min: 0, max: 40, stepSize: 5}}, { position: 'right', gridLines: { display: false, drawBorder: true }, ticks: { min: 0, max: 40, stepSize: 5}}]}} %>
 
-<%= column_chart [
-  { name: "Papers edited by #{@editor.login} by month", data: @editor_papers }
-], height: "500px", colors: ["#8FBC8F"], id: "editor", legend: false, library: { scales: { xAxes: [{ position: 'bottom' }], yAxes: [{ position: 'left', gridLines: { display: true, drawBorder: true }, ticks: { min: 0, max: 20, stepSize: 5}}, { position: 'right', gridLines: { display: false, drawBorder: true }, ticks: { min: 0, max: 20, stepSize: 5}}]}} %>
+  </div>
 
-<h2>Papers reviewed per month by <%= @reviewer %></h2>
+  <div class="generic-content-item" style="padding-bottom: 80px;">
+    <h3 class="float-left">Accepted papers per month by editor</h3>
+    <p class="float-right" style="font-weight: bolder; padding-left: 40px;">Select editor: <%= select_tag 'editors', options_from_collection_for_select(Editor.all, "login", "login", params[:editor].blank? ? current_user.editor.login : params[:editor]),
+      onchange: "top.location.href='/dashboard?editor=' + this.options[this.selectedIndex].value + '#editor';" %></p>
 
-<div style="font-weight: bolder; padding-left: 40px; float: left;">Search for reviewer (hit enter to search): <%= form_for("/dashboard", html: { method: 'GET', style: "display: inline !important;" }) do |f| %><%= text_field_tag 'reviewer', @reviewer  %><% end %> </div>
+      <%= column_chart [
+      { name: "Papers edited by #{@editor.login} by month", data: @editor_papers }
+    ], height: "500px", colors: ["#8FBC8F"], id: "editor", legend: false, library: { scales: { xAxes: [{ position: 'bottom' }], yAxes: [{ position: 'left', gridLines: { display: true, drawBorder: true }, ticks: { min: 0, max: 20, stepSize: 5}}, { position: 'right', gridLines: { display: false, drawBorder: true }, ticks: { min: 0, max: 20, stepSize: 5}}]}} %>
+  </div>
 
-<%= column_chart [
-  { name: "Papers reviewed by #{@reviewer} by month", data: @reviewer_papers }
-], height: "500px", colors: ["#FFA500"], id: "reviewers", legend: false, library: { scales: { xAxes: [{ position: 'bottom' }], yAxes: [{ position: 'left', gridLines: { display: true, drawBorder: true }, ticks: { min: 0, max: 20, stepSize: 5}}, { position: 'right', gridLines: { display: false, drawBorder: true }, ticks: { min: 0, max: 20, stepSize: 5}}]}} %>
+  <div class="generic-content-item" style="padding-bottom: 120px;">
+    <h3 class="float-left">Papers reviewed per month by <%= @reviewer %></h3>
 
-<br /><br />
+    <div class="float-right" style="font-weight: bolder; padding-left: 40px;">Search for reviewer (hit enter to search): <%= form_for("/dashboard", html: { method: 'GET', style: "display: inline !important;" }) do |f| %><%= text_field_tag 'reviewer', @reviewer  %><% end %> </div>
 
-<h2>Editor statistics</h2>
-
-<table class="table table-bordered table-hover editor-stats table-striped table-sm sortable">
-  <thead class="thead-light">
-    <tr>
-      <th scope="col" width="16%">Editor</th>
-      <th scope="col" width="14%">Assigned</th>
-      <th scope="col" width="14%">Week</th>
-      <th scope="col" width="14%">Month</th>
-      <th scope="col" width="14%">Quarter</th>
-      <th scope="col" width="14%">Year</th>
-      <th scope="col" width="14%">All time</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% Editor.active.order('LOWER(login)').each do |editor| %>
-    <tr class="<%= cycle('odd', 'even') -%>">
-      <td><%= link_to editor.login, "/dashboard/#{editor.login}" %><% if editor.retired? %> <em>(emeritus)</em><% end %></td>
-      <td sorttable_customkey=<%= count_without_ignored(Paper.in_progress.where(editor: editor)) %>><%= in_progress_for_editor(Paper.in_progress.where(editor: editor)) %></td>
-      <td><%= editor.papers.visible.since(1.week.ago).count %></td>
-      <td><%= editor.papers.visible.since(1.month.ago).count %></td>
-      <td><%= editor.papers.visible.since(3.months.ago).count %></td>
-      <td><%= editor.papers.visible.since(1.year.ago).count %></td>
-      <td><%= editor.papers.visible.since(100.year.ago).count %></td>
-    </tr>
-    <% end %>
-  </tbody>
-  <tfoot>
-    <% Editor.emeritus.order('LOWER(login)').each do |editor| %>
-    <tr class="<%= cycle('odd', 'even') -%>">
-      <td><%= link_to editor.login, "/dashboard/#{editor.login}" %><% if editor.retired? %> <em>(emeritus)</em><% end %></td>
-      <td><%= in_progress_for_editor(Paper.in_progress.where(editor: editor)) %></td>
-      <td><%= editor.papers.visible.since(1.week.ago).count %></td>
-      <td><%= editor.papers.visible.since(1.month.ago).count %></td>
-      <td><%= editor.papers.visible.since(3.months.ago).count %></td>
-      <td><%= editor.papers.visible.since(1.year.ago).count %></td>
-      <td><%= editor.papers.visible.since(100.year.ago).count %></td>
-    </tr>
-    <% end %>
-    <tr style="font-weight: bolder;">
-      <td>Totals</td>
-      <td><%= Paper.in_progress.count %></td>
-      <td><%= Paper.visible.since(1.week.ago).count %></td>
-      <td><%= Paper.visible.since(1.month.ago).count %></td>
-      <td><%= Paper.visible.since(3.months.ago).count %></td>
-      <td><%= Paper.visible.since(1.year.ago).count %></td>
-      <td><%= Paper.visible.since(100.year.ago).count %></td>
-    </tr>
-  </tfoot>
-</table>
-
-<br />
+    <%= column_chart [
+      { name: "Papers reviewed by #{@reviewer} by month", data: @reviewer_papers }
+    ], height: "500px", colors: ["#FFA500"], id: "reviewers", legend: false, library: { scales: { xAxes: [{ position: 'bottom' }], yAxes: [{ position: 'left', gridLines: { display: true, drawBorder: true }, ticks: { min: 0, max: 20, stepSize: 5}}, { position: 'right', gridLines: { display: false, drawBorder: true }, ticks: { min: 0, max: 20, stepSize: 5}}]}} %>
+  </div>
 </div>

--- a/app/views/home/reviews.html.erb
+++ b/app/views/home/reviews.html.erb
@@ -1,35 +1,40 @@
 <div class="container">
-    <div class="welcome">Welcome, <%= current_user.editor.full_name %></div>
-    <div class="hero-small dashboard">
-      <div class="hero-title">
-        <%= image_tag "icon_papers.svg", height: "32px" %><h1>Editor dashboard</h1>
+  <div class="row dashboard">
+    <div class="col-7">
+      <div class="welcome">Welcome, <%= current_user.editor.full_name %></div>
+      <div class="hero-small dashboard">
+        <div class="hero-title">
+          <%= image_tag "icon_papers.svg", height: "32px" %><h1>Editor dashboard</h1>
+        </div>
       </div>
     </div>
-</div>
+    <div class="col-5">
+      <div class="my-statistics">
+        <div class="banner">
+          <span class="text-left">Statistics</span>
+          <span class="float-right"><%= link_to "View more &raquo;".html_safe, dashboard_path %></span>
+        </div>
 
-<div class="container">
-  <div class="btn-group" role="group" aria-label="Paper Status">
-    <%= link_to "/dashboard/#{current_user.editor.login}", class: current_class?("/dashboard/#{current_user.editor.login}") do %>
-    Your papers
-    <div class="count-badge"><%= raw current_user.editor.papers.in_progress.count %></div>
-    <% end %>
-    <%= link_to "/dashboard/incoming", class: current_class?("/dashboard/incoming") do %>
-    Papers with no editor
-    <div class="count-badge"><%= raw Paper.unscoped.in_progress.where(editor: nil).count %></div>
-    <% end %>
-    <%= link_to "/dashboard/in_progress", class: current_class?("/dashboard/in_progress") do %>
-    In progress papers
-    <div class="count-badge"><%= raw Paper.unscoped.in_progress.count %></div>
-    <% end %>
-    <%= link_to "/dashboard/all", class: current_class?("/dashboard/all") do %>
-    All papers
-    <div class="count-badge"><%= raw Paper.unscoped.all.count %></div>
-    <% end %>
-    <%= link_to "/dashboard", class: current_class?("/dashboard") do %>
-    <%= Rails.application.settings['abbreviation'] %> Statistics
-    <% end %>
+        <div class="row">
+          <div class="stat col">
+            <div class="count"><%= @editor.papers.visible.since(1.month.ago).count %></div>
+            <div class="message">Papers last month</div>
+          </div>
+          <div class="stat col">
+            <div class="count"><%= @editor.three_month_average %><span class="sub">(3M average)</span></div>
+            <div class="message">Papers per month</div>
+          </div>
+          <div class="stat col">
+            <div class="count"><%= Editor.global_three_month_average %><span class="sub">(Editor average)</span></div>
+            <div class="message">Papers per month</div>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
+
+<%= render partial: "menu" %>
 
 <div class="container">
   <table class="dashboard-table">

--- a/app/views/home/reviews.html.erb
+++ b/app/views/home/reviews.html.erb
@@ -48,7 +48,7 @@
       <tr>
         <td class="state"><%= paper.state.titleize %></td>
         <td><%= link_to paper.title, paper_url(paper), title: paper.title, class: "d-inline-block text-truncate", style: "max-width: 450px;" %><div class="time">Submitted <%= time_ago_in_words(paper.created_at) %> ago <%= pretty_labels_for(paper) %></div></td>
-        <td class="text-center"><%= link_to truncate("#{paper.meta_review_issue_id}", length: 60), paper.meta_review_url  %> / <%= link_to truncate("#{paper.review_issue_id}", length: 60), paper.review_url  %></td>
+        <td class="text-center"><%= review_issue_links(paper) %></td>
         <td class="text-center mobile-hide">
           <%- paper.reviewers.each do |reviewer| %>
             <%= link_to image_tag(avatar(reviewer), size: "24x24", class: "avatar", title: reviewer), github_user_link(reviewer).html_safe %>

--- a/app/views/home/reviews.html.erb
+++ b/app/views/home/reviews.html.erb
@@ -29,9 +29,9 @@
         <th scope="col" width="12%">Status</th>
         <th scope="col" width="34%">Paper title</th>
         <th scope="col" width="10%">Reviews</th>
-        <th scope="col" width="8%">Reviewers</th>
-        <th scope="col" width="15%">Checklist</th>
-        <th scope="col" width="19%">Last activity</th>
+        <th class="mobile-hide" scope="col" width="8%">Reviewers</th>
+        <th class="mobile-hide" scope="col" width="15%">Checklist</th>
+        <th class="mobile-hide" scope="col" width="19%">Last activity</th>
         <th scope="col" width="2%" style="padding:0 1em 0 0;"><%= sort_icon(@order) %></th>
       </tr>
     </thead>
@@ -41,13 +41,13 @@
         <td class="state"><%= paper.state.titleize %></td>
         <td><%= link_to paper.title, paper_url(paper), title: paper.title, class: "d-inline-block text-truncate", style: "max-width: 360px;" %><div class="time">Submitted <%= time_ago_in_words(paper.created_at) %> ago <%= pretty_labels_for(paper) %></div></td>
         <td class="text-center"><%= link_to truncate("#{paper.meta_review_issue_id}", length: 60), paper.meta_review_url  %> / <%= link_to truncate("#{paper.review_issue_id}", length: 60), paper.review_url  %></td>
-        <td class="text-center">
+        <td class="text-center mobile-hide">
           <%- paper.reviewers.each do |reviewer| %>
             <%= link_to image_tag(avatar(reviewer), size: "24x24", class: "avatar", title: reviewer), github_user_link(reviewer).html_safe %>
           <%- end %>
         </td>
-        <td><%= checklist_activity(paper) %></td>
-        <td><%= comment_activity(paper) %></td>
+        <td class="mobile-hide"><%= checklist_activity(paper) %></td>
+        <td class="mobile-hide"><%= comment_activity(paper) %></td>
         <td style="display:none;"></td>
       </tr>
       <% end %>

--- a/app/views/home/reviews.html.erb
+++ b/app/views/home/reviews.html.erb
@@ -1,12 +1,21 @@
 <div class="container">
+    <div class="welcome">Welcome, <%= current_user.editor.full_name %></div>
+    <div class="hero-small dashboard">
+      <div class="hero-title">
+        <%= image_tag "icon_papers.svg", height: "32px" %><h1>Editor dashboard</h1>
+      </div>
+    </div>
+</div>
+
+<div class="container">
   <div class="btn-group" role="group" aria-label="Paper Status">
-    <%= link_to "/dashboard/incoming", class: current_class?("/dashboard/incoming") do %>
-    Papers with no editor
-    <div class="count-badge"><%= raw Paper.unscoped.in_progress.where(editor: nil).count %></div>
-    <% end %>
     <%= link_to "/dashboard/#{current_user.editor.login}", class: current_class?("/dashboard/#{current_user.editor.login}") do %>
     Your papers
     <div class="count-badge"><%= raw current_user.editor.papers.in_progress.count %></div>
+    <% end %>
+    <%= link_to "/dashboard/incoming", class: current_class?("/dashboard/incoming") do %>
+    Papers with no editor
+    <div class="count-badge"><%= raw Paper.unscoped.in_progress.where(editor: nil).count %></div>
     <% end %>
     <%= link_to "/dashboard/in_progress", class: current_class?("/dashboard/in_progress") do %>
     In progress papers

--- a/app/views/home/reviews.html.erb
+++ b/app/views/home/reviews.html.erb
@@ -39,8 +39,8 @@
         <th scope="col" width="34%">Paper title</th>
         <th scope="col" width="10%">Reviews</th>
         <th class="mobile-hide" scope="col" width="8%">Reviewers</th>
-        <th class="mobile-hide" scope="col" width="15%">Checklist</th>
-        <th class="mobile-hide" scope="col" width="19%">Last activity</th>
+        <th class="mobile-hide" scope="col" width="15%">Activity</th>
+        <th class="mobile-hide" scope="col" width="19%">Last comment</th>
         <th scope="col" width="2%" style="padding:0 1em 0 0;"><%= sort_icon(@order) %></th>
       </tr>
     </thead>

--- a/app/views/home/reviews.html.erb
+++ b/app/views/home/reviews.html.erb
@@ -47,7 +47,7 @@
       <% @papers.each do |paper| %>
       <tr>
         <td class="state"><%= paper.state.titleize %></td>
-        <td><%= link_to paper.title, paper_url(paper), title: paper.title, class: "d-inline-block text-truncate", style: "max-width: 360px;" %><div class="time">Submitted <%= time_ago_in_words(paper.created_at) %> ago <%= pretty_labels_for(paper) %></div></td>
+        <td><%= link_to paper.title, paper_url(paper), title: paper.title, class: "d-inline-block text-truncate", style: "max-width: 450px;" %><div class="time">Submitted <%= time_ago_in_words(paper.created_at) %> ago <%= pretty_labels_for(paper) %></div></td>
         <td class="text-center"><%= link_to truncate("#{paper.meta_review_issue_id}", length: 60), paper.meta_review_url  %> / <%= link_to truncate("#{paper.review_issue_id}", length: 60), paper.review_url  %></td>
         <td class="text-center mobile-hide">
           <%- paper.reviewers.each do |reviewer| %>

--- a/app/views/home/reviews.html.erb
+++ b/app/views/home/reviews.html.erb
@@ -1,53 +1,61 @@
-<div class="" style="margin: 0px 30px;">
-  <h2>Editor dashboard</h2>
-  <ul class="nav nav-pills nav-fill nav-justified" style="padding-bottom: 20px;">
-    <li class="nav-item">
-      <a class="<%= current_class?('/dashboard/incoming') %>" href="/dashboard/incoming">Papers with no editor</a>
-    </li>
-    <li class="nav-item">
-      <a class='<%= current_class?("/dashboard/#{current_user.editor.login}") %>' href="/dashboard/<%= current_user.editor.login %>">Your papers</a>
-    </li>
-    <li class="nav-item">
-      <a class="<%= current_class?('/dashboard/in_progress') %>" href="/dashboard/in_progress">In progress papers</a>
-    </li>
-    <li class="nav-item">
-      <a class="<%= current_class?('/dashboard/all') %>" href="/dashboard/all">All papers</a>
-    </li>
-    <li class="nav-item">
-      <a class="<%= current_class?('/dashboard') %>" href="/dashboard">JOSS statistics</a>
-    </li>
-  </ul>
-  <table class="table table-bordered table-hover table-striped table-responsive">
-    <thead class="thead-light">
+<div class="container">
+  <div class="btn-group" role="group" aria-label="Paper Status">
+    <%= link_to "/dashboard/incoming", class: current_class?("/dashboard/incoming") do %>
+    Papers with no editor
+    <div class="count-badge"><%= raw Paper.unscoped.in_progress.where(editor: nil).count %></div>
+    <% end %>
+    <%= link_to "/dashboard/#{current_user.editor.login}", class: current_class?("/dashboard/#{current_user.editor.login}") do %>
+    Your papers
+    <div class="count-badge"><%= raw current_user.editor.papers.in_progress.count %></div>
+    <% end %>
+    <%= link_to "/dashboard/in_progress", class: current_class?("/dashboard/in_progress") do %>
+    In progress papers
+    <div class="count-badge"><%= raw Paper.unscoped.in_progress.count %></div>
+    <% end %>
+    <%= link_to "/dashboard/all", class: current_class?("/dashboard/all") do %>
+    All papers
+    <div class="count-badge"><%= raw Paper.unscoped.all.count %></div>
+    <% end %>
+    <%= link_to "/dashboard", class: current_class?("/dashboard") do %>
+    <%= Rails.application.settings['abbreviation'] %> Statistics
+    <% end %>
+  </div>
+</div>
+
+<div class="container">
+  <table class="dashboard-table">
+    <thead>
       <tr>
-        <th scope="col" width="23%">Paper title</th>
-        <th scope="col" width="10%" class="text-center">Reviews</th>
-        <th scope="col" width="8%">State</th>
-        <th scope="col" width="18%">Reviewers</th>
-        <th scope="col" width="12%">Submitted</th>
-        <th scope="col" width="29%">Last Activity &middot; <%= stale_link %> &middot; <%= fresh_link %></th>
+        <th scope="col" width="13%">Status</th>
+        <th scope="col" width="35%">Paper title</th>
+        <th scope="col" width="10%">Reviews</th>
+        <th scope="col" width="8%">Reviewers</th>
+        <th scope="col" width="13%">Checklist</th>
+        <th scope="col" width="19%">Last activity</th>
+        <th scope="col" width="2%" style="padding:0 1em 0 0;"><%= sort_icon(@order) %></th>
       </tr>
     </thead>
     <tbody>
       <% @papers.each do |paper| %>
       <tr>
-        <td><%= link_to truncate(paper.title, length: 50), paper_url(paper), title: paper.title %> <%= pretty_labels_for(paper) %></td>
+        <td class="state"><%= paper.state.titleize %></td>
+        <td><h2 class="paper-title"><%= link_to truncate(paper.title, length: 40), paper_url(paper), title: paper.title %></h2><div class="time">Submitted <%= time_ago_in_words(paper.created_at) %> ago <%= pretty_labels_for(paper) %></div></td>
         <td class="text-center"><%= link_to truncate("#{paper.meta_review_issue_id}", length: 60), paper.meta_review_url  %> / <%= link_to truncate("#{paper.review_issue_id}", length: 60), paper.review_url  %></td>
-        <td><pre><%= paper.state %></pre></td>
-        <td><%= linked_reviewers(paper) %></td>
-        <td><%= time_ago_in_words(paper.created_at) %> ago</td>
-        <td style="position: relative;">
-          <%= last_comment_for(paper) %>
-          <a href="#paper-activity-<%= paper.id %>" data-toggle="collapse" aria-expanded="false" aria-controls="collapseExample" style="position: absolute; bottom: 4px; right: 4px">More ▼</a>
-          <div class="collapse" id="paper-activity-<%= paper.id %>" style="margin-top: 5px;">
-            <div class="card card-body" style="width: 85%;">
-              <%= card_activity(paper) %>
-            </div>
-          </div>
+        <td class="text-center">
+          <%- paper.reviewers.each do |reviewer| %>
+            <%= link_to image_tag(avatar(reviewer), size: "24x24", class: "avatar", title: reviewer), github_user_link(reviewer).html_safe %>
+          <%- end %>
         </td>
+        <td><%= checklist_activity(paper) %></td>
+        <td><%= comment_activity(paper) %></td>
+        <td style="display:none;"></td>
       </tr>
       <% end %>
     </tbody>
   </table>
-  <%= will_paginate @papers %>
+
+  <div class="row">
+    <!-- :class not applying here? --> <div class="pagination_helper"><%= page_entries_info(@papers).capitalize.html_safe %></div>
+    <%= will_paginate @papers, inner_window: 3, outer_window: 0, page_links: false %>
+  </div>
 </div>

--- a/app/views/home/reviews.html.erb
+++ b/app/views/home/reviews.html.erb
@@ -37,10 +37,9 @@
       <tr>
         <th scope="col" width="12%">Status</th>
         <th scope="col" width="34%">Paper title</th>
-        <th scope="col" width="10%">Reviews</th>
-        <th class="mobile-hide" scope="col" width="8%">Reviewers</th>
-        <th class="mobile-hide" scope="col" width="15%">Activity</th>
-        <th class="mobile-hide" scope="col" width="19%">Last comment</th>
+        <th scope="col" class="text-center" width="10%">Reviews</th>
+        <th class="mobile-hide text-center" scope="col" width="8%">Reviewers</th>
+        <th class="mobile-hide" scope="col" width="15%">Last comment</th>
         <th scope="col" width="2%" style="padding:0 1em 0 0;"><%= sort_icon(@order) %></th>
       </tr>
     </thead>
@@ -55,7 +54,6 @@
             <%= link_to image_tag(avatar(reviewer), size: "24x24", class: "avatar", title: reviewer), github_user_link(reviewer).html_safe %>
           <%- end %>
         </td>
-        <td class="mobile-hide"><%= checklist_activity(paper) %></td>
         <td class="mobile-hide"><%= comment_activity(paper) %></td>
         <td style="display:none;"></td>
       </tr>

--- a/app/views/home/reviews.html.erb
+++ b/app/views/home/reviews.html.erb
@@ -26,11 +26,11 @@
   <table class="dashboard-table">
     <thead>
       <tr>
-        <th scope="col" width="13%">Status</th>
-        <th scope="col" width="35%">Paper title</th>
+        <th scope="col" width="12%">Status</th>
+        <th scope="col" width="34%">Paper title</th>
         <th scope="col" width="10%">Reviews</th>
         <th scope="col" width="8%">Reviewers</th>
-        <th scope="col" width="13%">Checklist</th>
+        <th scope="col" width="15%">Checklist</th>
         <th scope="col" width="19%">Last activity</th>
         <th scope="col" width="2%" style="padding:0 1em 0 0;"><%= sort_icon(@order) %></th>
       </tr>
@@ -39,7 +39,7 @@
       <% @papers.each do |paper| %>
       <tr>
         <td class="state"><%= paper.state.titleize %></td>
-        <td><h2 class="paper-title"><%= link_to truncate(paper.title, length: 40), paper_url(paper), title: paper.title %></h2><div class="time">Submitted <%= time_ago_in_words(paper.created_at) %> ago <%= pretty_labels_for(paper) %></div></td>
+        <td><%= link_to paper.title, paper_url(paper), title: paper.title, class: "d-inline-block text-truncate", style: "max-width: 360px;" %><div class="time">Submitted <%= time_ago_in_words(paper.created_at) %> ago <%= pretty_labels_for(paper) %></div></td>
         <td class="text-center"><%= link_to truncate("#{paper.meta_review_issue_id}", length: 60), paper.meta_review_url  %> / <%= link_to truncate("#{paper.review_issue_id}", length: 60), paper.review_url  %></td>
         <td class="text-center">
           <%- paper.reviewers.each do |reviewer| %>

--- a/spec/models/editor_spec.rb
+++ b/spec/models/editor_spec.rb
@@ -45,6 +45,48 @@ RSpec.describe Editor, type: :model do
     end
   end
 
+  describe "#three_month_average" do
+    before(:each) {
+      create(:accepted_paper, :editor => editor, :accepted_at => 1.week.ago);
+      create(:accepted_paper, :editor => editor, :accepted_at => 3.weeks.ago);
+      create(:accepted_paper, :editor => editor, :accepted_at => 4.months.ago)
+    }
+
+    it "should know how many papers the editor has published" do
+      expect(editor.papers.count).to eq(3)
+    end
+
+    it "should know how to calculate the monntly average papers" do
+      expect(editor.three_month_average).to eq("0.7")
+    end
+  end
+
+  describe "#global editor stats" do
+    before do
+      # This editor should be ignored as they're retired
+      retired_editor = create(:editor, login: "@retired1", kind: "emeritus")
+      create(:accepted_paper, :editor => retired_editor, :accepted_at => 1.week.ago)
+      create(:accepted_paper, :editor => retired_editor, :accepted_at => 1.year.ago)
+
+      # This editor should be ignored as they're brand new
+      new_editor = create(:editor, login: "@topic1", kind: "topic")
+      create(:accepted_paper, :editor => new_editor, :accepted_at => 1.week.ago)
+
+      # These editors should be the ones that count
+      active_editor_1 = create(:editor, login: "@topic1", kind: "topic", :created_at => 4.months.ago)
+      create(:accepted_paper, :editor => active_editor_1, :accepted_at => 1.week.ago) #counts
+      create(:accepted_paper, :editor => active_editor_1, :accepted_at => 1.year.ago) #doesn't count
+
+      active_editor_2 = create(:editor, login: "@topic1", kind: "topic", :created_at => 4.years.ago)
+      create(:accepted_paper, :editor => active_editor_2, :accepted_at => 1.week.ago) #counts
+      create(:accepted_paper, :editor => active_editor_2, :accepted_at => 1.month.ago) #counts
+    end
+
+    it "should know how to calculate the overall #global_three_month_average" do
+      expect(Editor.global_three_month_average).to eq("0.5")
+    end
+  end
+
   describe "#active editors" do
     it "should exclude emeritus" do
       editor_1 = create(:editor, login: "@board1", kind: "board")


### PR DESCRIPTION
:wave: @openjournals/joss-editors @openjournals/joss-eics 

This PR brings the editor dashboard and summary screens up to date with the latest site designs. It also adds a little extra information to the dashboard views for each editor:

<img width="1396" alt="dashboard" src="https://user-images.githubusercontent.com/4483/75612648-90233280-5af3-11ea-9489-94228477b15e.png">

The new information available is as follows:

- Number of papers published in the last month that you edited.
- A rolling 3-month average for the number of papers being published per month edited by you.
- A rolling 3-month average for the number of papers being published per editor per month across all of JOSS.

Obviously for newer editors, these numbers may be zeroes, especially as papers take some time to process 😄.

Please let me know if you find any weird quirks with these numbers or if you have suggestions for more informative metrics. I think I did my maths correctly here 🤞
