### PR TITLE
Adding documentation about substantial scholarly effort 

### DIFF
--- a/app/helpers/dispatch_helper.rb
+++ b/app/helpers/dispatch_helper.rb
@@ -78,6 +78,10 @@ module DispatchHelper
       action == 'unlocked'
     end
 
+    def pinned?
+      action == 'pinned' || action == "unpinned"
+    end
+
     def assigned?
       action == 'assigned' || action == 'unassigned'
     end
@@ -108,6 +112,7 @@ module DispatchHelper
       return if opened?
       return if closed?
       return if locked?
+      return if pinned?
       return if unlocked?
 
       if edited?

--- a/app/views/content/github/_review_checklist.erb
+++ b/app/views/content/github/_review_checklist.erb
@@ -11,6 +11,7 @@
 - [ ] **Repository:** Is the source code for this software available at the <%= link_to "repository url", paper.repository_url, target: "_blank" %>?
 - [ ] **License:** Does the repository contain a plain-text LICENSE file with the contents of an [OSI approved](https://opensource.org/licenses/alphabetical) software license?
 - [ ] **Contribution and authorship:** Has the submitting author (<%= paper.submitting_author.github_username %>) made major contributions to the software? Does the full list of paper authors seem appropriate and complete?
+- [ ] **Substantial scholarly effort:** Does this submission meet the scope eligibility described in the [JOSS guidelines](https://joss.readthedocs.io/en/latest/submitting.html#substantial-scholarly-effort)
 
 ### Functionality
 

--- a/docs/editing.md
+++ b/docs/editing.md
@@ -20,7 +20,7 @@ Once a submission comes in, it will be in the queue for a quick check by the Edi
 The EiC assigns an editor (or a volunteering editor self-assigns) with the command `@whedon assign @username as editor` in a comment.
 
 ```eval_rst
-.. note:: If a paper is submitted without a recommended editor, it will show up in the weekly digest email under the category ‘Papers currently without an editor.’ Please review this weekly email and volunteer to edit papers that look to be in your domain. If you choose to be an editor in the issue thread type the command ``@whedon assign @yourhandle as editor``
+.. note:: If a paper is submitted without a recommended editor, it will show up in the weekly digest email under the category ‘Papers currently without an editor.’ Please review this weekly email and volunteer to edit papers that look to be in your domain. If you choose to be an editor in the issue thread type the command ``@whedon assign @yourhandle as editor`` or simply ``@whedon assign me as editor``
 ```
 
 ### How papers are assigned to editors

--- a/docs/editing.md
+++ b/docs/editing.md
@@ -17,6 +17,8 @@ Once a submission comes in, it will be in the queue for a quick check by the Edi
 .. important:: If the paper is out-of-scope for JOSS, editors assess this and notify the author in the ``PRE-REVIEW`` issue.
 ```
 
+Editors can flag submissions of questionable scope using the command `@whedon query scope`.
+
 The EiC assigns an editor (or a volunteering editor self-assigns) with the command `@whedon assign @username as editor` in a comment.
 
 ```eval_rst

--- a/docs/review_criteria.md
+++ b/docs/review_criteria.md
@@ -29,6 +29,22 @@ There should be an [OSI approved](https://opensource.org/licenses/alphabetical) 
 > **Acceptable:** A plain-text LICENSE file with the contents of an OSI approved license<br />            
 > **Not acceptable:** A phrase such as 'MIT license' in a README file
 
+### Substantial scholarly effort
+
+Reviewers should verify that the software represents substantial scholarly effort. As a rule of thumb, JOSS' minimum allowable contribution should represent **not less than** three months of work for an individual. Signals of effort include: 
+
+- Age of software (is this a well-established software project) / length of commit history.
+- Number of commits.
+- Number of authors.
+- Lines of code (LOC): These statistics are usually reported by Whedon in the `pre-review` issue thread.
+- Whether the software has already been cited in academic papers.
+- Whether the software is sufficiently useful that it is _likely to be cited_ by other researchers working in this domain.
+
+
+```eval_rst
+.. note:: The decision on scholarly effort is ultimately one made by JOSS editors. Reviewers are asked to flag submissions of questionable scope during the review process so that the editor can bring this to the attention of the JOSS editorial team.
+```
+
 ### Documentation
 
 There should be sufficient documentation for you, the reviewer to understand the core functionality of the software under review. A high-level overview of this documentation should be included in a `README` file (or equivalent). There should be:

--- a/docs/submitting.md
+++ b/docs/submitting.md
@@ -77,11 +77,15 @@ authors:
     affiliation: "1, 2" # (Multiple affiliations must be quoted)
   - name: Author Without ORCID
     affiliation: 2
+  - name: Author with no affiliation
+    affiliation: 3
 affiliations:
  - name: Lyman Spitzer, Jr. Fellow, Princeton University
    index: 1
- - name: Institution 2
+ - name: Institution Name
    index: 2
+ - name: Independent Researcher
+   index: 3
 date: 13 August 2017
 bibliography: paper.bib
 

--- a/docs/submitting.md
+++ b/docs/submitting.md
@@ -33,7 +33,7 @@ As a rule of thumb, JOSS' minimum allowable contribution should represent **not 
 - Age of software (is this a well-established software project) / length of commit history.
 - Number of commits.
 - Number of authors.
-- Total lines of code (LOC).
+- Total lines of code (LOC). Submissions under 1000 LOC will usually be flagged, those under 300 LOC will be desk rejected.
 - Whether the software has already been cited in academic papers.
 - Whether the software is sufficiently useful that it is _likely to be cited_ by your peer group.
 

--- a/docs/submitting.md
+++ b/docs/submitting.md
@@ -8,6 +8,7 @@ But please read these instructions carefully for a streamlined submission.
 
 - The software should be open source as per the [OSI definition](https://opensource.org/osd).
 - The software should have an **obvious** research application.
+- Your paper must not discuss new research results.
 - You should be a major contributor to the software you are submitting.
 - Your paper (`paper.md` and BibTeX files, plus any figures) must be hosted in a Git-based repository. Placing these items together with your software (rather than in a separate repository) is **strongly encouraged**.
 

--- a/docs/submitting.md
+++ b/docs/submitting.md
@@ -9,8 +9,6 @@ But please read these instructions carefully for a streamlined submission.
 - The software should be open source as per the [OSI definition](https://opensource.org/osd).
 - The software should have an **obvious** research application.
 - You should be a major contributor to the software you are submitting.
-- The software should be a significant contribution to the available open source software that either enables some new research challenges to be addressed or makes addressing research challenges significantly better (e.g., faster, easier, simpler).
-- The software should be feature-complete (no half-baked solutions) and designed for maintainable extension (not one-off modifications). **Minor ‘utility’ packages, including ‘thin’ API clients, and single-function packages are not acceptable**.
 - Your paper (`paper.md` and BibTeX files, plus any figures) must be hosted in a Git-based repository. Placing these items together with your software (rather than in a separate repository) is **strongly encouraged**.
 
 In addition, the software associated with your submission must:
@@ -20,7 +18,33 @@ In addition, the software associated with your submission must:
 - Have an issue tracker that is readable without registration.
 - Permit individuals to create issues/file tickets against your repository.
 
+### What we mean by research software
+
 JOSS publishes articles about research software. This definition includes software that: solves complex modeling problems in a scientific context (physics, mathematics, biology, medicine, social science, neuroscience, engineering); supports the functioning of research instruments or the execution of research experiments; extracts knowledge from large data sets; offers a mathematical library, or similar.
+
+
+### Substantial scholarly effort 
+
+JOSS publishes articles about software that represent substantial scholarly effort on the part of the authors. Your software should be a significant contribution to the available open source software that either enables some new research challenges to be addressed or makes addressing research challenges significantly better (e.g., faster, easier, simpler).
+
+As a rule of thumb, JOSS' minimum allowable contribution should represent **not less than** three months of work for an individual. Some factors that may be considered by editors and reviewers when judging effort include:
+
+- Age of software (is this a well-established software project) / length of commit history.
+- Number of commits.
+- Number of authors.
+- Total lines of code (LOC).
+- Whether the software has already been cited in academic papers.
+- Whether the software is sufficiently useful that it is _likely to be cited_ by your peer group.
+
+In addition, JOSS requires that software should be feature-complete (i.e. no half-baked solutions) and designed for maintainable extension (not one-off modifications of existing tools). "Minor utility" packages, including "thin" API clients, and single-function packages are not acceptable.
+
+#### Other venues for reviewing and publishing software packages
+
+Authors wishing to publish software deemed out of scope for JOSS have a few options available to them:
+
+- Follow [GitHub's guide](https://guides.github.com/activities/citable-code/) on how to create a permanent archive and DOI for your software. This DOI can then be used by others to cite your work.
+- Enquire whether your software might be considered by communities such as [rOpenSci](https://ropensci.org) and [pyOpenSci](https://pyopensci.org).
+
 
 ### Should I write my own software or contribute to an existing package?
 

--- a/docs/submitting.md
+++ b/docs/submitting.md
@@ -8,8 +8,8 @@ But please read these instructions carefully for a streamlined submission.
 
 - The software should be open source as per the [OSI definition](https://opensource.org/osd).
 - The software should have an **obvious** research application.
-- Your paper must not discuss new research results.
 - You should be a major contributor to the software you are submitting.
+- You paper should not focus on new research results accomplished with the software.
 - Your paper (`paper.md` and BibTeX files, plus any figures) must be hosted in a Git-based repository. Placing these items together with your software (rather than in a separate repository) is **strongly encouraged**.
 
 In addition, the software associated with your submission must:


### PR DESCRIPTION
This is an update to our guidelines to capture the revised/clarified scope for JOSS regarding software needing to represent substantial scholarly effort.