### PR TITLE
Update of the JuliaCon proceedings website (juliacon branch)

### DIFF
--- a/app/views/content/about/_general.html.erb
+++ b/app/views/content/about/_general.html.erb
@@ -23,12 +23,9 @@
 <h3>You said <em>developer friendly</em>, what do you mean?</h3>
 
 <p>
-  We have a simple submission workflow and <%= link_to "extensive documentation", "https://joss.readthedocs.io/en/latest/submitting.html", target: "_blank" %> to help you prepare your
-  submission. If your software is already well documented then paper preparation should take no
+  We have a simple submission workflow and an accessible <%= link_to "author's guide", "https://juliacon.github.io/proceedings-guide/author/", target: "_blank" %> to help you prepare your
+  submission. As further guidance, there is the <%= link_to "extensive JOSS documentation", "https://joss.readthedocs.io/en/latest/submitting.html", target: "_blank" %>. If your software is already well documented then paper preparation should take no
   more than an hour.
 </p>
 
-<p>
-  You can read more about our motivations to build <%= Rails.application.settings['abbreviation'] %> in our
-  <a href="http://www.arfon.org/announcing-the-journal-of-open-source-software" target="_blank">announcement blog post</a>.
-</p>
+<h3>I want to support you as a reviewer. Where do I apply?</h3>

--- a/app/views/content/about/_general.html.erb
+++ b/app/views/content/about/_general.html.erb
@@ -4,7 +4,7 @@
 <p>
   The <%= Rails.application.settings['name'] %> (<%= Rails.application.settings['abbreviation'] %>) is an academic journal (ISSN <%= Rails.application.settings['issn'] %>) with a formal
   peer review process that is designed to <em>improve the quality of the software submitted</em>.
-  Upon acceptance into <%= Rails.application.settings['abbreviation'] %>, a Crossref DOI is minted and we list your paper on the <%= Rails.application.settings['abbreviation'] %> website.
+  Upon acceptance into <%= Rails.application.settings['abbreviation'] %>, a Crossref DOI is minted and we list your paper on the <a href="https://juliacon.org/"><%= Rails.application.settings['abbreviation'] %> website</a>.
 </p>
 
 <h3>Don't we have enough journals already?</h3>

--- a/app/views/content/layout/_navbar.html.erb
+++ b/app/views/content/layout/_navbar.html.erb
@@ -25,7 +25,7 @@
 
       <%= active_link_to "About", about_path, class: "nav-item nav-link" %>
       <%= active_link_to "Papers", published_papers_path, class: "nav-item nav-link" %>
-      <%= active_link_to "Docs", "https://juliacon.github.io/proceedings-guide/", target: '_blank', class: "nav-item nav-link" %>
+      <%= active_link_to "Guide", "https://juliacon.github.io/proceedings-guide/", target: '_blank', class: "nav-item nav-link" %>
       <%= link_to "Blog", "http://blog.joss.theoj.org/", class: "nav-item nav-link" %>
       <%= active_link_to "Submit", new_paper_path, class: "nav-item nav-link" %>
       <% if current_user %>

--- a/app/views/content/layout/_navbar.html.erb
+++ b/app/views/content/layout/_navbar.html.erb
@@ -34,7 +34,7 @@
       <% else %>
       <%= link_to "Log in with ORCID", "/auth/orcid", class: "nav-item nav-link btn orcid" %>
       <% end %>
-      <%= link_to image_tag("github.svg"), "https://github.com/openjournals/joss", target: '_blank', class: "nav-item nav-link" %>
+      <%= link_to image_tag("github.svg"), "https://github.com/openjournals/joss/tree/juliacon", target: '_blank', class: "nav-item nav-link" %>
     </div>
 
     <div class="rss-dropdown dropdown">

--- a/app/views/content/layout/_navbar.html.erb
+++ b/app/views/content/layout/_navbar.html.erb
@@ -25,7 +25,7 @@
 
       <%= active_link_to "About", about_path, class: "nav-item nav-link" %>
       <%= active_link_to "Papers", published_papers_path, class: "nav-item nav-link" %>
-      <%= active_link_to "Docs", "https://joss.readthedocs.io/en/latest/index.html", target: '_blank', class: "nav-item nav-link" %>
+      <%= active_link_to "Docs", "https://juliacon.github.io/proceedings-guide/", target: '_blank', class: "nav-item nav-link" %>
       <%= link_to "Blog", "http://blog.joss.theoj.org/", class: "nav-item nav-link" %>
       <%= active_link_to "Submit", new_paper_path, class: "nav-item nav-link" %>
       <% if current_user %>

--- a/app/views/content/layout/_navbar.html.erb
+++ b/app/views/content/layout/_navbar.html.erb
@@ -24,9 +24,9 @@
       <%- end %>
 
       <%= active_link_to "About", about_path, class: "nav-item nav-link" %>
