### PR TITLE
Editor availability

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -135,6 +135,14 @@ table.dashboard-table{
     }
     tr {
       border-bottom: 1px solid #efefef;
+
+      &.availability-none {
+        background: #e2e3e5;
+      }
+
+      &.availability-somewhat {
+        background: #fff3cd;
+      }
     }
   }
 }

--- a/app/controllers/editors_controller.rb
+++ b/app/controllers/editors_controller.rb
@@ -59,6 +59,6 @@ class EditorsController < ApplicationController
     end
 
     def editor_params
-      params.require(:editor).permit(:kind, :title, :first_name, :last_name, :login, :email, :avatar_url, :category_list, :url, :description)
+      params.require(:editor).permit(:availability, :kind, :title, :first_name, :last_name, :login, :email, :avatar_url, :category_list, :url, :description)
     end
 end

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -174,4 +174,9 @@ module HomeHelper
   def linked_reviewers(paper)
     paper.reviewers.map { |reviewer| github_user(reviewer.gsub('@', '')) }.join(', ').html_safe
   end
+
+  def availability_class(editor)
+    return "" unless editor.availability? 
+    "availability-" + editor.availability.downcase.gsub(' ', '-')
+  end
 end

--- a/app/models/editor.rb
+++ b/app/models/editor.rb
@@ -15,6 +15,12 @@ class Editor < ActiveRecord::Base
     "topic"
   ].freeze
 
+  AVAILABILITY_STATES = [
+    "available",
+    "somewhat",
+    "none"
+  ]
+
   scope :board, -> { where(kind: "board") }
   scope :topic, -> { where(kind: "topic") }
   scope :emeritus, -> { where(kind: "emeritus") }

--- a/app/views/editors/_form.html.erb
+++ b/app/views/editors/_form.html.erb
@@ -48,7 +48,7 @@
   <div class="row">
     <div class="col">
       <%= f.label :login %>
-      <%# f.select :login, Repository.editors, { include_blank: true, selected: "@#{@editor.login}" }, class: "form-control" %>
+      <%= f.select :login, Repository.editors, { include_blank: true, selected: "@#{@editor.login}" }, class: "form-control" %>
     </div>
 
     <div class="col">

--- a/app/views/editors/_form.html.erb
+++ b/app/views/editors/_form.html.erb
@@ -20,6 +20,10 @@
       <%= f.select :kind, %w(topic board emeritus), {}, class: "form-control" %>
     </div>
     <div class="col">
+      <%= f.label :type, "Availability" %>
+      <%= f.select :availability, Editor::AVAILABILITY_STATES, {}, class: "form-control" %>
+    </div>
+    <div class="col">
       <%= f.label :title %>
       <%= f.text_field :title, disabled: @editor.kind != "board", class: "form-control" %>
     </div>
@@ -44,7 +48,7 @@
   <div class="row">
     <div class="col">
       <%= f.label :login %>
-      <%= f.select :login, Repository.editors, { include_blank: true, selected: "@#{@editor.login}" }, class: "form-control" %>
+      <%# f.select :login, Repository.editors, { include_blank: true, selected: "@#{@editor.login}" }, class: "form-control" %>
     </div>
 
     <div class="col">

--- a/app/views/home/dashboard.html.erb
+++ b/app/views/home/dashboard.html.erb
@@ -25,7 +25,7 @@
     </thead>
     <tbody>
       <% Editor.active.order('LOWER(login)').each do |editor| %>
-      <tr>
+      <tr class='<%= availability_class(editor) %>'>
         <td sorttable_customkey=<%= editor.login.downcase %>><%= image_tag(avatar(editor.login), size: "24x24", class: "avatar", title: editor.login) %> <%= link_to editor.login, "/dashboard/#{editor.login}" %><% if editor.retired? %> <em>(emeritus)</em><% end %></td>
         <td sorttable_customkey=<%= count_without_ignored(Paper.in_progress.where(editor: editor)) %>><%= in_progress_for_editor(Paper.in_progress.where(editor: editor)) %></td>
         <td class="text-center"><%= editor.three_month_average %></td>

--- a/app/views/home/dashboard.html.erb
+++ b/app/views/home/dashboard.html.erb
@@ -26,7 +26,7 @@
     <tbody>
       <% Editor.active.order('LOWER(login)').each do |editor| %>
       <tr class='<%= availability_class(editor) %>'>
-        <td sorttable_customkey=<%= editor.login.downcase %>><%= image_tag(avatar(editor.login), size: "24x24", class: "avatar", title: editor.login) %> <%= link_to editor.login, "/dashboard/#{editor.login}" %><% if editor.retired? %> <em>(emeritus)</em><% end %></td>
+        <td sorttable_customkey=<%= editor.login.downcase %>><%= image_tag(avatar(editor.login), size: "24x24", class: "avatar", title: editor.login) %> <%= link_to editor.login, "/dashboard/#{editor.login}", title: editor.availability %><% if editor.retired? %> <em>(emeritus)</em><% end %></td>
         <td sorttable_customkey=<%= count_without_ignored(Paper.in_progress.where(editor: editor)) %>><%= in_progress_for_editor(Paper.in_progress.where(editor: editor)) %></td>
         <td class="text-center"><%= editor.three_month_average %></td>
         <td class="text-center"><%= editor.papers.visible.since(1.week.ago).count %></td>

--- a/db/migrate/20200521184901_add_availability_to_editor.rb
+++ b/db/migrate/20200521184901_add_availability_to_editor.rb
@@ -1,0 +1,6 @@
+class AddAvailabilityToEditor < ActiveRecord::Migration[6.0]
+  def change
+    add_column :editors, :availability, :string
+    add_index :editors, :availability
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_06_231512) do
+ActiveRecord::Schema.define(version: 2020_05_21_184901) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -30,6 +30,8 @@ ActiveRecord::Schema.define(version: 2020_03_06_231512) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id"
+    t.string "availability"
+    t.index ["availability"], name: "index_editors_on_availability"
     t.index ["user_id"], name: "index_editors_on_user_id"
   end
 


### PR DESCRIPTION
This PR adds a small UI change to make it possible to show on the dashboard whether an editor is currently available to editor or not.

<img width="1126" alt="Screen_Shot_2020-05-21_at_3_52_56_PM" src="https://user-images.githubusercontent.com/4483/82600173-7d148180-9b7b-11ea-9124-5152520a0237.png">

The status of the editor can be updated in the editors views of the admin UI also.

/ cc @openjournals/joss-eics  