### PR TITLE
Skip specs affected by closing submissions

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
 
   resources :editors
-  resources :papers do
+  resources :papers, except: [:create] do
     member do
       post 'start_review'
       post 'start_meta_review'

--- a/spec/controllers/papers_controller_spec.rb
+++ b/spec/controllers/papers_controller_spec.rb
@@ -14,14 +14,6 @@ describe PapersController, type: :controller do
     end
   end
 
-  describe "POST #create" do
-    it "NOT LOGGED IN responds with redirect" do
-      paper_params = {title: "Yeah whateva", body: "something"}
-      post :create, params: {paper: paper_params}
-      expect(response).to be_redirect
-    end
-  end
-
   describe "#start_meta_review" do
     it "NOT LOGGED IN responds with redirect" do
       post :start_meta_review, params: {id: 'nothing much'}
@@ -139,6 +131,12 @@ describe PapersController, type: :controller do
       post :create, params: {paper: paper_params}
       expect(response).to be_redirect # as it's redirected us
       expect(Paper.count).to eq(paper_count)
+    end
+
+    it "NOT LOGGED IN responds with redirect" do
+      paper_params = {title: "Yeah whateva", body: "something"}
+      post :create, params: {paper: paper_params}
+      expect(response).to be_redirect
     end
   end
 

--- a/spec/controllers/papers_controller_spec.rb
+++ b/spec/controllers/papers_controller_spec.rb
@@ -97,7 +97,8 @@ describe PapersController, type: :controller do
     end
   end
 
-  describe "POST #create" do
+  describe "POST #create", skip: "New submissions are temporarily disabled - CoV19" do
+
     it "LOGGED IN responds with success" do
       user = create(:user)
       allow(controller).to receive_message_chain(:current_user).and_return(user)
@@ -117,8 +118,8 @@ describe PapersController, type: :controller do
       paper_params = {title: "Yeah whateva", body: "something", repository_url: "", archive_doi: "https://doi.org/10.6084/m9.figshare.828487"}
       post :create, params: {paper: paper_params}
 
-      # expect(response.body).to match /Your paper could not be saved/
-      # expect(Paper.count).to eq(paper_count)
+      expect(response.body).to match /Your paper could not be saved/
+      expect(Paper.count).to eq(paper_count)
     end
 
     it "LOGGED IN without a email on the submitting author account" do

--- a/spec/views/papers/new.html.erb_spec.rb
+++ b/spec/views/papers/new.html.erb_spec.rb
@@ -15,41 +15,41 @@ RSpec.describe "papers/new", type: :view do
     Rails.application.settings["paper_types"] = setting
   end
 
-  context "with multiple paper types" do
+  context "with multiple paper types", skip: "New submissions are temporarily disabled - CoV19" do
     let(:paper_types) { %w(type1 type2 type3) }
 
     it "renders the new paper form" do
       render
 
-      # assert_select "form[action=?][method=?]", papers_path, "post" do
-      #   assert_select "select#paper_kind[name=?]", "paper[kind]"
-      #   assert_select "input#paper_title[name=?]", "paper[title]"
-      #   assert_select "input#paper_repository_url[name=?]", "paper[repository_url]"
-      #   assert_select "input#paper_software_version[name=?]", "paper[software_version]"
-      #   assert_select "select#paper_suggested_editor[name=?]", "paper[suggested_editor]"
-      #   assert_select "textarea#paper_body[name=?]", "paper[body]"
-      #   assert_select "input#author-check"
-      #   assert_select "input#coc-check"
-      # end
+      assert_select "form[action=?][method=?]", papers_path, "post" do
+        assert_select "select#paper_kind[name=?]", "paper[kind]"
+        assert_select "input#paper_title[name=?]", "paper[title]"
+        assert_select "input#paper_repository_url[name=?]", "paper[repository_url]"
+        assert_select "input#paper_software_version[name=?]", "paper[software_version]"
+        assert_select "select#paper_suggested_editor[name=?]", "paper[suggested_editor]"
+        assert_select "textarea#paper_body[name=?]", "paper[body]"
+        assert_select "input#author-check"
+        assert_select "input#coc-check"
+      end
     end
   end
 
-  context "with no paper types" do
+  context "with no paper types", skip: "New submissions are temporarily disabled - CoV19" do
     let(:paper_types) { [] }
 
     it "renders the new paper form" do
       render
 
-      # assert_select "form[action=?][method=?]", papers_path, "post" do
-      #   assert_select "select#paper_kind", false
-      #   assert_select "input#paper_title[name=?]", "paper[title]"
-      #   assert_select "input#paper_repository_url[name=?]", "paper[repository_url]"
-      #   assert_select "input#paper_software_version[name=?]", "paper[software_version]"
-      #   assert_select "select#paper_suggested_editor[name=?]", "paper[suggested_editor]"
-      #   assert_select "textarea#paper_body[name=?]", "paper[body]"
-      #   assert_select "input#author-check"
-      #   assert_select "input#coc-check"
-      # end
+      assert_select "form[action=?][method=?]", papers_path, "post" do
+        assert_select "select#paper_kind", false
+        assert_select "input#paper_title[name=?]", "paper[title]"
+        assert_select "input#paper_repository_url[name=?]", "paper[repository_url]"
+        assert_select "input#paper_software_version[name=?]", "paper[software_version]"
+        assert_select "select#paper_suggested_editor[name=?]", "paper[suggested_editor]"
+        assert_select "textarea#paper_body[name=?]", "paper[body]"
+        assert_select "input#author-check"
+        assert_select "input#coc-check"
+      end
     end
   end
 end


### PR DESCRIPTION
This PR refactors the disabling of tests caused by suspending new submissions, so it will be easier to find when reverting to normal situation.
- papers#create route is disabled
- affected tests are skipped with proper message:

![rake spec](https://user-images.githubusercontent.com/6528/76611979-b1d0e080-651b-11ea-91dc-67a14f69e2b4.png)
