### PR TITLE
Reduced service mode updates

### DIFF
--- a/app/views/notifications/author_submission_email.html.erb
+++ b/app/views/notifications/author_submission_email.html.erb
@@ -2,6 +2,10 @@ Hello there, thanks for your submission to <em><%= Rails.application.settings['a
 <br />
 Your paper, <em>'<%= @paper.title %>'</em>, is currently awaiting triage by our managing editor. This generally takes between 24 and 72 hours and until then, your paper won't show up in the https://github.com/<%= Rails.application.settings['reviews'] %> repository.
 <br />
+
+Due to the COVID-19 pandemic, <%= Rails.application.settings['abbreviation'] %> is currently operating in a reduced service mode. More details about what this means for authors, editors, and reviewers is available in <%= link_to "this blog post", "#" %>, but in short, authors should anticipate a significantly longer review period than before and your patience is appreciated.
+<br />
+
 You can view the latest status of your paper here: <%= @url %>
 <br />
 Many thanks<br />

--- a/app/views/notifications/author_submission_email.html.erb
+++ b/app/views/notifications/author_submission_email.html.erb
@@ -3,7 +3,7 @@ Hello there, thanks for your submission to <em><%= Rails.application.settings['a
 Your paper, <em>'<%= @paper.title %>'</em>, is currently awaiting triage by our managing editor. This generally takes between 24 and 72 hours and until then, your paper won't show up in the https://github.com/<%= Rails.application.settings['reviews'] %> repository.
 <br />
 
-Due to the COVID-19 pandemic, <%= Rails.application.settings['abbreviation'] %> is currently operating in a reduced service mode. More details about what this means for authors, editors, and reviewers is available in <%= link_to "this blog post", "#" %>, but in short, authors should anticipate a significantly longer review period than before and your patience is appreciated.
+Due to the COVID-19 pandemic, <%= Rails.application.settings['abbreviation'] %> is currently operating in a reduced service mode. More details about what this means for authors, editors, and reviewers is available in <%= link_to "this blog post", "https://blog.joss.theoj.org/2020/05/reopening-joss" %>, but in short, authors should anticipate a significantly longer review period than before and your patience is appreciated.
 <br />
 
 You can view the latest status of your paper here: <%= @url %>

--- a/app/views/notifications/author_submission_email.text.erb
+++ b/app/views/notifications/author_submission_email.text.erb
@@ -2,7 +2,7 @@ Hello there, thanks for your submission to <%= Rails.application.settings['abbre
 
 Your paper, '<%= @paper.title %>', is currently awaiting triage by our managing editor. This generally takes between 24 and 72 hours and until then, your paper won't show up in the https://github.com/<%= Rails.application.settings['reviews'] %> repository.
 
-Due to the COVID-19 pandemic, <%= Rails.application.settings['abbreviation'] %> is currently operating in a reduced service mode. More details about what this means for authors, editors, and reviewers is available in <%= link_to "this blog post", "#" %>, but in short, authors should anticipate a significantly longer review period than before and your patience is appreciated.
+Due to the COVID-19 pandemic, <%= Rails.application.settings['abbreviation'] %> is currently operating in a reduced service mode. More details about what this means for authors, editors, and reviewers is available in <%= link_to "this blog post", "https://blog.joss.theoj.org/2020/05/reopening-joss" %>, but in short, authors should anticipate a significantly longer review period than before and your patience is appreciated.
 
 You can view the latest status of your paper here: <%= @url %>
 

--- a/app/views/notifications/author_submission_email.text.erb
+++ b/app/views/notifications/author_submission_email.text.erb
@@ -2,6 +2,8 @@ Hello there, thanks for your submission to <%= Rails.application.settings['abbre
 
 Your paper, '<%= @paper.title %>', is currently awaiting triage by our managing editor. This generally takes between 24 and 72 hours and until then, your paper won't show up in the https://github.com/<%= Rails.application.settings['reviews'] %> repository.
 
+Due to the COVID-19 pandemic, <%= Rails.application.settings['abbreviation'] %> is currently operating in a reduced service mode. More details about what this means for authors, editors, and reviewers is available in <%= link_to "this blog post", "#" %>, but in short, authors should anticipate a significantly longer review period than before and your patience is appreciated.
+
 You can view the latest status of your paper here: <%= @url %>
 
 Many thanks

--- a/app/views/papers/new.html.erb
+++ b/app/views/papers/new.html.erb
@@ -4,7 +4,7 @@
       <h1>Submit <%= setting(:product) %> for review</h1>
 
       <div class="alert alert-danger" role="alert">
-        <h4 class="alert-heading">JOSS is currently operating in a reduced service mode. You can read more about what this means in our <%= link_to "blog post", "#" %>.</h4>
+        <h4 class="alert-heading">JOSS is currently operating in a reduced service mode. You can read more about what this means in our <%= link_to "blog post", "https://blog.joss.theoj.org/2020/05/reopening-joss" %>.</h4>
       </div>
 
       <div class="alert alert-info" role="alert">

--- a/app/views/papers/new.html.erb
+++ b/app/views/papers/new.html.erb
@@ -1,36 +1,24 @@
 <div class="container">
   <div class="row justify-content-lg-center">
     <div class="col-lg-10">
-      <!-- <h1>Submit <%= setting(:product) %> for review</h1> -->
+      <h1>Submit <%= setting(:product) %> for review</h1>
 
       <div class="alert alert-danger" role="alert">
-        <h4 class="alert-heading">Submissions to JOSS are suspended until at least 18th May 2020.</h4>
-
-        <p>In light of the COVID-19 pandemic, JOSS submissions have been suspended since 12th March 2020. Over the next two weeks, the JOSS editorial team is going to put together a plan for beginning to resume accepting submissions.</p>
-        
-        <p>Existing submissions will be handled on a 'best effort' basis but new submissions will not be accepted until we are confident we can handle submissions in a timely fashion.</p>
-
-        <p>Additionally, authors planning to submit can make use of the <a href="http://whedon.theoj.org">JOSS paper preview service</a> to prepare their manuscripts ahead of submissions reopening.</p>
-
-        <p>Please check back here again on the 18th of May or follow our <a href="https://twitter.com/joss_theoj">Twitter account</a> for updates.</p>
-
-
-        <p><em>Arfon Smith, Editor in Chief, on behalf of the JOSS editorial team.</em></p>
+        <h4 class="alert-heading">JOSS is currently operating in a reduced service mode. You can read more about what this means in our <%= link_to "blog post", "#" %>.</h4>
       </div>
 
-      <!-- <div class="alert alert-info" role="alert">
+      <div class="alert alert-info" role="alert">
+        <center><strong>⚠️ ⚠️ ⚠️ Before you submit ⚠️ ⚠️ ⚠️ </strong></center>
+        <p>As the submitting author, before you submit, please make sure that you have reviewed the following items. We promise this will make things go much more quickly during the review process:
+        <ul>
+          <li>You have reviewed the <a href="https://joss.readthedocs.io/en/latest/submitting.html">submission instructions</a> and verified that your submission meets our <a href="https://joss.readthedocs.io/en/latest/submitting.html#submission-requirements">submission requirements</a>.</li>
+          <li>There is a Markdown file named <code>paper.md</code> present in your repository that is structured <a href="https://joss.readthedocs.io/en/latest/submitting.html#example-paper-and-bibliography">like this</a>, and you've tested it compiles properly using <a href='https://whedon.theoj.org'>this preview service</a>.</li>
+          <li>You have included the <a href="https://joss.readthedocs.io/en/latest/submitting.html#what-should-my-paper-contain">required sections</a> in your paper.</li>
+        </ul>
+        </p>
+      </div>
 
-      <center><strong>⚠️ ⚠️ ⚠️ Before you submit ⚠️ ⚠️ ⚠️ </strong></center>
-      <p>As the submitting author, before you submit, please make sure that you have reviewed the following items. We promise this will make things go much more quickly during the review process:
-      <ul>
-        <li>You have reviewed the <a href="https://joss.readthedocs.io/en/latest/submitting.html">submission instructions</a> and verified that your submission meets our <a href="https://joss.readthedocs.io/en/latest/submitting.html#submission-requirements">submission requirements</a>.</li>
-        <li>There is a Markdown file named <code>paper.md</code> present in your repository that is structured <a href="https://joss.readthedocs.io/en/latest/submitting.html#example-paper-and-bibliography">like this</a>, and you've tested it compiles properly using <a href='https://whedon.theoj.org'>this preview service</a>.</li>
-        <li>You have included the <a href="https://joss.readthedocs.io/en/latest/submitting.html#what-should-my-paper-contain">required sections</a> in your paper.</li>
-      </ul>
-      </p>
-      </div> -->
-
-      <%# render partial: "form", locals: { paper: @paper } %>
+      <%= render partial: "form", locals: { paper: @paper } %>
 
     </div>
   </div>

--- a/app/views/papers/new.html.erb
+++ b/app/views/papers/new.html.erb
@@ -1,11 +1,10 @@
 <div class="container">
   <div class="row justify-content-lg-center">
     <div class="col-lg-10">
-      <h1>Submit <%= setting(:product) %> for review</h1>
-
       <div class="alert alert-danger" role="alert">
-        <h4 class="alert-heading">JOSS is currently operating in a reduced service mode. You can read more about what this means in our <%= link_to "blog post", "https://blog.joss.theoj.org/2020/05/reopening-joss" %>.</h4>
+        <h5 class="alert-heading">JOSS is operating in a reduced service mode. More details about this means are in our <%= link_to "blog post", "https://blog.joss.theoj.org/2020/05/reopening-joss" %>.</h5>
       </div>
+      <h1>Submit <%= setting(:product) %> for review</h1>
 
       <div class="alert alert-info" role="alert">
         <center><strong>⚠️ ⚠️ ⚠️ Before you submit ⚠️ ⚠️ ⚠️ </strong></center>

--- a/app/views/shared/meta_view_body.text.erb
+++ b/app/views/shared/meta_view_body.text.erb
@@ -5,6 +5,10 @@
 **Reviewer:** Pending
 **Managing EiC:** <%= eic_name %>
 
+**:warning: JOSS reduced service mode :warning:**
+
+Due to the challenges of the COVID-19 pandemic, JOSS is currently operating in a "reduced service mode". You can read more about what that means in [our blog post](https://blog.joss.theoj.org/2020/05/reopening-joss).
+
 **Author instructions**
 
 <%- abbreviation, reviewers = Rails.application.settings.values_at("abbreviation", "reviewers") %>

--- a/app/views/shared/review_body.text.erb
+++ b/app/views/shared/review_body.text.erb
@@ -5,6 +5,10 @@
 **Reviewer:** <%= reviewers.join(', ') %>
 **Archive:** Pending
 
+**:warning: JOSS reduced service mode :warning:**
+
+Due to the challenges of the COVID-19 pandemic, JOSS is currently operating in a "reduced service mode". You can read more about what that means in [our blog post](https://blog.joss.theoj.org/2020/05/reopening-joss).
+
 ## Status
 
 <%- url = Rails.application.settings["url"] %>
@@ -28,7 +32,7 @@ Please avoid lengthy details of difficulties in the review thread. Instead, plea
 
 The reviewer guidelines are available here: https://joss.readthedocs.io/en/latest/reviewer_guidelines.html. Any questions/concerns please let <%= editor %> know.
 
-✨ **Please try and complete your review in the next two weeks** ✨ 
+✨ **Please try and complete your review in the next six weeks** ✨ 
 
 <%- reviewers.each do |reviewer| %>
 ## Review checklist for <%= reviewer %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
 
   resources :editors
-  resources :papers, except: [:create] do
+  resources :papers do
     member do
       post 'start_review'
       post 'start_meta_review'

--- a/spec/controllers/papers_controller_spec.rb
+++ b/spec/controllers/papers_controller_spec.rb
@@ -97,7 +97,7 @@ describe PapersController, type: :controller do
     end
   end
 
-  describe "POST #create", skip: "New submissions are temporarily disabled - CoV19" do
+  describe "POST #create" do
 
     it "LOGGED IN responds with success" do
       user = create(:user)

--- a/spec/views/papers/new.html.erb_spec.rb
+++ b/spec/views/papers/new.html.erb_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "papers/new", type: :view do
     Rails.application.settings["paper_types"] = setting
   end
 
-  context "with multiple paper types", skip: "New submissions are temporarily disabled - CoV19" do
+  context "with multiple paper types" do
     let(:paper_types) { %w(type1 type2 type3) }
 
     it "renders the new paper form" do
@@ -34,7 +34,7 @@ RSpec.describe "papers/new", type: :view do
     end
   end
 
-  context "with no paper types", skip: "New submissions are temporarily disabled - CoV19" do
+  context "with no paper types" do
     let(:paper_types) { [] }
 
     it "renders the new paper form" do


### PR DESCRIPTION
This PR includes a number of updates to the JOSS site to:

- Re-enable submissions.
- Warn authors on the submission screen (see below) about the reduced service mode.
- Add language about the reduced service mode to author submission notifications.

<img width="941" alt="Screen Shot 2020-05-15 at 4 08 45 PM" src="https://user-images.githubusercontent.com/4483/82118892-13920e80-9748-11ea-88fd-6ba5e6edd61c.png">
/ cc https://github.com/openjournals/joss/issues/733