### PR TITLE
Make search for author/editor/reviewer not exact

### DIFF
--- a/app/controllers/papers_controller.rb
+++ b/app/controllers/papers_controller.rb
@@ -107,21 +107,21 @@ class PapersController < ApplicationController
       @term = "in #{params['language']}"
 
     elsif params['author']
-      @papers = Paper.search(params['author'], fields: [authors: :exact], order: { accepted_at: :desc },
+      @papers = Paper.search(params['author'], fields: [:authors], order: { accepted_at: :desc },
                   page: params[:page],
                   per_page: 10
                 )
       @term = "by #{params['author']}"
 
     elsif params['editor']
-      @papers = Paper.search(params['editor'], fields: [editor: :exact], order: { accepted_at: :desc },
+      @papers = Paper.search(params['editor'], fields: [:editor], order: { accepted_at: :desc },
                   page: params[:page],
                   per_page: 10
                 )
       @term = "edited by #{params['editor']}"
 
     elsif params['reviewer']
-      @papers = Paper.search(params['reviewer'], fields: [reviewers: :exact], order: { accepted_at: :desc },
+      @papers = Paper.search(params['reviewer'], fields: [:reviewers], order: { accepted_at: :desc },
                   page: params[:page],
                   per_page: 10
                 )


### PR DESCRIPTION
Since [this change](https://github.com/openjournals/joss/commit/f82479e6359bc6a87e1c77bca00827d5c1843a16#diff-80c2de5496f8beac6c1754149c0a30f4L110-R124) some searches are not working. Esamples:

- Empty 'by author' seach: if I click in any of the author's link in this recently published paper:  https://joss.theoj.org/papers/10.21105/joss.02102 the resulting page for "All papers by XXX" does not return any [result](https://joss.theoj.org/papers/by/Samantha%20Hood).
- By reviewer/editor searches: These [editor](https://joss.theoj.org/papers/edited_by/@arfon)/[reviewer](https://joss.theoj.org/papers/reviewed_by/@arfon) work, but [these](https://joss.theoj.org/papers/edited_by/Arfon) [two](https://joss.theoj.org/papers/reviewed_by/arfon) don't. I think they should return the same results.

This PR just removes the `exact` search attribute for the `:authors`, `:reviewers` and `:editors` fields.