### PR TITLE
Optimize queries

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -25,6 +25,12 @@ class HomeController < ApplicationController
 
     @assignment_by_editor = Paper.unscoped.in_progress.group(:editor_id).count
     @paused_by_editor = Paper.unscoped.in_progress.where("labels->>'paused' ILIKE '%'").group(:editor_id).count
+
+    @papers_last_week = Paper.unscoped.visible.since(1.week.ago).group(:editor_id).count
+    @papers_last_month = Paper.unscoped.visible.since(1.month.ago).group(:editor_id).count
+    @papers_last_3_months = Paper.unscoped.visible.since(3.months.ago).group(:editor_id).count
+    @papers_last_year = Paper.unscoped.visible.since(1.year.ago).group(:editor_id).count
+    @papers_all_time = Paper.unscoped.visible.since(100.year.ago).group(:editor_id).count
   end
 
   def incoming

--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -106,7 +106,6 @@ class Paper < ApplicationRecord
 
   scope :since, -> (date) { where('accepted_at >= ?', date) }
   scope :in_progress, -> { where(state: IN_PROGRESS_STATES) }
-  scope :in_progress, -> { where(state: IN_PROGRESS_STATES) }
   scope :public_in_progress, -> { where(state: PUBLIC_IN_PROGRESS_STATES) }
   scope :visible, -> { where(state: VISIBLE_STATES) }
   scope :invisible, -> { where(state: INVISIBLE_STATES) }

--- a/app/views/home/dashboard.html.erb
+++ b/app/views/home/dashboard.html.erb
@@ -28,12 +28,12 @@
       <tr class='<%= availability_class(editor) %>'>
         <td sorttable_customkey=<%= editor.login.downcase %>><%= image_tag(avatar(editor.login), size: "24x24", class: "avatar", title: editor.login) %> <%= link_to editor.login, "/dashboard/#{editor.login}" %><% if editor.retired? %> <em>(emeritus)</em><% end %></td>
         <td sorttable_customkey=<%= in_progress_no_paused_for_editor(editor) %>><%= in_progress_for_editor(editor) %></td>
-        <td class="text-center"><%= editor.three_month_average %></td>
-        <td class="text-center"><%= editor.papers.visible.since(1.week.ago).count %></td>
-        <td class="text-center"><%= editor.papers.visible.since(1.month.ago).count %></td>
-        <td class="text-center"><%= editor.papers.visible.since(3.months.ago).count %></td>
-        <td class="text-center"><%= editor.papers.visible.since(1.year.ago).count %></td>
-        <td class="text-center"><%= editor.papers.visible.since(100.year.ago).count %></td>
+        <td class="text-center"><%= sprintf("%.1f", @papers_last_3_months[editor.id].to_i / 3.0) %></td>
+        <td class="text-center"><%= @papers_last_week[editor.id].to_i %></td>
+        <td class="text-center"><%= @papers_last_month[editor.id].to_i %></td>
+        <td class="text-center"><%= @papers_last_3_months[editor.id].to_i %></td>
+        <td class="text-center"><%= @papers_last_year[editor.id].to_i %></td>
+        <td class="text-center"><%= @papers_all_time[editor.id].to_i %></td>
       </tr>
       <% end %>
     </tbody>
@@ -42,12 +42,12 @@
       <tr class="<%= cycle('odd', 'even') -%>">
         <td><%= image_tag(avatar(editor.login), size: "24x24", class: "avatar", title: editor.login) %> <%= link_to editor.login, "/dashboard/#{editor.login}" %><% if editor.retired? %> <em>(emeritus)</em><% end %></td>
         <td><%= in_progress_for_editor(editor) %></td>
-        <td class="text-center"><%= editor.three_month_average %></td>
-        <td class="text-center"><%= editor.papers.visible.since(1.week.ago).count %></td>
-        <td class="text-center"><%= editor.papers.visible.since(1.month.ago).count %></td>
-        <td class="text-center"><%= editor.papers.visible.since(3.months.ago).count %></td>
-        <td class="text-center"><%= editor.papers.visible.since(1.year.ago).count %></td>
-        <td class="text-center"><%= editor.papers.visible.since(100.year.ago).count %></td>
+        <td class="text-center"><%= sprintf("%.1f", @papers_last_3_months[editor.id].to_i / 3.0) %></td>
+        <td class="text-center"><%= @papers_last_week[editor.id].to_i %></td>
+        <td class="text-center"><%= @papers_last_month[editor.id].to_i %></td>
+        <td class="text-center"><%= @papers_last_3_months[editor.id].to_i %></td>
+        <td class="text-center"><%= @papers_last_year[editor.id].to_i %></td>
+        <td class="text-center"><%= @papers_all_time[editor.id].to_i %></td>
       </tr>
       <% end %>
       <tr style="font-weight: bolder;">


### PR DESCRIPTION
This PR removes a N+1 problem in the rendering of the dashboard stats page. 

Currently there's six queries per editor, totaling 207 queries to show the stats on editor activity. This PR reduces it to 5 queries independent of the number of editors. Should increase the performance of the dashboard stats page drastically.