### PR TITLE
Track editor invitations

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,0 +1,7 @@
+class InvitationsController < ApplicationController
+  before_action :require_admin_user
+
+  def index
+    @invitations = Invitation.includes(:editor, :paper).order(created_at: :desc).limit(25)
+  end
+end

--- a/app/helpers/invitations_helper.rb
+++ b/app/helpers/invitations_helper.rb
@@ -1,0 +1,14 @@
+module InvitationsHelper
+  def invitation_status(invitation)
+    status = "⏳ Pending"
+
+    if invitation.accepted?
+      status = "✅ Accepted"
+    elsif invitation.paper.review_issue_id.present? &&
+          invitation.paper.editor_id != invitation.editor_id
+      status = "❌ Rejected"
+    end
+
+    status
+  end
+end

--- a/app/models/editor.rb
+++ b/app/models/editor.rb
@@ -7,6 +7,7 @@ class Editor < ApplicationRecord
   belongs_to :user, optional: true
   has_many :papers
   has_many :votes
+  has_many :invitations
 
   before_save :clear_title, if: :board_removed?
   before_save :format_login, if: :login_changed?

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -1,0 +1,8 @@
+class Invitation < ApplicationRecord
+  belongs_to :editor
+  belongs_to :paper
+
+  def accept!
+    self.update_attribute(:accepted, true)
+  end
+end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -2,7 +2,15 @@ class Invitation < ApplicationRecord
   belongs_to :editor
   belongs_to :paper
 
+  scope :accepted, -> { where(accepted: true) }
+  scope :pending, -> { where(accepted: false) }
+
   def accept!
     self.update_attribute(:accepted, true)
+  end
+
+  def self.accept_if_pending(paper, editor)
+    invitation = pending.find_by(paper: paper, editor: editor)
+    invitation.accept! if invitation
   end
 end

--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -7,25 +7,26 @@ class Paper < ApplicationRecord
   serialize :activities, Hash
   serialize :metadata, Hash
 
-  belongs_to  :submitting_author,
-              class_name: 'User',
-              validate: true,
-              foreign_key: "user_id"
+  belongs_to :submitting_author,
+             class_name: 'User',
+             validate: true,
+             foreign_key: "user_id"
 
-  belongs_to  :editor, optional: true
-  belongs_to  :eic,
-              class_name: 'Editor',
-              optional: true,
-              foreign_key: "eic_id"
+  belongs_to :editor, optional: true
+  belongs_to :eic,
+             class_name: 'Editor',
+             optional: true,
+             foreign_key: "eic_id"
 
-  has_many    :votes
-  has_many    :in_scope_votes,
-              -> { in_scope },
-              class_name: 'Vote'
+  has_many :invitations
+  has_many :votes
+  has_many :in_scope_votes,
+           -> { in_scope },
+           class_name: 'Vote'
 
-  has_many    :out_of_scope_votes,
-              -> { out_of_scope },
-              class_name: 'Vote'
+  has_many :out_of_scope_votes,
+           -> { out_of_scope },
+           class_name: 'Vote'
 
   include AASM
 
@@ -171,6 +172,7 @@ class Paper < ApplicationRecord
   def invite_editor(editor_handle)
     return false unless editor = Editor.find_by_login(editor_handle)
     Notifications.editor_invite_email(self, editor).deliver_now
+    invitations.create(editor: editor)
   end
 
   def scholar_title

--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -370,6 +370,7 @@ class Paper < ApplicationRecord
   # Updated the paper with the editor_id
   def set_editor(editor)
     self.update_attribute(:editor_id, editor.id)
+    Invitation.accept_if_pending(self, editor)
   end
 
   # Update the Paper review_issue_id field

--- a/app/views/eic_dashboard/_menu.html.erb
+++ b/app/views/eic_dashboard/_menu.html.erb
@@ -2,5 +2,6 @@
   <div class="btn-group" role="group" aria-label="Paper Status">
     <%= link_to "Submissions overview", eic_dashboard_path, class: current_class?(eic_dashboard_path) %>
     <%= link_to "Editors", editors_path, class: current_class?(editors_path) %>
+    <%= link_to "Invitations", invitations_path, class: current_class?(invitations_path) %>
   </div>
 </div>

