### PR TITLE
Make subsections linkable

### DIFF
--- a/docs/submitting.md
+++ b/docs/submitting.md
@@ -274,19 +274,19 @@ Note that the paper ends with a References heading, and the references are built
 
 JOSS uses Pandoc to compile papers from their Markdown form into a PDF. There are a few different ways you can test that your paper is going to compile properly for JOSS:
 
-**JOSS paper preview service**
+### JOSS paper preview service
 
 Visit [https://whedon.theoj.org](https://whedon.theoj.org) and enter your repository address (and custom branch if you're using one). Note that your repository must be world-readable (i.e., it cannot require a login to access).
 
 <img width="1348" alt="Screen Shot 2020-11-23 at 12 08 58 PM" src="https://user-images.githubusercontent.com/4483/99960475-b4f7be00-2d84-11eb-83bd-7784e9e23913.png">
 
-**GitHub Action**
+### GitHub Action
 
-If you're using GitHub for your repository, you can use the [Open Journals GitHub Action](https://github.com/marketplace/actions/open-journals-pdf-generator) to automatically compile your paper each time you update your repository. 
+If you're using GitHub for your repository, you can use the [Open Journals GitHub Action](https://github.com/marketplace/actions/open-journals-pdf-generator) to automatically compile your paper each time you update your repository.
 
 The PDF is available via the Actions tab in your project and click on the latest workflow run. The zip archive file (including the `paper.pdf`) is listed in the run's Artifacts section.
 
-**Docker**
+### Docker
 
 If you have Docker installed on your local machine, you can use the same Docker Image to compile a draft of your paper locally. In the example below, the `paper.md` file is in the `paper` directory. Upon successful execution of the command, the `paper.pdf` file will be created in the same location as the `paper.md` file:
 


### PR DESCRIPTION
This PR makes the different options to generate a paper linkable so we can add links to the [preview service](https://whedon.theoj.org/).