### PR TITLE
Adds explicit statement of need to review checklist

### DIFF
--- a/app/views/content/github/_review_checklist.erb
+++ b/app/views/content/github/_review_checklist.erb
@@ -21,7 +21,7 @@
 
 ### Documentation
 
-- [ ] **A statement of need:** Do the authors have a Statement of Need that clearly states what problems the software is designed to solve and who the target audience is?
+- [ ] **A statement of need:** Does the paper have a section titled 'Statement of Need' that clearly states what problems the software is designed to solve and who the target audience is?
 - [ ] **Installation instructions:** Is there a clearly-stated list of dependencies? Ideally these should be handled with an automated package management solution.
 - [ ] **Example usage:** Do the authors include examples of how to use the software (ideally to solve real-world analysis problems).
 - [ ] **Functionality documentation:** Is the core functionality of the software documented to a satisfactory level (e.g., API method documentation)?

--- a/app/views/content/github/_review_checklist.erb
+++ b/app/views/content/github/_review_checklist.erb
@@ -21,7 +21,7 @@
 
 ### Documentation
 
-- [ ] **A statement of need:** Do the authors clearly state what problems the software is designed to solve and who the target audience is?
+- [ ] **A statement of need:** Do the authors have a Statement of Need that clearly states what problems the software is designed to solve and who the target audience is?
 - [ ] **Installation instructions:** Is there a clearly-stated list of dependencies? Ideally these should be handled with an automated package management solution.
 - [ ] **Example usage:** Do the authors include examples of how to use the software (ideally to solve real-world analysis problems).
 - [ ] **Functionality documentation:** Is the core functionality of the software documented to a satisfactory level (e.g., API method documentation)?

--- a/docs/review_checklist.md
+++ b/docs/review_checklist.md
@@ -30,7 +30,7 @@ Below is an example of the review checklist for the [Yellowbrick JOSS submission
 
 ### Documentation
 
-- **A statement of need:** Do the authors clearly state what problems the software is designed to solve and who the target audience is?
+- **A statement of need:** Do the authors have a Statement of Need that clearly states what problems the software is designed to solve and who the target audience is?
 - **Installation instructions:** Is there a clearly-stated list of dependencies? Ideally these should be handled with an automated package management solution.
 - **Example usage:** Do the authors include examples of how to use the software (ideally to solve real-world analysis problems).
 - **Functionality documentation:** Is the core functionality of the software documented to a satisfactory level (e.g., API method documentation)?

--- a/docs/review_checklist.md
+++ b/docs/review_checklist.md
@@ -30,7 +30,7 @@ Below is an example of the review checklist for the [Yellowbrick JOSS submission
 
 ### Documentation
 
-- **A statement of need:** Do the authors have a Statement of Need that clearly states what problems the software is designed to solve and who the target audience is?
+- **A statement of need:** Does the paper have a section titled 'Statement of Need' that clearly states what problems the software is designed to solve and who the target audience is?
 - **Installation instructions:** Is there a clearly-stated list of dependencies? Ideally these should be handled with an automated package management solution.
 - **Example usage:** Do the authors include examples of how to use the software (ideally to solve real-world analysis problems).
 - **Functionality documentation:** Is the core functionality of the software documented to a satisfactory level (e.g., API method documentation)?


### PR DESCRIPTION
The item for statement of need in the review checklist does not reflect our [explicit requirement](https://joss.readthedocs.io/en/latest/submitting.html#submission-requirements) to have this section, so this add it