--- a/app/views/eic_dashboard/index.html.erb
+++ b/app/views/eic_dashboard/index.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-<p id="notice"><%= notice %></p>
+  <p id="notice"><%= notice %></p>
   <div class="col-7">
     <div class="welcome">Welcome, <%= current_user.editor.full_name %></div>
     <div class="hero-small dashboard">

--- a/app/views/invitations/index.html.erb
+++ b/app/views/invitations/index.html.erb
@@ -1,0 +1,49 @@
+<div class="container">
+  <p id="notice"><%= notice %></p>
+  <div class="col-7">
+    <div class="welcome">Editors in Chief Dashboard</div>
+    <div class="hero-small dashboard">
+      <div class="hero-title">
+        <%= image_tag "icon_papers.svg", height: "32px" %><h1>Invitations</h1>
+      </div>
+    </div>
+  </div>
+</div>
+
+<%= render partial: "eic_dashboard/menu" %>
+<div class="container">
+  <% if @invitations.empty? %>
+    <div class="generic-content-item">There are <b>no recent invitations</b> to show</div>
+  <% else %>
+    <table class="dashboard-table sortable">
+      <thead>
+        <tr class="text-nowrap">
+          <th scope="col">Editor</th>
+          <th scope="col" class="sorttable_nosort">Paper</th>
+          <th scope="col" class="sorttable_nosort">Invitation status</th>
+          <th scope="col">Date</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <%- @invitations.each do |invitation| %>
+        <tr>
+          <td sorttable_customkey=<%= invitation.editor.full_name %>>
+            <%= image_tag(avatar(invitation.editor.login), size: "24x24", class: "avatar", title: github_user_link(invitation.editor.login)) %>
+            <%= link_to invitation.editor.full_name, invitation.editor, title: "Editor profile" %>
+            (<%= link_to "@#{invitation.editor.login}", github_user_link(invitation.editor.login), title: "GitHub profile", target: "_blank" %>)
+          </td>
+          <td>
+            <%= link_to truncate(invitation.paper.title, length: 80), invitation.paper.meta_review_url, title: invitation.paper.title %>
+          </td>
+          <td><%= invitation_status(invitation) %></td>
+          <td sorttable_customkey=<%= invitation.created_at %>>Invited <%= time_ago_in_words(invitation.created_at) %> ago</td>
+        </tr>
+        <%- end %>
+      </tbody>
+    </table>
+    <div class="row">
+      <div class="pagination_helper">Displaying last <b><%= @invitations.size %></b> invitations</div>
+    </div>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
 
   resources :editors
+  resources :invitations, only: [:index]
   resources :papers do
     resources :votes, only: ['create']
 

--- a/db/migrate/20210325114224_create_invitations.rb
+++ b/db/migrate/20210325114224_create_invitations.rb
@@ -1,0 +1,12 @@
+class CreateInvitations < ActiveRecord::Migration[6.1]
+  def change
+    create_table :invitations do |t|
+      t.belongs_to :editor
+      t.belongs_to :paper
+      t.boolean :accepted, default: false
+      t.timestamps
+    end
+
+    add_index :invitations, :created_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_22_114454) do
+ActiveRecord::Schema.define(version: 2021_03_25_114224) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -30,13 +30,23 @@ ActiveRecord::Schema.define(version: 2021_02_22_114454) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id"
-    t.string "availability"
     t.string "availability_comment"
-    t.index ["availability"], name: "index_editors_on_availability"
+    t.string "availability"
     t.index ["user_id"], name: "index_editors_on_user_id"
   end
 
-  create_table "papers", id: :serial, force: :cascade do |t|
+  create_table "invitations", force: :cascade do |t|
+    t.bigint "editor_id"
+    t.bigint "paper_id"
+    t.boolean "accepted", default: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["created_at"], name: "index_invitations_on_created_at"
+    t.index ["editor_id"], name: "index_invitations_on_editor_id"
+    t.index ["paper_id"], name: "index_invitations_on_paper_id"
+  end
+
+  create_table "papers", force: :cascade do |t|
     t.string "title"
     t.string "state"
     t.string "repository_url"
@@ -52,10 +62,10 @@ ActiveRecord::Schema.define(version: 2021_02_22_114454) do
     t.text "paper_body"
     t.integer "meta_review_issue_id"
     t.string "suggested_editor"
