### PR TITLE
Show vote summary only when relevant

### DIFF
--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -51,9 +51,13 @@ module HomeHelper
   end
 
   def vote_summary(paper)
-    capture do
-      concat(content_tag(:small, "👍(#{paper.votes.in_scope.count}) / 👎 (#{paper.votes.out_of_scope.count})"))
-    end 
+    if paper.labels.keys.include?("query-scope")
+      capture do
+        concat(content_tag(:small, "👍(#{paper.votes.in_scope.count}) / 👎 (#{paper.votes.out_of_scope.count})"))
+      end
+    else
+      'OK'
+    end
   end
 
   def review_issue_links(paper)
@@ -185,7 +189,7 @@ module HomeHelper
   end
 
   def availability_class(editor)
-    return "" unless editor.availability? 
+    return "" unless editor.availability?
     "availability-" + editor.availability.downcase.gsub(' ', '-')
   end
 end


### PR DESCRIPTION
This PR adds a change to the `scope-no-scope` branch to show the vote summary in the editors dashboard only for papers labeled with `query-scope`.