+      <%= link_to "JCON", "https://juliacon.org/", class: "nav-item nav-link" %>
       <%= active_link_to "Papers", published_papers_path, class: "nav-item nav-link" %>
       <%= active_link_to "Guide", "https://juliacon.github.io/proceedings-guide/", target: '_blank', class: "nav-item nav-link" %>
-      <%= link_to "Blog", "http://blog.joss.theoj.org/", class: "nav-item nav-link" %>
       <%= active_link_to "Submit", new_paper_path, class: "nav-item nav-link" %>
       <% if current_user %>
       <%= link_to "My Profile", profile_path, class: "nav-item nav-link" %>

--- a/app/views/home/about.html.erb
+++ b/app/views/home/about.html.erb
@@ -68,7 +68,7 @@
         <p>
         <ul>
           <li>To suggest a feature or report a bug in <%= setting(:abbreviation) %>, please <a href="https://github.com/<%= setting(:github) %>/issues/new">open a GitHub Issue</a></li>
-          <li>To contact the <%= setting(:abbreviation) %> staff, please <a href="mailto:admin@theoj.org">email us</a></li>
+          <li>To contact the <%= setting(:abbreviation) %> staff, please <a href="mailto:juliacon@julialang.org">email us</a></li>
         </ul>
         </p>
       </div>

--- a/app/views/home/about.html.erb
+++ b/app/views/home/about.html.erb
@@ -25,25 +25,21 @@
 
       <div id="submitting" class="generic-content-item">
 
-        <h1>Scope & submission requirements</h1>
+        <h1>Submissions</h1>
 
-        <p>Not all software is eligible to be published in JOSS.</p>
+        <p>Not all papers are eligible to be published in the JuliaCon proceedings. Submissions must be related to JuliaCon contributions such as talks, posters, or similar. Generally, JCON is accepting two different kinds of submissions:
+          <ul>
+            <li>a short form extended abstract (similar to a <a href="https://joss.readthedocs.io/en/latest/submitting.html">standard JOSS paper</a>) of about one page excluding references,</li>
 
-        <p>JOSS publishes articles about research software. This definition includes software that: solves complex modeling problems in a scientific context (physics, mathematics, biology, medicine, social science, neuroscience, engineering); supports the functioning of research instruments or the execution of research experiments; extracts knowledge from large data sets; offers a mathematical library; or similar.</p>
+            <li>a more in-depth long form paper of about 5-10 pages.</li>
+          </ul>
+        </p>
 
-        <p>JOSS submissions must:</p>
-
-        <ul>
-          <li>Be open source (i.e., have an <%= link_to "OSI-approved license", "https://opensource.org/licenses/category", :target => "_blank" %>).</li>
-          <li>Have an obvious research application.</li>
-          <li>Be feature-complete (no half-baked solutions) and be designed for maintainable extension (not one-off modifications).</li>
-          <li>Minor 'utility' packages, including 'thin' API clients, and single-function packages are not acceptable.</li>
-        </ul>
-
-        <p>Authors wishing to make a pre-submission enquiry should <%= link_to "open an issue", "https://github.com/#{Rails.application.settings["github"]}/issues/new?title=Pre-submission%20enquiry"%> on the <%= setting(:abbreviation) %> repository.</p>
         <div class="alert alert-primary" role="alert">
-          <%= link_to "👀Full details about the #{setting(:abbreviation)} submission requirements and submission process&xrarr;".html_safe, "https://joss.readthedocs.io/en/latest/submitting.html" %>
+          <%= link_to "👀 More details about the #{setting(:abbreviation)} submission specifications and submission process&xrarr;".html_safe, "https://juliacon.github.io/proceedings-guide/author/" %>
         </div>
+
+        <p>Authors wishing to make a pre-submission enquiry should <%= link_to "open an issue", "https://github.com/JuliaCon/proceedings-review/issues/new?title=Pre-submission%20enquiry"%> on the <%= setting(:abbreviation) %> repository.</p>
       </div>
 
       <div class="generic-content-item" id="editorial_board">
@@ -240,7 +236,7 @@
     <div class="sub-nav">
       <nav class="menu" id="subnav">
         <a class="menu-item selected" href="#about">About</a>
-        <a class="menu-item" href="#submitting">Submission scope</a>
+        <a class="menu-item" href="#submitting">Submissions</a>
         <a class="menu-item" href="#editorial_board">Editorial Board</a>
         <a class="menu-item" href="#topic_editors">Topic Editors</a>
         <a class="menu-item" href="#editors_emeritus">Editors Emeritus</a>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -15,9 +15,9 @@
       <%= image_tag 'icon_papers.svg' %>
       Explore Papers
       <% end %>
-      <%= link_to "https://joss.readthedocs.io/en/latest/" do %>
+      <%= link_to "https://juliacon.github.io/proceedings-guide/" do %>
       <%= image_tag 'icon_docs.svg' %>
