### PR TITLE
EiC dashboard

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -54,6 +54,3 @@ private
     render plain: "404 Not Found", status: 404
   end
 end
-
-
-

--- a/app/controllers/eic_dashboard_controller.rb
+++ b/app/controllers/eic_dashboard_controller.rb
@@ -1,0 +1,9 @@
+class EicDashboardController < ApplicationController
+  before_action :require_admin_user
+
+  def index
+    @recommend_accept = GITHUB.issues(Rails.application.settings["reviews"], labels: "recommend-accept", state:"open")
+    @with_query_scope = GITHUB.issues(Rails.application.settings["reviews"], labels: "query-scope", state:"open")
+  end
+
+end

--- a/app/views/content/layout/_navbar.html.erb
+++ b/app/views/content/layout/_navbar.html.erb
@@ -17,7 +17,7 @@
     <div class="navbar-nav ml-auto">
 
       <%- if current_user&.admin? %>
-      <%= link_to "Editors", editors_path, class: "nav-item nav-link" %>
+      <%= link_to "EiC", eic_dashboard_path, class: "nav-item nav-link" %>
       <%- end %>
 
       <%- if current_user&.editor %>

--- a/app/views/editors/index.html.erb
+++ b/app/views/editors/index.html.erb
@@ -1,13 +1,17 @@
 <div class="container">
   <p id="notice"><%= notice %></p>
   <div class="col-7">
+    <div class="welcome">Editors in Chief Dashboard</div>
     <div class="hero-small dashboard">
       <div class="hero-title">
         <%= image_tag "icon_papers.svg", height: "32px" %><h1>Active Editors</h1>
       </div>
     </div>
   </div>
+</div>
 
+<%= render partial: "eic_dashboard/menu" %>
+<div class="container">
   <%= link_to 'New Editor', new_editor_path, class: 'btn action-btn' %>
 
   <table class="dashboard-table sortable">

--- a/app/views/eic_dashboard/_menu.html.erb
+++ b/app/views/eic_dashboard/_menu.html.erb
@@ -1,0 +1,6 @@
+<div class="container">
+  <div class="btn-group" role="group" aria-label="Paper Status">
+    <%= link_to "Submissions overview", eic_dashboard_path, class: current_class?(eic_dashboard_path) %>
+    <%= link_to "Editors", editors_path, class: current_class?(editors_path) %>
+  </div>
+</div>

--- a/app/views/eic_dashboard/index.html.erb
+++ b/app/views/eic_dashboard/index.html.erb
@@ -1,0 +1,56 @@
+<div class="container">
+<p id="notice"><%= notice %></p>
+  <div class="col-7">
+    <div class="welcome">Welcome, <%= current_user.editor.full_name %></div>
+    <div class="hero-small dashboard">
+      <div class="hero-title">
+        <%= image_tag "icon_papers.svg", height: "32px" %><h1>Editors in Chief Dashboard</h1>
+      </div>
+    </div>
+  </div>
+</div>
+
+<%= render partial: "menu" %>
+
+<div class="container">
+  <div id="submitting" class="generic-content-item">
+    <h1>Accepted and ready to publish</h1>
+    <% if @recommend_accept.any? %>
+      <p>Papers labeled as <strong>recommend-accept</strong> but still open:</p>
+      <ul>
+      <% @recommend_accept.each do |accepted_issue| %>
+        <li><%= link_to "##{accepted_issue.number}", accepted_issue.html_url, :target => "_blank" %> <%= accepted_issue.title %> </li>
+      <% end %>
+      </ul>
+      <% accepted_link_text = "List of ready to publish submissions at Github" %>
+    <% else %>
+      <% accepted_link_text = "There are no <strong>open</strong> submissions labeled as <strong>recommend-accept</strong>.".html_safe %>
+    <% end %>
+    <p>
+      <%= link_to accepted_link_text,
+            "https://github.com/openjournals/joss-reviews/issues?utf8=%E2%9C%93&q=+label:recommend-accept+-label:published+",
+            target: "_blank" %>
+    </p>
+  </div>
+
+  <div class="generic-content-item" id="code_of_conduct">
+    <h1>Scope query</h1>
+    <% if @with_query_scope.any? %>
+      <p>Open submissions flagged for editorial review (labeled as <strong>query-scope</strong>):</p>
+      <ul>
+      <% @with_query_scope.each do |flagged_issue| %>
+        <li><%= link_to "##{flagged_issue.number}", flagged_issue.html_url, :target => "_blank" %> <%= flagged_issue.title %> </li>
+      <% end %>
+      </ul>
+      <% scope_query_link_text = "List of submissions pending editorial review at Github" %>
+    <% else %>
+      <% scope_query_link_text = "There are no <strong>open</strong> submissions flagged for editorial review (labeled as <strong>query-scope</strong>).".html_safe %>
+    <% end %>
+
+    <p>
+      <%= link_to scope_query_link_text,
+                  "https://github.com/openjournals/joss-reviews/labels/query-scope",
+                  target: "_blank" %>
+    </p>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
     end
   end
 
