### PR TITLE
Softening scholarly effort language

### DIFF
--- a/docs/review_criteria.md
+++ b/docs/review_criteria.md
@@ -31,7 +31,7 @@ There should be an [OSI approved](https://opensource.org/licenses/alphabetical) 
 
 ### Substantial scholarly effort
 
-Reviewers should verify that the software represents substantial scholarly effort. As a rule of thumb, JOSS' minimum allowable contribution should represent **not less than** three months of work for an individual. Signals of effort include: 
+Reviewers should verify that the software represents substantial scholarly effort. As a rule of thumb, JOSS' minimum allowable contribution should represent **not less than** three months of work for an individual. Signals of effort may include: 
 
 - Age of software (is this a well-established software project) / length of commit history.
 - Number of commits.


### PR DESCRIPTION
We've had some feedback that the list of criteria for _Substantial scholarly effort_ are being interpreted too strictly, i.e. everything in this list *must* be met (which I don't believe is the case).

My understanding of this list is that these are _examples_ of signals that a reviewer can use to understand the level of scholarly effort related to a JOSS submission.

This PR simply adds 'may' to the sentence preceding the list of (possible) criteria.

/ cc @openjournals/joss-editors 