### PR TITLE
Track last comment from users

### DIFF
--- a/app/helpers/dispatch_helper.rb
+++ b/app/helpers/dispatch_helper.rb
@@ -66,6 +66,10 @@ module DispatchHelper
       action == 'closed'
     end
 
+    def commented?
+      action == 'created'
+    end
+
     def edited?
       action == 'edited'
     end
@@ -98,7 +102,8 @@ module DispatchHelper
             'review' => {}
           },
           'comments' => [],
-          'last_edits' => {}
+          'last_edits' => {},
+          'last_comments' => {}
         }
       }
 
@@ -135,6 +140,18 @@ module DispatchHelper
 
         paper.labels = new_labels
         paper.save and return
+      end
+
+      # New addition to keep track of the last comments by each 
+      # person on the thread.
+      if commented?
+        if issues.has_key?('last_comments')
+          issues['last_comments'][sender] = payload['issue']['updated_at']
+        else
+          issues['last_comments'] = {}
+          issues['last_comments'][sender] = payload['issue']['updated_at']
+        end
+        paper.last_activity = payload['issue']['updated_at']
       end
 
       if pre_review?

--- a/spec/controllers/dispatch_controller_spec.rb
+++ b/spec/controllers/dispatch_controller_spec.rb
@@ -48,7 +48,7 @@ describe DispatchController, type: :controller do
 
     it "should initialize the activities when an issue is opened" do
       expect(response).to be_ok
-      expect(@paper.activities).to eq({"issues"=>{"commenters"=>{"pre-review"=>{}, "review"=>{}}, "comments"=>[], "last_edits"=>{}}})
+      expect(@paper.activities).to eq({"issues"=>{"commenters"=>{"pre-review"=>{}, "review"=>{}}, "comments"=>[], "last_edits"=>{}, "last_comments" => {}}})
     end
 
     it "should UPDATE the activities when an issue is then commented on" do
@@ -63,9 +63,8 @@ describe DispatchController, type: :controller do
       expect(response).to be_ok
       expect(@paper.activities['issues']['commenters']).to eq({"pre-review"=>{"whedon"=>1, "editor"=>1}, "review"=>{}})
       expect(@paper.activities['issues']['comments'].length).to eq(2)
-
-      # expect(@paper.activities['issues']['review']['commenters']).to be_empty
-      # expect(@paper.activities['issues']['review']['comments'].length).to eq(0)
+      expect(@paper.activities['issues']['last_comments']['editor']).to eq("2018-09-30T11:48:30Z")
+      expect(@paper.activities['issues']['last_comments']['whedon']).to eq("2018-09-30T11:48:40Z")
     end
   end
 
@@ -109,7 +108,7 @@ describe DispatchController, type: :controller do
 
     it "should initialize the activities when a review issue is opened" do
       expect(response).to be_ok
-      expect(@paper.activities).to eq({"issues"=>{"commenters"=>{"pre-review"=>{}, "review"=>{}}, "comments"=>[], "last_edits"=>{}}})
+      expect(@paper.activities).to eq({"issues"=>{"commenters"=>{"pre-review"=>{}, "review"=>{}}, "comments"=>[], "last_edits"=>{}, "last_comments" => {}}})
     end
   end
 
@@ -124,7 +123,7 @@ describe DispatchController, type: :controller do
 
     it "should update the last_edits key" do
       expect(response).to be_ok
-      expect(@paper.activities).to eq({"issues"=>{"commenters"=>{"pre-review"=>{}, "review"=>{}}, "comments"=>[], "last_edits"=>{"comment-editor"=>"2018-10-06T16:18:56Z"}}})
+      expect(@paper.activities).to eq({"issues"=>{"commenters"=>{"pre-review"=>{}, "review"=>{}}, "comments"=>[], "last_comments" => {}, "last_edits"=>{"comment-editor"=>"2018-10-06T16:18:56Z"}}})
     end
 
     it "should update the last_activity field" do

--- a/spec/fixtures/whedon-pre-review-comment.json
+++ b/spec/fixtures/whedon-pre-review-comment.json
@@ -42,8 +42,8 @@
     ],
     "milestone": null,
     "comments": 0,
-    "created_at": "2018-09-30T11:48:26Z",
-    "updated_at": "2018-09-30T11:48:30Z",
+    "created_at": "2018-09-30T11:48:36Z",
+    "updated_at": "2018-09-30T11:48:40Z",
     "closed_at": null,
     "author_association": "COLLABORATOR",
     "body": "**Submitting author:** @arfon (<a href=\"http://orcid.org/0000-0002-1236-5109\">Robert Gieseke</a>)\r\n**Repository:** <a href=\"https://github.com/arfon/fidgit\" target =\"_blank\">https://github.com/arfon/fidgit</a>\r\n**Version:** v1.0.1\r\n**Editor:** @arfon\r\n**Reviewers:** @Robot\r\n\r\n**Author instructions**\r\n\r\nThanks for submitting your paper to JOSS @rgieseke. The JOSS editor (shown at the top of this issue) will work with you on this issue to find a reviewer for your submission before creating the main review issue.\r\n\r\n@rgieseke if you have any suggestions for potential reviewers then please mention them here in this thread. In addition, [this list of people](https://github.com/openjournals/joss/blob/master/docs/reviewers.csv) have already agreed to review for JOSS and may be suitable for this submission.\r\n\r\n**Editor instructions**\r\n\r\nThe JOSS submission bot @whedon is here to help you find and assign reviewers and start the main review. To find out what @whedon can do for you type:\r\n\r\n```\r\n@whedon commands\r\n```\r\n\r\n  "


### PR DESCRIPTION
Small PR to add additional key to paper activity metadata to start tracking the last commenting date by user.