### PR TITLE
Invitations improvements

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -6,4 +6,10 @@ class InvitationsController < ApplicationController
                               order(created_at: :desc).
                               paginate(page: params[:page], per_page: 25)
   end
+
+  def expire
+    @invitation = Invitation.pending.find(params[:id])
+    @invitation.expire! if @invitation
+    redirect_to invitations_path(page: params[:page].presence), notice: "Invitation canceled!"
+  end
 end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -2,6 +2,8 @@ class InvitationsController < ApplicationController
   before_action :require_admin_user
 
   def index
-    @invitations = Invitation.includes(:editor, :paper).order(created_at: :desc).limit(25)
+    @invitations = Invitation.includes(:editor, :paper).
+                              order(created_at: :desc).
+                              paginate(page: params[:page], per_page: 25)
   end
 end

--- a/app/helpers/invitations_helper.rb
+++ b/app/helpers/invitations_helper.rb
@@ -4,9 +4,8 @@ module InvitationsHelper
 
     if invitation.accepted?
       status = "✅ Accepted"
-    elsif invitation.paper.review_issue_id.present? &&
-          invitation.paper.editor_id != invitation.editor_id
-      status = "❌ Rejected"
+    elsif invitation.expired?
+      status = "❌ Expired"
     end
 
     status

--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -370,7 +370,7 @@ class Paper < ApplicationRecord
   # Updated the paper with the editor_id
   def set_editor(editor)
     self.update_attribute(:editor_id, editor.id)
-    Invitation.accept_if_pending(self, editor)
+    Invitation.resolve_pending(self, editor)
   end
 
   # Update the Paper review_issue_id field

--- a/app/views/invitations/index.html.erb
+++ b/app/views/invitations/index.html.erb
@@ -22,6 +22,7 @@
           <th scope="col" class="sorttable_nosort">Paper</th>
           <th scope="col" class="sorttable_nosort">Invitation status</th>
           <th scope="col">Date</th>
+          <th scope="col" class="sorttable_nosort">Actions</th>
         </tr>
       </thead>
 
@@ -38,6 +39,7 @@
           </td>
           <td><%= invitation_status(invitation) %></td>
           <td sorttable_customkey=<%= invitation.created_at %>>Invited <%= time_ago_in_words(invitation.created_at) %> ago</td>
+          <td><%= link_to("expire", expire_invitation_path(invitation, page: params[:page]), method: :put, data: {confirm: "Are you sure you want to mark this invitation as expired?" }) if invitation.pending? %></td>
         </tr>
         <%- end %>
       </tbody>

--- a/app/views/invitations/index.html.erb
+++ b/app/views/invitations/index.html.erb
@@ -43,7 +43,8 @@
       </tbody>
     </table>
     <div class="row">
-      <div class="pagination_helper">Displaying last <b><%= @invitations.size %></b> invitations</div>
+      <div class="pagination_helper"><%= page_entries_info(@invitations).capitalize.html_safe %></div>
+      <%= will_paginate @invitations, page_links: false %>
     </div>
   <% end %>
 </div>

--- a/app/views/invitations/index.html.erb
+++ b/app/views/invitations/index.html.erb
@@ -39,7 +39,7 @@
           </td>
           <td><%= invitation_status(invitation) %></td>
           <td sorttable_customkey=<%= invitation.created_at %>>Invited <%= time_ago_in_words(invitation.created_at) %> ago</td>
-          <td><%= link_to("expire", expire_invitation_path(invitation, page: params[:page]), method: :put, data: {confirm: "Are you sure you want to mark this invitation as expired?" }) if invitation.pending? %></td>
+          <td><%= link_to("Cancel", expire_invitation_path(invitation, page: params[:page]), method: :put, data: {confirm: "Are you sure you want to mark this invitation as expired?" }) if invitation.pending? %></td>
         </tr>
         <%- end %>
       </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
 
   resources :editors
-  resources :invitations, only: [:index]
+  resources :invitations, only: [:index] do
+    put 'expire', on: :member
+  end
   resources :papers do
     resources :votes, only: ['create']
 

--- a/db/migrate/20210505104138_add_state_to_invitations.rb
+++ b/db/migrate/20210505104138_add_state_to_invitations.rb
@@ -1,0 +1,24 @@
+class AddStateToInvitations < ActiveRecord::Migration[6.1]
+  def change
+    add_column :invitations, :state, :string, default: 'pending'
+
+    migrate_state
+
+    remove_column :invitations, :accepted
+
+    add_index :invitations, :state
+  end
+
+  def migrate_state
+    Invitation.includes(:paper).in_batches.each_record do |invitation|
+      if invitation.accepted == true
+        invitation.update_attribute(:state, 'accepted')
+      elsif invitation.paper.editor_id.present? && invitation.paper.editor_id != invitation.editor_id
+        invitation.update_attribute(:state, 'expired')
+      end
+
+      # If migration is rollbacked:
+      invitation.update_attribute(:accepted, true) if invitation.state == 'accepted'
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_25_114224) do
+ActiveRecord::Schema.define(version: 2021_05_05_104138) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -38,15 +38,16 @@ ActiveRecord::Schema.define(version: 2021_03_25_114224) do
   create_table "invitations", force: :cascade do |t|
     t.bigint "editor_id"
     t.bigint "paper_id"
