### PR TITLE
Optimize invitations queries

### DIFF
--- a/app/controllers/editors_controller.rb
+++ b/app/controllers/editors_controller.rb
@@ -8,6 +8,8 @@ class EditorsController < ApplicationController
     @editors = Editor.all
     @assignment_by_editor = Paper.unscoped.in_progress.group(:editor_id).count
     @paused_by_editor = Paper.unscoped.in_progress.where("labels->>'paused' ILIKE '%'").group(:editor_id).count
+    @pending_invitations_by_editor = Invitation.pending.group(:editor_id).count
+    @pending_invitations = Invitation.includes(:paper).pending
   end
 
   def show

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -46,6 +46,8 @@ class HomeController < ApplicationController
                 )
     end
 
+    load_pending_invitations_for_papers(@papers)
+
     @editor = current_user.editor
 
     render template: "home/reviews"
@@ -97,6 +99,8 @@ class HomeController < ApplicationController
                 per_page: 20
               )
 
+    load_pending_invitations_for_papers(@papers)
+
     render template: "home/reviews"
   end
 
@@ -119,6 +123,7 @@ class HomeController < ApplicationController
               per_page: 20
             )
 
+    load_pending_invitations_for_papers(@papers)
 
     render template: "home/reviews"
   end
@@ -148,5 +153,9 @@ private
 
   def user_params
     params.require(:user).permit(:email, :github_username)
+  end
+
+  def load_pending_invitations_for_papers(papers)
+    @pending_invitations = Invitation.includes(:editor).pending.where(paper: papers)
   end
 end

--- a/app/helpers/editors_helper.rb
+++ b/app/helpers/editors_helper.rb
@@ -68,7 +68,7 @@ module EditorsHelper
 
     output = []
     @pending_invitations.each do |invite|
-      if invite.editor == editor
+      if invite.editor_id == editor.id
         output << link_to(invite.paper.meta_review_issue_id, invite.paper.meta_review_url)
       end
     end

--- a/app/helpers/editors_helper.rb
+++ b/app/helpers/editors_helper.rb
@@ -17,7 +17,7 @@ module EditorsHelper
     comment = "#{editor.max_assignments} max."
 
     display_count = editor.max_assignments
-    
+
     if editor.availability_comment.present?
       display_count = "#{display_count}*"
       comment += " : #{editor.availability_comment}"
@@ -55,7 +55,7 @@ module EditorsHelper
       ""
     end
   end
-  
+
   def in_progress_no_paused_for_editor(editor)
     paused_count = @paused_by_editor[editor.id].to_i
     total_paper_count = @assignment_by_editor[editor.id].to_i
@@ -64,13 +64,13 @@ module EditorsHelper
   end
 
   def open_invites_for_editor(editor)
-    invites = editor.invitations.pending
-
-    return "–" if invites.empty?
+    return "–" if @pending_invitations_by_editor[editor.id].to_i == 0
 
     output = []
-    invites.each do |invite|
-      output << link_to(invite.paper.meta_review_issue_id, invite.paper.meta_review_url)
+    @pending_invitations.each do |invite|
+      if invite.editor == editor
+        output << link_to(invite.paper.meta_review_issue_id, invite.paper.meta_review_url)
+      end
     end
 
     return output.join(" • ").html_safe

--- a/app/helpers/papers_helper.rb
+++ b/app/helpers/papers_helper.rb
@@ -145,15 +145,13 @@ module PapersHelper
   end
 
   def open_invites_for_paper(paper)
-    invites = paper.invitations.pending
-
-    return "–" if invites.empty?
-
     output = []
-    invites.each do |invite|
-      output << link_to(image_tag(avatar(invite.editor.login), size: "24x24", class: "avatar", title: "#{invite.editor.full_name} invited #{time_ago_in_words(invite.created_at)} ago"), invite.paper.meta_review_url)
+    @pending_invitations.each do |invite|
+      if invite.paper_id == paper.id
+        output << link_to(image_tag(avatar(invite.editor.login), size: "24x24", class: "avatar", title: "#{invite.editor.full_name} invited #{time_ago_in_words(invite.created_at)} ago"), paper.meta_review_url)
+      end
     end
 
-    return output.join(" • ").html_safe
+    return output.empty? ? "–" : output.join(" • ").html_safe
   end
 end

--- a/app/views/editors/index.html.erb
+++ b/app/views/editors/index.html.erb
@@ -36,7 +36,7 @@
         <td style="max-width:250px"><%= editor.category_list %></td>
         <td class="text-center" title="Max: <%= editor.max_assignments %>"><%= link_to in_progress_for_editor(editor), "/dashboard/#{editor.login}" %></td>
         <td class="text-center" title="Limit: <%= editor.max_assignments %>"><%= display_availability(editor) %></td>
-        <td sorttable_customkey=<%=editor.invitations.pending.count %> class="text-center" title="Invites"><%= open_invites_for_editor(editor) %></td>
+        <td sorttable_customkey=<%= @pending_invitations_by_editor[editor.id].to_i %> class="text-center" title="Invites"><%= open_invites_for_editor(editor) %></td>
         <td><%= link_to 'Edit', edit_editor_path(editor), title: 'Edit' %></td>
       </tr>
       <%- end %>


### PR DESCRIPTION
This PR speeds up the editors and papers listings in the dashboard preloading the queries for pending invitations