### PR TITLE
Make it a requirement that the paper has to be with the software

### DIFF
--- a/docs/submitting.md
+++ b/docs/submitting.md
@@ -10,7 +10,7 @@ But please read these instructions carefully for a streamlined submission.
 - The software should have an **obvious** research application.
 - You should be a major contributor to the software you are submitting.
 - Your paper should not focus on new research results accomplished with the software.
-- Your paper (`paper.md` and BibTeX files, plus any figures) must be hosted in a Git-based repository together with your software (although they may be in a different branch).
+- Your paper (`paper.md` and BibTeX files, plus any figures) must be hosted in a Git-based repository together with your software (although they may be in a short-lived branch which is never merged with the default).
 
 In addition, the software associated with your submission must:
 

--- a/docs/submitting.md
+++ b/docs/submitting.md
@@ -10,7 +10,7 @@ But please read these instructions carefully for a streamlined submission.
 - The software should have an **obvious** research application.
 - You should be a major contributor to the software you are submitting.
 - Your paper should not focus on new research results accomplished with the software.
-- Your paper (`paper.md` and BibTeX files, plus any figures) must be hosted in a Git-based repository. Placing these items together with your software (rather than in a separate repository) is **strongly encouraged**.
+- Your paper (`paper.md` and BibTeX files, plus any figures) must be hosted in a Git-based repository together with your software (although they may be in a different branch).
 
 In addition, the software associated with your submission must:
 


### PR DESCRIPTION
Handling papers where the software isn't in a git repository _together with the paper_ is a huge pain for our editorial teams and breaks most (all?) of our automation. 

This PR makes what is currently a _strongly encouraged_ thing, compulsory.

/ cc @openjournals/joss-eics @openjournals/joss-editors 