+    t.string "kind"
     t.text "authors"
     t.text "citation_string"
     t.datetime "accepted_at"
-    t.string "kind"
     t.integer "editor_id"
     t.string "reviewers", default: [], array: true
     t.text "activities"
@@ -77,7 +87,7 @@ ActiveRecord::Schema.define(version: 2021_02_22_114454) do
     t.index ["user_id"], name: "index_papers_on_user_id"
   end
 
-  create_table "users", id: :serial, force: :cascade do |t|
+  create_table "users", force: :cascade do |t|
     t.string "provider"
     t.string "uid"
     t.string "name"

--- a/spec/controllers/dispatch_controller_spec.rb
+++ b/spec/controllers/dispatch_controller_spec.rb
@@ -126,7 +126,7 @@ describe DispatchController, type: :controller do
       expect(@paper.activities).to eq({"issues"=>{"commenters"=>{"pre-review"=>{}, "review"=>{}}, "comments"=>[], "last_comments" => {}, "last_edits"=>{"comment-editor"=>"2018-10-06T16:18:56Z"}}})
     end
 
-    it "should update the percent_complete value" do 
+    it "should update the percent_complete value" do
       expect(@paper.percent_complete).to eq(0.9375)
     end
 
@@ -316,6 +316,8 @@ describe DispatchController, type: :controller do
       post_params = { secret: "mooo", id: 1234, editor: "jimmy" }
 
       expect { post :api_editor_invite, params: post_params }.to change { ActionMailer::Base.deliveries.count }.by(1)
+      expect { post :api_editor_invite, params: post_params }.to change { editor.invitations.count }.by(1)
+      expect { post :api_editor_invite, params: post_params }.to change { paper.invitations.count }.by(1)
     end
 
     it "with the correct API key and invalid editor" do

--- a/spec/factories/editors.rb
+++ b/spec/factories/editors.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     kind { "topic" }
     first_name { "Person" }
     last_name { "McEditor" }
-    login { "mceditor" }
+    sequence(:login) {|n| "mceditor_#{n}" }
     email { "mceditor@example.com" }
     avatar_url { "http://placekitten.com/g/200" }
     categories { %w(topic1 topic2 topic3) }

--- a/spec/factories/invitations.rb
+++ b/spec/factories/invitations.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :invitation do
+    paper { create(:paper) }
+    editor { create(:editor) }
+
+    trait :pending do
+      accepted { false }
+    end
+
+    trait :accepted do
+      accepted { true }
+    end
+  end
+end

--- a/spec/models/editor_spec.rb
+++ b/spec/models/editor_spec.rb
@@ -25,9 +25,14 @@ RSpec.describe Editor, type: :model do
       association = Editor.reflect_on_association(:votes)
       expect(association.macro).to eq(:has_many)
     end
-    
+
     it "has many papers" do
       association = Editor.reflect_on_association(:papers)
+      expect(association.macro).to eq(:has_many)
+    end
+
+    it "has many invitations" do
+      association = Editor.reflect_on_association(:invitations)
       expect(association.macro).to eq(:has_many)
     end
   end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -11,4 +11,25 @@ describe Invitation do
     invitation.accept!
     expect(invitation).to be_accepted
   end
+
+  describe ".accept_if_pending" do
+    it "should accept the invitation if pending" do
+      pending_invitation = create(:invitation, :pending)
+      Invitation.accept_if_pending(pending_invitation.paper, pending_invitation.editor)
+      expect(pending_invitation.reload).to be_accepted
+    end
+
+    it "should do nothing if invitation already accepted" do
+      invitation = create(:invitation, :accepted)
+      expect { Invitation.accept_if_pending(invitation.paper, invitation.editor) }.to_not change { Invitation.pending.count }
+      expect { Invitation.accept_if_pending(invitation.paper, invitation.editor) }.to_not change { Invitation.accepted.count }
+    end
+
+    it "should do nothing if no invitation exists" do
+      create(:invitation, :accepted)
+      create(:invitation, :pending)
+      expect { Invitation.accept_if_pending(create(:paper), create(:editor)) }.to_not change { Invitation.pending.count }
+      expect { Invitation.accept_if_pending(create(:paper), create(:editor)) }.to_not change { Invitation.accepted.count }
+    end
+  end
 end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe Invitation do
