### PR TITLE
Improving whedon command docs

### DIFF
--- a/docs/whedon.md
+++ b/docs/whedon.md
@@ -61,7 +61,8 @@ EDITORIAL TASKS
 # Ask Whedon to check the references for missing DOIs
 @whedon check references
 
-# Ask Whedon to check repository statistics for the submitted software
+# Ask Whedon to check repository statistics for the submitted software, for license, and
+# for Statement of Need section in paper
 @whedon check repository
 
 EiC TASKS

--- a/docs/whedon.md
+++ b/docs/whedon.md
@@ -66,6 +66,9 @@ EDITORIAL TASKS
 
 EiC TASKS
 
+# Flag submission for editoral review, due to size or question about being research software
+@whedon query scope
+
 # Invite an editor to edit a submission (sending them an email)
 @whedon invite @editor as editor
 


### PR DESCRIPTION
The `@whedon query scope` command was missing from the docs