-    t.boolean "accepted", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "state", default: "pending"
     t.index ["created_at"], name: "index_invitations_on_created_at"
     t.index ["editor_id"], name: "index_invitations_on_editor_id"
     t.index ["paper_id"], name: "index_invitations_on_paper_id"
+    t.index ["state"], name: "index_invitations_on_state"
   end
 
-  create_table "papers", id: :serial, force: :cascade do |t|
+  create_table "papers", force: :cascade do |t|
     t.string "title"
     t.string "state"
     t.string "repository_url"
@@ -62,10 +63,10 @@ ActiveRecord::Schema.define(version: 2021_03_25_114224) do
     t.text "paper_body"
     t.integer "meta_review_issue_id"
     t.string "suggested_editor"
+    t.string "kind"
     t.text "authors"
     t.text "citation_string"
     t.datetime "accepted_at"
-    t.string "kind"
     t.integer "editor_id"
     t.string "reviewers", default: [], array: true
     t.text "activities"
@@ -87,7 +88,7 @@ ActiveRecord::Schema.define(version: 2021_03_25_114224) do
     t.index ["user_id"], name: "index_papers_on_user_id"
   end
 
-  create_table "users", id: :serial, force: :cascade do |t|
+  create_table "users", force: :cascade do |t|
     t.string "provider"
     t.string "uid"
     t.string "name"

--- a/spec/factories/invitations.rb
+++ b/spec/factories/invitations.rb
@@ -4,11 +4,15 @@ FactoryBot.define do
     editor { create(:editor) }
 
     trait :pending do
-      accepted { false }
+      state { 'pending' }
     end
 
     trait :accepted do
-      accepted { true }
+      state { 'accepted' }
+    end
+
+    trait :expired do
+      state { 'expired' }
     end
   end
 end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -12,24 +12,40 @@ describe Invitation do
     expect(invitation).to be_accepted
   end
 
-  describe ".accept_if_pending" do
-    it "should accept the invitation if pending" do
+  it "can be expired" do
+    invitation = Invitation.create!(paper: create(:paper), editor: create(:editor))
+    invitation.expire!
+    expect(invitation).to be_expired
+  end
+
+  describe ".resolve_pending" do
+    it "should accept the pending invitation of the assigned editor" do
       pending_invitation = create(:invitation, :pending)
-      Invitation.accept_if_pending(pending_invitation.paper, pending_invitation.editor)
+      Invitation.resolve_pending(pending_invitation.paper, pending_invitation.editor)
       expect(pending_invitation.reload).to be_accepted
     end
 
     it "should do nothing if invitation already accepted" do
       invitation = create(:invitation, :accepted)
-      expect { Invitation.accept_if_pending(invitation.paper, invitation.editor) }.to_not change { Invitation.pending.count }
-      expect { Invitation.accept_if_pending(invitation.paper, invitation.editor) }.to_not change { Invitation.accepted.count }
+      expect { Invitation.resolve_pending(invitation.paper, invitation.editor) }.to_not change { Invitation.pending.count }
+      expect { Invitation.resolve_pending(invitation.paper, invitation.editor) }.to_not change { Invitation.accepted.count }
+    end
+
+    it "should expire invitations to not assigned editors" do
+      invitation_1 = create(:invitation, :pending)
+      invitation_2 = create(:invitation, :pending, paper: invitation_1.paper)
+      assigned_editor = create(:editor)
+
+      Invitation.resolve_pending(invitation_1.paper, assigned_editor)
+      expect(invitation_1.reload).to be_expired
+      expect(invitation_2.reload).to be_expired
     end
 
     it "should do nothing if no invitation exists" do
       create(:invitation, :accepted)
       create(:invitation, :pending)
-      expect { Invitation.accept_if_pending(create(:paper), create(:editor)) }.to_not change { Invitation.pending.count }
-      expect { Invitation.accept_if_pending(create(:paper), create(:editor)) }.to_not change { Invitation.accepted.count }
+      expect { Invitation.resolve_pending(create(:paper), create(:editor)) }.to_not change { Invitation.pending.count }
+      expect { Invitation.resolve_pending(create(:paper), create(:editor)) }.to_not change { Invitation.accepted.count }
     end
   end
 end