+  get '/eic/', to: "eic_dashboard#index", as: "eic_dashboard"
   get '/editors/lookup/:login', to: "editors#lookup"
   get '/papers/lookup/:id', to: "papers#lookup"
   get '/papers/in/:language', to: "papers#filter", as: 'papers_by_language'

--- a/spec/controllers/eic_dashboard_controller_spec.rb
+++ b/spec/controllers/eic_dashboard_controller_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+RSpec.describe EicDashboardController, type: :controller do
+  render_views
+  let(:current_user) { create(:admin_user, editor: create(:editor)) }
+
+  before(:each) do
+    allow(controller).to receive(:current_user).and_return(current_user)
+  end
+
+  context "when not logged in" do
+    let(:current_user) { nil }
+    it "redirects to root with a login message" do
+      get :index
+      expect(response).to redirect_to root_path
+      expect(flash[:error]).to eql "Please login first"
+    end
+  end
+
+  context "when logged in as a non-admin user" do
+    let(:current_user) { create(:user) }
+    it "redirects to root with a not allowed message" do
+      get :index
+      expect(response).to redirect_to root_path
+      expect(flash[:error]).to eql "You are not permitted to view that page"
+    end
+  end
+
+  describe "#index" do
+    let(:accepted_params) { [Rails.application.settings[:reviews], {labels: "recommend-accept", state: "open"}] }
+    let(:flagged_params) { [Rails.application.settings[:reviews], {labels: "query-scope", state: "open"}] }
+    let(:accepted_issue_1) { OpenStruct.new(number: 1, html_url: "/test1", title: "Accepted paper 1") }
+    let(:accepted_issue_2) { OpenStruct.new(number: 2, html_url: "/test2", title: "Accepted paper 2") }
+    let(:flagged_issue_1) { OpenStruct.new(number: 3, html_url: "/test3", title: "Flagged paper 1") }
+    let(:flagged_issue_2) { OpenStruct.new(number: 4, html_url: "/test4", title: "Flagged paper 2") }
+
+    it "lists all open accepted issues" do
+      allow(GITHUB).to receive(:issues).with(*accepted_params).and_return([accepted_issue_1, accepted_issue_2])
+      allow(GITHUB).to receive(:issues).with(*flagged_params).and_return([])
+
+      get :index
+
+      expect(response.body).to have_content "List of ready to publish submissions at Github"
+      expect(response.body).to have_link("#1", href: "/test1")
+      expect(response.body).to have_link("#2", href: "/test2")
+      expect(response.body).to have_content "Accepted paper 1"
+      expect(response.body).to have_content "Accepted paper 2"
+      expect(response.body).to_not have_content "There are no open submissions labeled as recommend-accept"
+    end
+
+    it "includes a no submissions message if there are not open accepted issues" do
+      allow(GITHUB).to receive(:issues).with(*accepted_params).and_return([])
+      allow(GITHUB).to receive(:issues).with(*flagged_params).and_return([flagged_issue_1])
+
+      get :index
+
+      expect(response.body).to have_content "There are no open submissions labeled as recommend-accept"
+      expect(response.body).to_not have_content "List of ready to publish submissions at Github"
+    end
+
+    it "lists all issues flagged with query-scope" do
+      allow(GITHUB).to receive(:issues).with(*flagged_params).and_return([flagged_issue_1, flagged_issue_2])
+      allow(GITHUB).to receive(:issues).with(*accepted_params).and_return([])
+
+      get :index
+
+      expect(response.body).to have_content "List of submissions pending editorial review at Github"
+      expect(response.body).to have_link("#3", href: "/test3")
+      expect(response.body).to have_link("#4", href: "/test4")
+      expect(response.body).to have_content "Flagged paper 1"
+      expect(response.body).to have_content "Flagged paper 2"
+      expect(response.body).to_not have_content "There are no open submissions flagged for editorial review"
+    end
+
+    it "includes a no submissions message if there are not open flagged issues" do
+      allow(GITHUB).to receive(:issues).with(*flagged_params).and_return([])
+      allow(GITHUB).to receive(:issues).with(*accepted_params).and_return([accepted_issue_1])
+
+      get :index
+
+      expect(response.body).to have_content "There are no open submissions flagged for editorial review"
+      expect(response.body).to_not have_content "List of submissions pending editorial review at Github"
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,6 +3,7 @@ ENV["RAILS_ENV"] ||= 'test'
 require 'spec_helper'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
+require 'ostruct'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in


### PR DESCRIPTION
This PR adds a EiC dashboard with access to a list of ready-for-acceptance and flagged papers, the EiC dashboard also links to the editors management list.

![EiC_dashboard](https://user-images.githubusercontent.com/6528/109964600-29c88580-7cee-11eb-8318-7c650e6fa507.png)

