### PR TITLE
Update name change policy in line with COPE principles

### DIFF
--- a/docs/submitting.md
+++ b/docs/submitting.md
@@ -345,6 +345,6 @@ If you want to learn more details about the review process, take a look at the [
 
 Please write admin@theoj.org with confidential matters such as retraction requests, report of misconduct, and retroactive author name changes.
 
-In case of a legal name change, the DOI will be unchanged and the paper will be updated to use the new name and note that a name has been changed, but without identifying the author.
+In case of a name change, the DOI will be unchanged and the paper will be updated without publishing a correction notice or notifying co-authors.
 
 JOSS will also update CrossRef metadata.


### PR DESCRIPTION
I want to propose an update to JOSS’s name change policy, originally suggested by @jedbrown in #805.

In the months since, the Committee on Publication Ethics (COPE) has [formed a working group](https://publicationethics.org/news/update-cope-guidance-regarding-author-name-changes) to develop guidance for name changes based on [a set of high-level principles](https://publicationethics.org/news/vision-more-trans-inclusive-publishing-world). These have since been adopted by some [major](https://www.wiley.com/network/the-wiley-network/new-author-name-change-policy-supports-a-more-inclusive-publishing-environment) [publishers](https://www.elsevier.com/about/press-releases/corporate/elsevier-launches-a-trans-inclusive-name-change-policy).

JOSS’s current policy conflicts with the COPE principles in two points:

1. “In case of a legal name change” — As noted in COPE principle 1 (“Accessibility”), a legal name change may be inaccessible or completely impossible in many states or countries. I would suggest changing this to “In case of a name change”.

2. “the paper will be updated to use the new name and note that a name has been changed, but without identifying the author.” — If a paper has just a single author, noting that a name has been changed would automatically identify the author. Looking at papers published in JOSS between [March 31st](https://joss.theoj.org/papers/10.21105/joss.03078) and [today](https://joss.theoj.org/papers/10.21105/joss.03075)), almost half (9 out of 20) have just a single author. It would thus be better to change the name on the paper silently without adding a note, in line with COPE principle 3 (“Invisibility”).

Both suggested changes are included in this PR; please let me know if you have any questions or comments!