### PR TITLE
Validate Git repository on submission

### DIFF
--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -1,3 +1,5 @@
+require 'open3'
+
 class Paper < ActiveRecord::Base
   searchkick index_name: "joss-production"
 
@@ -123,6 +125,7 @@ class Paper < ActiveRecord::Base
   validates_presence_of :body, message: "^Description can't be blank"
   validates :kind, inclusion: { in: Rails.application.settings["paper_types"] }, allow_nil: true
   validates :submission_kind, inclusion: { in: SUBMISSION_KINDS }, allow_nil: false
+  validate :check_repository_address, on: :create
 
   def notify_editors
     Notifications.submission_email(self).deliver_now
@@ -462,6 +465,15 @@ class Paper < ActiveRecord::Base
 
 private
 
+  def check_repository_address
+    stdout_str, stderr_str, status = Open3.capture3("git ls-remote #{repository_url}")
+
+    if !status.success?
+      errors.add(:base, "Invalid Git repository address. Check that your repository can be cloned from the value entered and that access doesn't require authentication.")
+      return false
+    end
+  end
+  
   def set_sha
     self.sha ||= SecureRandom.hex
   end

--- a/app/views/papers/new.html.erb
+++ b/app/views/papers/new.html.erb
@@ -1,9 +1,6 @@
 <div class="container">
   <div class="row justify-content-lg-center">
     <div class="col-lg-10">
-      <div class="alert alert-danger" role="alert">
-        <h5 class="alert-heading">JOSS is in a reduced service mode. More details about this means are in our <%= link_to "blog post", "https://blog.joss.theoj.org/2020/05/reopening-joss" %>.</h5>
-      </div>
       <h1>Submit <%= setting(:product) %> for review</h1>
 
       <div class="alert alert-info" role="alert">

--- a/spec/controllers/papers_controller_spec.rb
+++ b/spec/controllers/papers_controller_spec.rb
@@ -104,7 +104,7 @@ describe PapersController, type: :controller do
       allow(controller).to receive_message_chain(:current_user).and_return(user)
       paper_count = Paper.count
 
-      paper_params = {title: "Yeah whateva", body: "something", repository_url: "https://github.com/foo/bar", archive_doi: "https://doi.org/10.6084/m9.figshare.828487", software_version: "v1.0.1", submission_kind: "new", suggested_editor: "@editor"}
+      paper_params = {title: "Yeah whateva", body: "something", repository_url: "https://github.com/openjournals/joss", archive_doi: "https://doi.org/10.6084/m9.figshare.828487", software_version: "v1.0.1", submission_kind: "new", suggested_editor: "@editor"}
       post :create, params: {paper: paper_params}
       expect(response).to be_redirect # as it's created the thing
       expect(Paper.count).to eq(paper_count + 1)

--- a/spec/models/paper_spec.rb
+++ b/spec/models/paper_spec.rb
@@ -5,6 +5,11 @@ describe Paper do
     Paper.destroy_all
   end
 
+  it "should know how to validate a Git repository address" do
+    paper = build(:paper, :repository_url => 'https://example.com')
+    expect { paper.save! }.to raise_error(ActiveRecord::RecordInvalid)
+  end
+
   it "belongs to the submitting author" do
     association = Paper.reflect_on_association(:submitting_author)
     expect(association.macro).to eq(:belongs_to)


### PR DESCRIPTION
Frequently, authors will submit papers with a Git address that can't be cloned. For example, the following are valid:

- https://github.com/arfon/fidgit
- https://github.com/arfon/fidgit.git
- git@github.com:arfon/fidgit.git

The following are not valid:

- https://github.com/arfon/fidgit/blob/master/paper/paper.md
- https://github.com/arfon/fidgit/tree/figure

The errors on submission usually arise because the author is trying to be specific about the branch or location of the `paper.md` file.

This pull request validates that the address can be `git cloned` (so Whedon will be able to handle it). The error message hopefully explains what's going wrong if an author submits something that won't work (suggestions welcome for improved language).

<img width="1103" alt="Screen Shot 2020-10-03 at 20 17 40" src="https://user-images.githubusercontent.com/4483/95000545-ac231100-05b9-11eb-8a1f-e4541c8e5262.png">

/ cc @openjournals/joss-eics 
