### PR TITLE
Making periods work in name lookups

### DIFF
--- a/app/helpers/papers_helper.rb
+++ b/app/helpers/papers_helper.rb
@@ -60,7 +60,7 @@ module PapersHelper
 
   def author_link(author)
     name = "#{author['given_name']} #{author['middle_name']} #{author['last_name']}".squish
-    author_search_link = link_to name, papers_by_author_path(author: name)
+    author_search_link = link_to(name, "/papers/by/#{name}".gsub('.', '%2E'))
 
     if author['orcid']
       orcid_link = link_to author['orcid'], "http://orcid.org/#{author['orcid']}", target: "_blank"


### PR DESCRIPTION
There is likely a better way to handle this but right now, any author name with a period in it fails to load properly.

There's no doubt some kind of fancy Rails route regex that would allow us to support periods and the `.atom`, `.json`, `.html` responses but I'm struggling to figure it out...