### PR TITLE
Extending editor metadata in JSON response

### DIFF
--- a/app/models/editor.rb
+++ b/app/models/editor.rb
@@ -51,6 +51,10 @@ class Editor < ApplicationRecord
     [first_name, last_name].join(" ")
   end
 
+  def orcid
+    user.uid
+  end
+
   def clear_title
     self.title = nil
   end

--- a/app/views/papers/show.json.jbuilder
+++ b/app/views/papers/show.json.jbuilder
@@ -10,6 +10,10 @@ if @paper.published?
   json.page @paper.page
   json.authors @paper.metadata_authors
   json.editor @paper.metadata_editor
+  if @paper.editor
+    json.editor_name @paper.editor.full_name
+    json.editor_url @paper.editor.url if @paper.editor.url
+  end
   json.reviewers @paper.metadata_reviewers
   json.languages @paper.language_tags.join(', ')
   json.tags @paper.author_tags.join(', ')

--- a/app/views/papers/show.json.jbuilder
+++ b/app/views/papers/show.json.jbuilder
@@ -13,6 +13,7 @@ if @paper.published?
   if @paper.editor
     json.editor_name @paper.editor.full_name
     json.editor_url @paper.editor.url if @paper.editor.url
+    json.editor_orcid @paper.editor.orcid
   end
   json.reviewers @paper.metadata_reviewers
   json.languages @paper.language_tags.join(', ')

--- a/spec/controllers/papers_controller_spec.rb
+++ b/spec/controllers/papers_controller_spec.rb
@@ -275,7 +275,8 @@ describe PapersController, type: :controller do
     end
 
     it "returns publication info for accepted papers" do
-      editor = create(:editor)
+      user = create(:user)
+      editor = create(:editor, user: user)
       paper = create(:accepted_paper, editor: editor)
       get :show, params: {doi: paper.doi}, format: "json"
       parsed_response = JSON.parse(response.body)
@@ -283,6 +284,7 @@ describe PapersController, type: :controller do
       expect(parsed_response["state"]).to eq("accepted")
       expect(parsed_response["editor"]).to eq("@arfon")
       expect(parsed_response["editor_name"]).to eq("Person McEditor")
+      expect(parsed_response["editor_orcid"]).to eq("0000-0000-0000-1234")
       expect(parsed_response["doi"]).to eq("10.21105/joss.00000")
       expect(parsed_response["published_at"]).to_not be_nil
     end

--- a/spec/controllers/papers_controller_spec.rb
+++ b/spec/controllers/papers_controller_spec.rb
@@ -275,12 +275,14 @@ describe PapersController, type: :controller do
     end
 
     it "returns publication info for accepted papers" do
-      paper = create(:accepted_paper)
+      editor = create(:editor)
+      paper = create(:accepted_paper, editor: editor)
       get :show, params: {doi: paper.doi}, format: "json"
       parsed_response = JSON.parse(response.body)
       expect(parsed_response["title"]).to eq(paper.title)
       expect(parsed_response["state"]).to eq("accepted")
       expect(parsed_response["editor"]).to eq("@arfon")
+      expect(parsed_response["editor_name"]).to eq("Person McEditor")
       expect(parsed_response["doi"]).to eq("10.21105/joss.00000")
       expect(parsed_response["published_at"]).to_not be_nil
     end


### PR DESCRIPTION
Augmenting what we did in #907

/ cc @tarleb 