### PR TITLE
Squish not squeeze strings

### DIFF
--- a/app/helpers/papers_helper.rb
+++ b/app/helpers/papers_helper.rb
@@ -59,7 +59,7 @@ module PapersHelper
   end
 
   def author_link(author)
-    name = "#{author['given_name']} #{author['middle_name']} #{author['last_name']}".squeeze
+    name = "#{author['given_name']} #{author['middle_name']} #{author['last_name']}".squish
     author_search_link = link_to name, papers_by_author_path(author: name)
 
     if author['orcid']

--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -168,12 +168,12 @@ class Paper < ActiveRecord::Base
 
   def scholar_authors
     return nil unless published?
-    metadata['paper']['authors'].collect {|a| "#{a['given_name']} #{a['middle_name']} #{a['last_name']}".squeeze}.join(', ')
+    metadata['paper']['authors'].collect {|a| "#{a['given_name']} #{a['middle_name']} #{a['last_name']}".squish}.join(', ')
   end
 
   def bibtex_authors
     return nil unless published?
-    metadata['paper']['authors'].collect {|a| "#{a['given_name']} #{a['middle_name']} #{a['last_name']}".squeeze}.join(' and ')
+    metadata['paper']['authors'].collect {|a| "#{a['given_name']} #{a['middle_name']} #{a['last_name']}".squish}.join(' and ')
   end
 
   def bibtex_key


### PR DESCRIPTION
In https://github.com/openjournals/joss/pull/744 we introduced a minor regression that meant author names with repeated characters were affected, e.g. `Danny` became `Dany`. #744 was designed to compress whitespace only using the `.squeeze` method.

Rails has a related function `.squish` which compresses whitespace only which is what we actually want here.

Fixes #746 