### PR TITLE
Clobber old votes

### DIFF
--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -4,13 +4,13 @@ class VotesController < ApplicationController
 
   def create
     if params[:commit].include?("in scope")
-      puts "IN SCOPE"
+      logger.info "IN SCOPE"
       kind = "in-scope"
     elsif params[:commit].include?("out of scope")
-      puts "OUT OF SCOPE"
+      logger.info "OUT OF SCOPE"
       kind = "out-of-scope"
     elsif params[:commit].include?("Just comment")
-      puts "JUST COMMENTING"
+      logger.info "JUST COMMENTING"
       kind = "comment"
     end
 
@@ -19,6 +19,10 @@ class VotesController < ApplicationController
     @vote = @paper.votes.build(params)
 
     begin
+      if previous_vote = Vote.find_by_paper_id_and_editor_id(@paper, current_user.editor)
+        previous_vote.destroy!
+      end
+
       @vote.save!
       flash[:notice] = "Vote recorded"
       redirect_to paper_path(@paper)

--- a/app/mailers/notifications.rb
+++ b/app/mailers/notifications.rb
@@ -28,7 +28,7 @@ class Notifications < ApplicationMailer
 
   def editor_scope_email(editor, issues)
     @query_scope_issues = issues
-    @editor = editor.login
+    @editor = editor
     mail(to: editor.email, subject: "[Please review]: #{Rails.application.settings["abbreviation"]} scope check summary")
   end
 end

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -25,5 +25,9 @@ class Vote < ActiveRecord::Base
     kind == "comment"
   end
 
+  def self.has_vote_for?(paper, editor)
+    find_by_paper_id_and_editor_id(paper, editor)
+  end
+
   validates :kind, inclusion: { in: VOTE_KINDS }, allow_nil: false
 end

--- a/app/views/notifications/editor_scope_email.html.erb
+++ b/app/views/notifications/editor_scope_email.html.erb
@@ -4,10 +4,11 @@
 
 <% if @query_scope_issues.any? %>
   <% @query_scope_issues.each do |issue| %>
-
-  <h4><%= issue.title %> (<%= issue.paper.created_at.strftime('%F') %>)</h4>
-  <p><%= issue.paper.body %></p>
-  <p><%= link_to "VOTE ON SCOPE HERE", "#{Rails.application.settings["url"]}/papers/#{issue.paper.sha}" %> &middot; <%= link_to "View review issue", "https://github.com/#{Rails.application.settings['reviews']}/issues/#{issue.number}" %> &middot; <%= link_to "View software repository", issue.paper.repository_url %></p>
-  <hr />
+    <% unless Vote.has_vote_for?(issue.paper, @editor) %>
+<h4><%= issue.title %> (<%= issue.paper.created_at.strftime('%F') %>)</h4>
+<p><%= issue.paper.body %></p>
+<p><%= link_to "VOTE ON SCOPE HERE", "#{Rails.application.settings["url"]}/papers/#{issue.paper.sha}" %> &middot; <%= link_to "View review issue", "https://github.com/#{Rails.application.settings['reviews']}/issues/#{issue.number}" %> &middot; <%= link_to "View software repository", issue.paper.repository_url %></p>
+<hr />
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/notifications/editor_scope_email.text.erb
+++ b/app/views/notifications/editor_scope_email.text.erb
@@ -4,6 +4,8 @@ Please review the recently-flagged submissions below and vote on the <%= Rails.a
 
 <% if @query_scope_issues.any? %>
   <% @query_scope_issues.each do |issue| %>
+    <% unless Vote.has_vote_for?(issue.paper, @editor) %>
+
 <%= issue.title %> (<%= issue.paper.created_at.strftime('%F') %>)
   
 <%= issue.paper.body %>
@@ -13,6 +15,6 @@ Review issue: https://github.com/<%= Rails.application.settings["reviews"] %>/is
 Software repository: <%= issue.paper.repository_url %>
 
 –––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––------------
-
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/papers/_vote_summary.html.erb
+++ b/app/views/papers/_vote_summary.html.erb
@@ -3,7 +3,7 @@
   Scope summary <% if @paper.votes.any? %><small>👍 <%= @paper.votes.in_scope.count %> &middot; 👎 <%= @paper.votes.out_of_scope.count %></small><% end %>
   </div>
   <div class="card-body">
-    <p class="card-text">Record your opinion on whether or not this submission is in scope, optionally leaving a comment explaining your decision for the EiCs.</p>
+    <p class="card-text">Record your opinion on whether or not this submission is in scope, optionally leaving a comment explaining your decision for the EiCs. If you make a mistake or want to change your vote, simply fill out the form again (this will remove your first vote).</p>
 
     <%= form_for [@paper, Vote.new] do |f| %>
       <div class="form-group">

--- a/spec/controllers/votes_controller_spec.rb
+++ b/spec/controllers/votes_controller_spec.rb
@@ -1,5 +1,39 @@
 require 'rails_helper'
 
 RSpec.describe VotesController, type: :controller do
+  it "LOGGED IN responds with success" do
+    editor = create(:editor, login: "josseditor")
+    editing_user = create(:user, editor: editor)
+    paper = create(:submitted_paper)
 
+    allow(controller).to receive_message_chain(:current_user).and_return(editing_user)
+    vote_count = paper.votes.count
+
+    vote_params = { vote: { comment: ""}, 
+                    commit: "Vote as in scope 👍", 
+                    paper_id: paper.sha }
+
+    post :create, params: vote_params
+    expect(response).to be_redirect # as it's created the thing
+    expect(paper.votes.count).to eq(vote_count + 1)
+  end
+
+  it "LOGGED IN responds with success should an additional vote (but destroy the first)" do
+    editor = create(:editor, login: "josseditor")
+    editing_user = create(:user, editor: editor)
+    paper = create(:submitted_paper)
+    original_vote = create(:in_scope_vote, paper: paper, editor: editor)
+
+    allow(controller).to receive_message_chain(:current_user).and_return(editing_user)
+    vote_count = paper.votes.count
+
+    vote_params = { vote: { comment: ""}, 
+                    commit: "Vote as out of scope 👎", 
+                    paper_id: paper.sha }
+
+    post :create, params: vote_params
+    expect(response).to be_redirect # as it's created the thing
+    expect(paper.votes.count).to eq(vote_count)
+    expect(Vote.find_by_id(original_vote.id)).to be_nil
+  end  
 end

--- a/spec/models/vote_spec.rb
+++ b/spec/models/vote_spec.rb
@@ -34,6 +34,17 @@ describe Vote do
     assert out_of_scope_vote.out_of_scope?
   end
 
+  it "should know how to look up a vote for an editor" do
+    editor = create(:editor)
+    editor2 = create(:editor)
+    paper = create(:paper)
+    create(:in_scope_vote, editor: editor, paper: paper)
+
+    expect(Vote.has_vote_for?(paper, editor)).to be_a_kind_of(Vote)
+    expect(Vote.has_vote_for?(paper, editor2)).to be_nil
+  end
+  
+
   it "should know about #in_scope and #out_of_scope" do
     submitted_paper = create(:paper, state: "submitted")
 


### PR DESCRIPTION
This is a small update to the editor scope voting that allows editors to change their mind by simply voting again (this will clobber/delete) the first vote.

Each editor can still only vote once per submission.

UPDATE: Also, now an editor will only be emailed about papers with queried scopes if they haven't already voted on the scope of that paper.