--- a/spec/models/paper_spec.rb
+++ b/spec/models/paper_spec.rb
@@ -108,6 +108,17 @@ describe Paper do
       paper.set_editor editor
       expect(invitation.reload).to be_accepted
     end
+
+    it "should expire other editor's pending invitations" do
+      paper = create(:paper)
+      editor = create(:editor)
+      invitation_1 = create(:invitation, :pending, paper: paper)
+      invitation_2 = create(:invitation, :pending, paper: paper)
+
+      paper.set_editor editor
+      expect(invitation_1.reload).to be_expired
+      expect(invitation_2.reload).to be_expired
+    end
   end
 
   describe "#invite_editor" do

--- a/spec/system/invitations_spec.rb
+++ b/spec/system/invitations_spec.rb
@@ -48,6 +48,27 @@ feature "Invitations list" do
       expect(page).to have_content("user3")
     end
 
+    scenario "expire invitations" do
+      invitation = create(:invitation, :pending)
+      visit invitations_path
+
+      expect(page).to have_content("⏳ Pending")
+      expect(page).to have_link("expire", href: expire_invitation_path(invitation))
+      click_link "expire"
+      expect(page).to have_content("Invitation canceled")
+      expect(page).to have_content("❌ Expired")
+      expect(page).to_not have_link("expire")
+      expect(page).to_not have_content("⏳ Pending")
+    end
+
+    scenario "only pending invitations can be canceled" do
+      create(:invitation, :accepted)
+      create(:invitation, :expired)
+      visit invitations_path
+
+      expect(page).to_not have_link("expire")
+    end
+
     scenario "paginate invitations" do
       create_list(:invitation, 10, :accepted)
       create_list(:invitation, 10, :pending)

--- a/spec/system/invitations_spec.rb
+++ b/spec/system/invitations_spec.rb
@@ -49,25 +49,24 @@ feature "Invitations list" do
     end
 
     scenario "show status for accepted invitations" do
-      create(:invitation, accepted: true)
+      create(:invitation, :accepted)
       visit invitations_path
 
       expect(page).to have_content("✅ Accepted")
     end
 
     scenario "show status for pending invitations" do
-      create(:invitation, accepted: false)
+      create(:invitation, :pending)
       visit invitations_path
 
       expect(page).to have_content("⏳ Pending")
     end
 
-    scenario "show status for rejected invitations" do
-      paper = create(:paper, review_issue_id: 42, editor: create(:editor, id: 33))
-      create(:invitation, accepted: false, paper: paper, editor: create(:editor, id: 21))
+    scenario "show status for expired invitations" do
+      create(:invitation, :expired)
       visit invitations_path
 
-      expect(page).to have_content("❌ Rejected")
+      expect(page).to have_content("❌ Expired")
     end
   end
 end

--- a/spec/system/invitations_spec.rb
+++ b/spec/system/invitations_spec.rb
@@ -53,11 +53,11 @@ feature "Invitations list" do
       visit invitations_path
 
       expect(page).to have_content("⏳ Pending")
-      expect(page).to have_link("expire", href: expire_invitation_path(invitation))
-      click_link "expire"
+      expect(page).to have_link("Cancel", href: expire_invitation_path(invitation))
+      click_link "Cancel"
       expect(page).to have_content("Invitation canceled")
       expect(page).to have_content("❌ Expired")
-      expect(page).to_not have_link("expire")
+      expect(page).to_not have_link("Cancel")
       expect(page).to_not have_content("⏳ Pending")
     end
 
@@ -66,7 +66,7 @@ feature "Invitations list" do
       create(:invitation, :expired)
       visit invitations_path
 
-      expect(page).to_not have_link("expire")
+      expect(page).to_not have_link("Cancel")
     end
 
     scenario "paginate invitations" do

--- a/spec/system/invitations_spec.rb
+++ b/spec/system/invitations_spec.rb
@@ -48,6 +48,16 @@ feature "Invitations list" do
       expect(page).to have_content("user3")
     end
 
+    scenario "paginate invitations" do
+      create_list(:invitation, 10, :accepted)
+      create_list(:invitation, 10, :pending)
+      create_list(:invitation, 10, :expired)
+      visit invitations_path
+
+      expect(page).to have_content("Displaying invitation 1 - 25 of 30 in total")
+      expect(page).to have_link("Next →", href: invitations_path(page:2))
+    end
+
     scenario "show status for accepted invitations" do
       create(:invitation, :accepted)
       visit invitations_path


### PR DESCRIPTION
This PR refactors the invitations state to be one of [`accepted`/`pending`/`expired`] and better show them in the UI.

Now whenever an editor is assigned to a paper, any other pending invitation to other people to edit that paper is expired.