-      Documentation
+      Read the Guide
       <% end %>
       <%= link_to about_path do %>
       <%= image_tag 'icon_info.svg' %>

--- a/app/views/papers/new.html.erb
+++ b/app/views/papers/new.html.erb
@@ -7,9 +7,9 @@
         <center><strong>⚠️ ⚠️ ⚠️ Before you submit ⚠️ ⚠️ ⚠️ </strong></center>
         <p>As the submitting author, before you submit, please make sure that you have reviewed the following items. We promise this will make things go much more quickly during the review process:
         <ul>
-          <li>You have reviewed the <a href="https://joss.readthedocs.io/en/latest/submitting.html">submission instructions</a> and verified that your submission meets our <a href="https://joss.readthedocs.io/en/latest/submitting.html#submission-requirements">submission requirements</a>.</li>
-          <li>There is a Markdown file named <code>paper.md</code> present in your repository that is structured <a href="https://joss.readthedocs.io/en/latest/submitting.html#example-paper-and-bibliography">like this</a>, and you've tested it compiles properly using <a href='https://whedon.theoj.org'>this preview service</a>.</li>
-          <li>You have included the <a href="https://joss.readthedocs.io/en/latest/submitting.html#what-should-my-paper-contain">required sections</a> in your paper.</li>
+          <li>You have reviewed the <a href="https://juliacon.github.io/proceedings-guide/author/">author's guide</a> and, as a complementary resource, the <a href="https://joss.readthedocs.io/en/latest/submitting.html">JOSS submission docs</a>.</li>
+          <li>Your <code>paper/</code> subfolder (or alternatively your separate paper repository) has the <a href="https://juliacon.github.io/proceedings-guide/author/#submission_details">required structure</a>. </li>
+          <li>Your paper is written in LaTeX, i.e. there is a <code>paper.tex</code> file. (Note that Markdown is <b>not supported</b> and there musn't be a <code>paper.md</code> in your repository!)</li>
         </ul>
         </p>
       </div>

--- a/config/settings-development.yml
+++ b/config/settings-development.yml
@@ -1,22 +1,22 @@
 # Changing this file necessitates a server restart
-name: "Journal of Open Source Software"
-abbreviation: "JOSS"
-issn: "2475-9066"
-tagline: "a <span class='font-weight-bold'>developer friendly</span> journal for research software packages."
-logo_url: "https://joss.theoj.org/logo_large.png"
-url: "http://0.0.0.0:3000"
-editor_email: "joss.theoj@gmail.com"
-noreply_email: "noreply@joss.theoj.org"
-twitter: "@JOSS_TheOJ"
-google_analytics: "UA-47852178-4"
+name: "Proceedings of the JuliaCon Conferences"
+abbreviation: "JCON"
+issn: "2642-4029"
+tagline: "an open-access journal published in cooperation with the <a href='http://www.theoj.org/'>the Open Journals</a>."
+logo_url: "http://proceedings.juliacon.org/logo_large.jpg"
+url: "https://proceedings.juliacon.org"
+editor_email: "admin@theoj.org"
+noreply_email: "noreply@proceedings.juliacon.org"
+twitter: "@juliaconorg"
+google_analytics: "UA-47852178-9"
 github: "openjournals/joss"
-reviews: "openjournals/joss-reviews"
-papers_html_url: "https://www.theoj.org/joss-papers"
-papers_repo: "openjournals/joss-papers"
-product: "software" # the *thing* being submitted for review
-reviewers: "https://bit.ly/joss-reviewers"
+reviews: "JuliaCon/proceedings-review"
+papers_html_url: "https://juliacon.github.io/proceedings-papers"
+papers_repo: "JuliaCon/proceedings-paper"
+product: "paper" # the *thing* being submitted for review
+reviewers: "https://bit.ly/jcon-reviewers"
 submission_enquiry: |-
   **Project repository URL:** INSERT YOUR REPOSITORY LINK HERE
 
-  Briefly describe your software, its research application and any questions you have about the JOSS submission criteria.
-paper_types: []
+  Briefly describe your software, its research application and any questions you have about the JulianCon submission criteria.
+paper_types: ["full paper", "extended abstract"]


### PR DESCRIPTION
Overhaul of the proceedings.juliacon.org website (ping: @vchuravy).

With the help of @arfon I was able to test the changes locally. However, I'm mostly modifying text in this PR so nothing should break anyways.

Summary:
* sync settings-developement.yml with settings-production.yml
* update new submission banner
* update text on the about page
* update the navigation
  * Github icon now points to the juliacon branch
  * new JCON entry that links to juliacon.org
  * dropped "Blog"
  * renamed "Docs" to "Guide" and linked it to juliacon.github.io/proceedings-guide
