### PR TITLE
Active Editors List

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -409,8 +409,6 @@ TODO
     }
 }
 
-
-
 .pagination_helper {
     margin: 0.5em auto;
     display: block;
@@ -727,7 +725,7 @@ $btn-primary-border: darken($btn-primary-bg, 5%) !default;
     background-color: #FFB500 !important;
 }
 
-.paper-btn, .btn.paper-submit {
+.action-btn, .paper-btn, .btn.paper-submit {
     background-color: #2E294E;
     color: #fff;
     font-weight: bold;
@@ -744,6 +742,10 @@ $btn-primary-border: darken($btn-primary-bg, 5%) !default;
         color: #fff;
     }
 
+}
+.action-btn{
+ float: inline-end;
+ margin-bottom: 15px;
 }
 
 .btn.orcid {

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -72,7 +72,7 @@ table.dashboard-table{
   thead {
     tr {
       th {
-        padding: 1em 0em 1em 1em;
+        padding: 1em 0.3em 1em 0.7em;
       }
 
       border-bottom: 1px solid #efefef;
@@ -82,7 +82,7 @@ table.dashboard-table{
   tbody, tfoot {
     tr {
       td {
-        padding: 1em 0em 1em 1em;
+        padding: 1em 0.3em 1em 0.7em;
         font-size: 1em;
         line-height: 1em;
 

--- a/app/controllers/editors_controller.rb
+++ b/app/controllers/editors_controller.rb
@@ -59,6 +59,6 @@ class EditorsController < ApplicationController
     end
 
     def editor_params
-      params.require(:editor).permit(:availability, :kind, :title, :first_name, :last_name, :login, :email, :avatar_url, :category_list, :url, :description)
+      params.require(:editor).permit(:availability, :availability_comment, :kind, :title, :first_name, :last_name, :login, :email, :avatar_url, :category_list, :url, :description)
     end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -38,7 +38,6 @@ class HomeController < ApplicationController
     end
 
     @editor = current_user.editor
-    @active_tab = "incoming"
 
     render template: "home/reviews"
   end
@@ -56,8 +55,8 @@ class HomeController < ApplicationController
     end
 
     if params[:editor]
-      @active_tab = @editor = Editor.find_by_login(params[:editor])
-      
+      @editor = Editor.find_by_login(params[:editor])
+
       @papers = Paper.unscoped.in_progress.where(editor: @editor).order(percent_complete: @order).paginate(
         page: params[:page],
         per_page: 20
@@ -105,13 +104,13 @@ class HomeController < ApplicationController
     end
 
     @editor = current_user.editor
-    
+
     @papers = Paper.unscoped.all.order(percent_complete: @order).paginate(
               page: params[:page],
               per_page: 20
             )
 
-    
+
     render template: "home/reviews"
   end
 

--- a/app/helpers/editors_helper.rb
+++ b/app/helpers/editors_helper.rb
@@ -1,2 +1,18 @@
 module EditorsHelper
+  def display_availability(editor)
+    icon = case editor.availability
+            when 'none'
+              "🔴"
+            when 'somewhat'
+              "🟠"
+            else
+              "🟢"
+           end
+    if editor.availability_comment.present?
+      icon += "*"
+      comment = ": #{editor.availability_comment}"
+    end
+
+    "<span title='#{editor.availability.try(:capitalize)}#{comment}' %>#{icon}</span>".html_safe
+  end
 end

--- a/app/views/editors/_form.html.erb
+++ b/app/views/editors/_form.html.erb
@@ -6,7 +6,7 @@
 
       <ul>
       <% @editor.errors.each do |error| %>
-        <li><%= error.message %></li>
+        <li><%= error.attribute.to_s.humanize %>: <%= error.message %></li>
       <% end %>
       </ul>
     </div>

--- a/app/views/editors/_form.html.erb
+++ b/app/views/editors/_form.html.erb
@@ -24,6 +24,10 @@
       <%= f.select :availability, Editor::AVAILABILITY_STATES, {}, class: "form-control" %>
     </div>
     <div class="col">
+      <%= f.label :type, "Comment on availability" %>
+      <%= f.text_field :availability_comment, class: "form-control" %>
+    </div>
+    <div class="col">
       <%= f.label :title %>
       <%= f.text_field :title, disabled: @editor.kind != "board", class: "form-control" %>
     </div>

--- a/app/views/editors/index.html.erb
+++ b/app/views/editors/index.html.erb
@@ -15,8 +15,9 @@
       <tr>
         <th scope="col" width="15%">Name</th>
         <th scope="col" width="15%">Login</th>
+        <th scope="col" width="30%">Description</th>
         <th scope="col">Categories</th>
-        <th scope="col" width="15%" title="Papers assigned (+ paused)">Paper load</th>
+        <th scope="col" width="10%" title="Papers assigned (+ paused)">Paper load</th>
         <th scope="col" class="text-center">Availability</th>
         <th scope="col" colspan="2" class="sorttable_nosort"></th>
       </tr>
@@ -26,14 +27,15 @@
       <%- Editor.active.order('last_name ASC').each do |editor| %>
       <tr>
         <td>
-          <%= link_to editor.full_name, editor, title: editor.description.html_safe %>
+          <%= link_to editor.full_name, editor, title: strip_tags(editor.description) %>
           <%= "(new)" if editor.created_at > 2.months.ago %>
         </td>
         <td sorttable_customkey=<%= editor.login.downcase %>>
           <%= link_to image_tag(avatar(editor.login), size: "24x24", class: "avatar", title: github_user_link(editor.login)), github_user_link(editor.login), target: "_blank" %>
           <%= editor.login %>
         </td>
-        <td style="max-width:300px"><%= editor.category_list %></td>
+        <td class="text-justify" title="<%= strip_tags(editor.description) %>"><%= truncate(strip_tags(editor.description), length: 150) %></td>
+        <td style="max-width:250px"><%= editor.category_list %></td>
         <td><%= link_to in_progress_for_editor(Paper.in_progress.where(editor: editor)), "/dashboard/#{editor.login}" %></td>
         <td class="text-center"><%= display_availability(editor) %></td>
         <td><%= link_to '✏️', edit_editor_path(editor), title: 'Edit' %></td>

--- a/app/views/editors/index.html.erb
+++ b/app/views/editors/index.html.erb
@@ -23,7 +23,10 @@
     <tbody>
       <%- Editor.active.order('last_name ASC').each do |editor| %>
       <tr>
-        <td><%= link_to editor.full_name, editor, title: editor.description.html_safe %></td>
+        <td>
+          <%= link_to editor.full_name, editor, title: editor.description.html_safe %>
+          <%= "(new)" if editor.created_at > 2.months.ago %>
+        </td>
         <td sorttable_customkey=<%= editor.login.downcase %>>
           <%= link_to image_tag(avatar(editor.login), size: "24x24", class: "avatar", title: github_user_link(editor.login)), github_user_link(editor.login), target: "_blank" %>
           <%= editor.login %>

--- a/app/views/editors/index.html.erb
+++ b/app/views/editors/index.html.erb
@@ -13,21 +13,26 @@
         <th scope="col" width="15%">Name</th>
         <th scope="col" width="15%">Login</th>
         <th scope="col">Categories</th>
-        <th scope="col" width="20%">Description</th>
+        <th scope="col"  width="15%" title="Papers assigned (+ paused)">Paper load</th>
+        <th scope="col">Availability</th>
         <th scope="col">Type</th>
-        <th scope="col" colspan="3" width="20%"></th>
+        <th scope="col" colspan="2" width="10%"></th>
       </tr>
     </thead>
 
     <tbody>
       <%- Editor.active.order('last_name ASC').each do |editor| %>
       <tr>
-        <td><%= editor.full_name %></td>
-        <td sorttable_customkey=<%= editor.login.downcase %>><%= image_tag(avatar(editor.login), size: "24x24", class: "avatar", title: editor.login) %> <%= link_to editor.login, "/dashboard/#{editor.login}" %><% if editor.retired? %> <em>(emeritus)</em><% end %></td>
-        <td><%= editor.category_list %></td>
-        <td class="d-inline-block text-truncate" style="max-width:300px"><%= editor.description.html_safe %></td>
+        <td><%= link_to editor.full_name, editor, title: editor.description.html_safe %></td>
+        <td sorttable_customkey=<%= editor.login.downcase %>>
+          <%= link_to image_tag(avatar(editor.login), size: "24x24", class: "avatar", title: github_user_link(editor.login)), github_user_link(editor.login), target: "_blank" %>
+          <%= editor.login %>
+          <% if editor.retired? %><em>(emeritus)</em><% end %>
+        </td>
+        <td style="max-width:300px"><%= editor.category_list %></td>
+        <td><%= link_to in_progress_for_editor(Paper.in_progress.where(editor: editor)), "/dashboard/#{editor.login}" %></td>
+        <td><strong><%= editor.availability.try(:capitalize) %></strong> <%= editor.availability_comment %></td>
         <td><%= editor.kind %></td>
-        <td><%= link_to 'Show', editor %></td>
         <td><%= link_to 'Edit', edit_editor_path(editor) %></td>
         <td><%= link_to 'Destroy', editor, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>

--- a/app/views/editors/index.html.erb
+++ b/app/views/editors/index.html.erb
@@ -61,21 +61,22 @@
         <th scope="col" width="15%">Name</th>
         <th scope="col" width="15%">Login</th>
         <th scope="col">Categories</th>
-        <th scope="col" width="20%">Description</th>
+        <th scope="col" width="30%">Description</th>
         <th scope="col">Type</th>
-        <th scope="col" colspan="3" width="20%"></th>
+        <th scope="col" colspan="2" width="10%"></th>
       </tr>
     </thead>
 
     <tbody>
       <%- Editor.emeritus.order('last_name ASC').each do |editor| %>
       <tr>
-        <td><%= editor.full_name %></td>
-        <td sorttable_customkey=<%= editor.login.downcase %>><%= image_tag(avatar(editor.login), size: "24x24", class: "avatar", title: editor.login) %> <%= link_to editor.login, "/dashboard/#{editor.login}" %><% if editor.retired? %><% end %></td>
+        <td><%= link_to editor.full_name, editor %></td>
+        <td sorttable_customkey=<%= editor.login.downcase %>>
+          <%= link_to image_tag(avatar(editor.login), size: "24x24", class: "avatar", title: github_user_link(editor.login)), github_user_link(editor.login), target: "_blank" %>
+          <%= link_to editor.login, "/dashboard/#{editor.login}" %></td>
         <td><%= editor.category_list %></td>
-        <td class="d-inline-block text-truncate" style="max-width:300px"><%= editor.description.html_safe %></td>
+        <td class="d-inline-block text-truncate" style="max-width:450px"><%= editor.description.html_safe %></td>
         <td><%= editor.kind %></td>
-        <td><%= link_to 'Show', editor %></td>
         <td><%= link_to 'Edit', edit_editor_path(editor) %></td>
         <td><%= link_to 'Destroy', editor, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>

--- a/app/views/editors/index.html.erb
+++ b/app/views/editors/index.html.erb
@@ -30,7 +30,6 @@
         <td sorttable_customkey=<%= editor.login.downcase %>>
           <%= link_to image_tag(avatar(editor.login), size: "24x24", class: "avatar", title: github_user_link(editor.login)), github_user_link(editor.login), target: "_blank" %>
           <%= editor.login %>
-          <% if editor.retired? %><em>(emeritus)</em><% end %>
         </td>
         <td style="max-width:300px"><%= editor.category_list %></td>
         <td><%= link_to in_progress_for_editor(Paper.in_progress.where(editor: editor)), "/dashboard/#{editor.login}" %></td>

--- a/app/views/editors/index.html.erb
+++ b/app/views/editors/index.html.erb
@@ -16,9 +16,9 @@
         <th scope="col" width="15%">Name</th>
         <th scope="col" width="15%">Login</th>
         <th scope="col">Categories</th>
-        <th scope="col"  width="15%" title="Papers assigned (+ paused)">Paper load</th>
+        <th scope="col" width="15%" title="Papers assigned (+ paused)">Paper load</th>
         <th scope="col">Availability</th>
-        <th scope="col" colspan="2" width="10%"></th>
+        <th scope="col" colspan="2"></th>
       </tr>
     </thead>
 
@@ -35,9 +35,9 @@
         </td>
         <td style="max-width:300px"><%= editor.category_list %></td>
         <td><%= link_to in_progress_for_editor(Paper.in_progress.where(editor: editor)), "/dashboard/#{editor.login}" %></td>
-        <td><strong><%= editor.availability.try(:capitalize) %></strong> <%= editor.availability_comment %></td>
-        <td><%= link_to 'Edit', edit_editor_path(editor) %></td>
-        <td><%= link_to 'Destroy', editor, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= display_availability(editor) %></td>
+        <td><%= link_to '✏️', edit_editor_path(editor), title: 'Edit' %></td>
+        <td><%= link_to '🗑', editor, method: :delete, data: { confirm: 'Are you sure?' }, title: 'Delete' %></td>
       </tr>
       <%- end %>
     </tbody>
@@ -67,7 +67,7 @@
         <th scope="col" width="15%">Login</th>
         <th scope="col">Categories</th>
         <th scope="col" width="30%">Description</th>
-        <th scope="col" colspan="2" width="10%"></th>
+        <th scope="col" colspan="2"></th>
       </tr>
     </thead>
 
@@ -80,8 +80,8 @@
           <%= link_to editor.login, "/dashboard/#{editor.login}" %></td>
         <td><%= editor.category_list %></td>
         <td class="d-inline-block text-truncate" style="max-width:450px"><%= editor.description.html_safe %></td>
-        <td><%= link_to 'Edit', edit_editor_path(editor) %></td>
-        <td><%= link_to 'Destroy', editor, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to '✏️', edit_editor_path(editor), title: 'Edit' %></td>
+        <td><%= link_to '🗑', editor, method: :delete, data: { confirm: 'Are you sure?' }, title: 'Delete' %></td>
       </tr>
       <%- end %>
     </tbody>

--- a/app/views/editors/index.html.erb
+++ b/app/views/editors/index.html.erb
@@ -7,6 +7,9 @@
       </div>
     </div>
   </div>
+
+  <%= link_to 'New Editor', new_editor_path, class: 'btn action-btn' %>
+
   <table class="dashboard-table">
     <thead>
       <tr>
@@ -41,6 +44,10 @@
       <%- end %>
     </tbody>
   </table>
+
+  <div class="links">
+    <%= link_to 'New Editor', new_editor_path, class: 'btn action-btn' %>
+  </div>
 </div>
 
 <br />
@@ -83,8 +90,4 @@
       <%- end %>
     </tbody>
   </table>
-
-  <div class="links">
-    <%= link_to 'New Editor', new_editor_path %>
-  </div>
 </div>

--- a/app/views/editors/index.html.erb
+++ b/app/views/editors/index.html.erb
@@ -10,15 +10,15 @@
 
   <%= link_to 'New Editor', new_editor_path, class: 'btn action-btn' %>
 
-  <table class="dashboard-table">
+  <table class="dashboard-table sortable">
     <thead>
       <tr>
         <th scope="col" width="15%">Name</th>
         <th scope="col" width="15%">Login</th>
         <th scope="col">Categories</th>
         <th scope="col" width="15%" title="Papers assigned (+ paused)">Paper load</th>
-        <th scope="col">Availability</th>
-        <th scope="col" colspan="2"></th>
+        <th scope="col" class="text-center">Availability</th>
+        <th scope="col" colspan="2" class="sorttable_nosort"></th>
       </tr>
     </thead>
 
@@ -35,7 +35,7 @@
         </td>
         <td style="max-width:300px"><%= editor.category_list %></td>
         <td><%= link_to in_progress_for_editor(Paper.in_progress.where(editor: editor)), "/dashboard/#{editor.login}" %></td>
-        <td><%= display_availability(editor) %></td>
+        <td class="text-center"><%= display_availability(editor) %></td>
         <td><%= link_to '✏️', edit_editor_path(editor), title: 'Edit' %></td>
         <td><%= link_to '🗑', editor, method: :delete, data: { confirm: 'Are you sure?' }, title: 'Delete' %></td>
       </tr>

--- a/app/views/editors/index.html.erb
+++ b/app/views/editors/index.html.erb
@@ -18,7 +18,6 @@
         <th scope="col">Categories</th>
         <th scope="col"  width="15%" title="Papers assigned (+ paused)">Paper load</th>
         <th scope="col">Availability</th>
-        <th scope="col">Type</th>
         <th scope="col" colspan="2" width="10%"></th>
       </tr>
     </thead>
@@ -37,7 +36,6 @@
         <td style="max-width:300px"><%= editor.category_list %></td>
         <td><%= link_to in_progress_for_editor(Paper.in_progress.where(editor: editor)), "/dashboard/#{editor.login}" %></td>
         <td><strong><%= editor.availability.try(:capitalize) %></strong> <%= editor.availability_comment %></td>
-        <td><%= editor.kind %></td>
         <td><%= link_to 'Edit', edit_editor_path(editor) %></td>
         <td><%= link_to 'Destroy', editor, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>
@@ -69,7 +67,6 @@
         <th scope="col" width="15%">Login</th>
         <th scope="col">Categories</th>
         <th scope="col" width="30%">Description</th>
-        <th scope="col">Type</th>
         <th scope="col" colspan="2" width="10%"></th>
       </tr>
     </thead>
@@ -83,7 +80,6 @@
           <%= link_to editor.login, "/dashboard/#{editor.login}" %></td>
         <td><%= editor.category_list %></td>
         <td class="d-inline-block text-truncate" style="max-width:450px"><%= editor.description.html_safe %></td>
-        <td><%= editor.kind %></td>
         <td><%= link_to 'Edit', edit_editor_path(editor) %></td>
         <td><%= link_to 'Destroy', editor, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>

--- a/app/views/editors/show.html.erb
+++ b/app/views/editors/show.html.erb
@@ -56,6 +56,7 @@
 
     <p>
       <strong>Availability: <%= @editor.availability.try(:capitalize) %></strong>
+      <%= @editor.availability_comment %>
     </p>
 
     <div class="links">

--- a/app/views/editors/show.html.erb
+++ b/app/views/editors/show.html.erb
@@ -54,6 +54,10 @@
       <%= @editor.description.html_safe %>
     </p>
 
+    <p>
+      <strong>Availability: <%= @editor.availability.try(:capitalize) %></strong>
+    </p>
+
     <div class="links">
       <%= link_to 'Edit', edit_editor_path(@editor) %> |
       <%= link_to 'List', editors_path %>

--- a/app/views/home/reviews.html.erb
+++ b/app/views/home/reviews.html.erb
@@ -4,7 +4,8 @@
       <div class="welcome">Welcome, <%= current_user.editor.full_name %></div>
       <div class="hero-small dashboard">
         <div class="hero-title">
-          <%= image_tag "icon_papers.svg", height: "32px" %><h1>Editor dashboard</h1>
+          <%= image_tag "icon_papers.svg", height: "32px" %>
+          <h1>Editor dashboard <%= " - @#{@editor.login}" if @editor != current_user.editor%></h1>
         </div>
       </div>
     </div>

--- a/db/migrate/20210222114454_add_availability_comment_to_editors.rb
+++ b/db/migrate/20210222114454_add_availability_comment_to_editors.rb
@@ -1,0 +1,5 @@
+class AddAvailabilityCommentToEditors < ActiveRecord::Migration[6.1]
+  def change
+    add_column :editors, :availability_comment, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_14_162210) do
+ActiveRecord::Schema.define(version: 2021_02_22_114454) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 2021_02_14_162210) do
     t.datetime "updated_at", null: false
     t.integer "user_id"
     t.string "availability"
+    t.string "availability_comment"
     t.index ["availability"], name: "index_editors_on_availability"
     t.index ["user_id"], name: "index_editors_on_user_id"
   end

--- a/spec/factories/editors.rb
+++ b/spec/factories/editors.rb
@@ -10,5 +10,6 @@ FactoryBot.define do
     url { "http://placekitten.com" }
     description { "Person McEditor is an editor" }
     availability { "available" }
+    availability_comment { "OOO until March 1" }
   end
 end

--- a/spec/factories/editors.rb
+++ b/spec/factories/editors.rb
@@ -9,5 +9,6 @@ FactoryBot.define do
     categories { %w(topic1 topic2 topic3) }
     url { "http://placekitten.com" }
     description { "Person McEditor is an editor" }
+    availability { "available" }
   end
 end

--- a/spec/views/editors/edit.html.erb_spec.rb
+++ b/spec/views/editors/edit.html.erb_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "editors/edit", type: :view do
 
     assert_select "form[action=?][method=?]", editor_path(@editor), "post" do
       assert_select "select#editor_kind[name=?]", "editor[kind]"
+      assert_select "select#editor_availability[name=?]", "editor[availability]"
       assert_select "input#editor_title[name=?]", "editor[title]"
       assert_select "input#editor_first_name[name=?]", "editor[first_name]"
       assert_select "input#editor_last_name[name=?]", "editor[last_name]"

--- a/spec/views/editors/edit.html.erb_spec.rb
+++ b/spec/views/editors/edit.html.erb_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "editors/edit", type: :view do
     assert_select "form[action=?][method=?]", editor_path(@editor), "post" do
       assert_select "select#editor_kind[name=?]", "editor[kind]"
       assert_select "select#editor_availability[name=?]", "editor[availability]"
+      assert_select "input#editor_availability_comment[name=?]", "editor[availability_comment]"
       assert_select "input#editor_title[name=?]", "editor[title]"
       assert_select "input#editor_first_name[name=?]", "editor[first_name]"
       assert_select "input#editor_last_name[name=?]", "editor[last_name]"

--- a/spec/views/editors/index.html.erb_spec.rb
+++ b/spec/views/editors/index.html.erb_spec.rb
@@ -9,8 +9,9 @@ RSpec.describe "editors/index", type: :view do
     render
     assert_select "tr>td:nth-of-type(1)", text: /Person McEditor/, count: 2
     assert_select "tr>td:nth-of-type(2)", text: "mceditor", count: 2
-    assert_select "tr>td:nth-of-type(3)", text: "topic1, topic2, topic3", count: 2
-    assert_select "tr>td:nth-of-type(5)", text: "🟢*", count: 2
-    assert_select "tr>td:nth-of-type(5)>span[title=?]", "Available: OOO until March 1", count: 2
+    assert_select "tr>td:nth-of-type(3)", text: "Person McEditor is an editor", count: 2
+    assert_select "tr>td:nth-of-type(4)", text: "topic1, topic2, topic3", count: 2
+    assert_select "tr>td:nth-of-type(6)", text: "🟢*", count: 2
+    assert_select "tr>td:nth-of-type(6)>span[title=?]", "Available: OOO until March 1", count: 2
   end
 end

--- a/spec/views/editors/index.html.erb_spec.rb
+++ b/spec/views/editors/index.html.erb_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "editors/index", type: :view do
     assert_select "tr>td:nth-of-type(1)", text: /Person McEditor/, count: 2
     assert_select "tr>td:nth-of-type(2)", text: "mceditor", count: 2
     assert_select "tr>td:nth-of-type(3)", text: "topic1, topic2, topic3", count: 2
-    assert_select "tr>td:nth-of-type(5)", text: "Available OOO until March 1", count: 2
+    assert_select "tr>td:nth-of-type(5)", text: "🟢*", count: 2
+    assert_select "tr>td:nth-of-type(5)>span[title=?]", "Available: OOO until March 1", count: 2
   end
 end

--- a/spec/views/editors/index.html.erb_spec.rb
+++ b/spec/views/editors/index.html.erb_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe "editors/index", type: :view do
 
   it "renders a list of editors" do
     render
-    assert_select "tr>td:nth-of-type(1)", text: "Person McEditor", count: 2
+    assert_select "tr>td:nth-of-type(1)", text: /Person McEditor/, count: 2
     assert_select "tr>td:nth-of-type(2)", text: "mceditor", count: 2
     assert_select "tr>td:nth-of-type(3)", text: "topic1, topic2, topic3", count: 2
+    assert_select "tr>td:nth-of-type(5)", text: "Available OOO until March 1", count: 2
   end
 end

--- a/spec/views/editors/show.html.erb_spec.rb
+++ b/spec/views/editors/show.html.erb_spec.rb
@@ -17,5 +17,6 @@ RSpec.describe "editors/show", type: :view do
     expect(rendered).to match(/Categories/)
     expect(rendered).to match(/Url/)
     expect(rendered).to match(/Description/)
+    expect(rendered).to match(/Availability/)
   end
 end


### PR DESCRIPTION
This PR adds information to the current editor list in the EiCs dashboard.
The new table includes this changes:
* `Show` action linked from the editor's name
* added link to GitHub page from the editor's avatar
* Editor login is now plain text easy to copy
* Description moved to appear only when hovering over the name of each editor
* Added a `Paper load` column with the current number of papers assigned to an editor, and linking to that editor's dashboard.
* Added availability info: status ([available/somewhat/none]) and comment
* Availability comment is a new editable field 
* Editors created in the last two months are marked as _new_  
* `New editor` button available before and after the editors table

---
**Current view:**
![current_editors_list](https://user-images.githubusercontent.com/6528/108823962-6ba44e00-75c1-11eb-8fb1-04af2c32b4f7.png)

---
**New view:**
![screenshot_editors_new_page](https://user-images.githubusercontent.com/6528/109148937-30438400-7767-11eb-9fe7-c3251fe1e8a1.png)