+  it "at creation is not accepted" do
+    invitation = Invitation.create!(paper: create(:paper), editor: create(:editor))
+    expect(invitation).to_not be_accepted
+  end
+
+  it "can be accepted" do
+    invitation = Invitation.create!(paper: create(:paper), editor: create(:editor))
+    invitation.accept!
+    expect(invitation).to be_accepted
+  end
+end

--- a/spec/models/paper_spec.rb
+++ b/spec/models/paper_spec.rb
@@ -91,6 +91,25 @@ describe Paper do
     expect(paper.review_url).to eq("https://github.com/#{Rails.application.settings["reviews"]}/issues/999")
   end
 
+  describe "#set_editor" do
+    it "should update paper's editor" do
+      paper = create(:paper)
+      editor = create(:editor)
+
+      paper.set_editor editor
+      expect(paper.editor).to eq(editor)
+    end
+
+    it "should mark editor's pending invitation as accepted" do
+      paper = create(:paper)
+      editor = create(:editor)
+      invitation = create(:invitation, :pending, paper: paper, editor: editor)
+
+      paper.set_editor editor
+      expect(invitation.reload).to be_accepted
+    end
+  end
+
   describe "#invite_editor" do
     it "should return false if editor does not exist" do
       expect(create(:paper).invite_editor("invalid")).to be false

--- a/spec/system/invitations_spec.rb
+++ b/spec/system/invitations_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+feature "Invitations list" do
+  let(:user_editor) { create(:user, editor: create(:editor, first_name: "Lorena")) }
+  let(:admin) { create(:admin_user) }
+
+  scenario "Is not public" do
+    visit invitations_path
+    expect(page).to have_content("Please login first")
+  end
+
+  scenario "Is not available to non-eic users" do
+    login_as(user_editor)
+    visit invitations_path
+    expect(page).to have_content("You are not permitted to view that page")
+  end
+
+  scenario "Is visible to admins" do
+    login_as(admin)
+    visit invitations_path
+    expect(page).to_not have_content("You are not permitted to view that page")
+  end
+
+  feature "Logged as an admin" do
+    before do
+      create(:editor, first_name: "Tester",
+                      login: "tester",
+                      description: "Software testing editor",
+                      categories: ["Computing", "Test systems"],
+                      availability_comment: "Always available")
+      login_as(admin)
+    end
+
+    scenario "show no invitations message" do
+      visit invitations_path
+      expect(page).to_not have_content("Invitation status")
+      expect(page).to have_content("There are no recent invitations to show")
+    end
+
+    scenario "list invitations" do
+      create(:invitation, paper: create(:paper, title: "Test paper"), editor: create(:editor, login: "tester1"))
+      create(:invitation, paper: create(:paper, title: "Science paper"), editor: create(:editor, login: "user3"))
+      visit invitations_path
+
+      expect(page).to have_content("Test paper")
+      expect(page).to have_content("tester1")
+      expect(page).to have_content("Science paper")
+      expect(page).to have_content("user3")
+    end
+
+    scenario "show status for accepted invitations" do
+      create(:invitation, accepted: true)
+      visit invitations_path
+
+      expect(page).to have_content("✅ Accepted")
+    end
+
+    scenario "show status for pending invitations" do
+      create(:invitation, accepted: false)
+      visit invitations_path
+
+      expect(page).to have_content("⏳ Pending")
+    end
+
+    scenario "show status for rejected invitations" do
+      paper = create(:paper, review_issue_id: 42, editor: create(:editor, id: 33))
+      create(:invitation, accepted: false, paper: paper, editor: create(:editor, id: 21))
+      visit invitations_path
+
+      expect(page).to have_content("❌ Rejected")
+    end
+  end
+end


### PR DESCRIPTION
This PR adds tracking invitations capabilities to JOSS, logging everytime an editor is invited in a meta review issue via the "_invite editor_" bot command.
The recent invitations to editors are listed in the EiC dashboard.

![invitations](https://user-images.githubusercontent.com/6528/112986569-f1d42700-9161-11eb-8d88-a887e8fce605.png)
