### PR TITLE
Adding status badge to pre-review issue

### DIFF
--- a/app/views/shared/meta_view_body.text.erb
+++ b/app/views/shared/meta_view_body.text.erb
@@ -9,6 +9,18 @@
 
 Due to the challenges of the COVID-19 pandemic, JOSS is currently operating in a "reduced service mode". You can read more about what that means in [our blog post](https://blog.joss.theoj.org/2020/05/reopening-joss).
 
+## Status
+
+<%- url = Rails.application.settings["url"] %>
+[![status](<%= url %>/papers/<%= paper.sha %>/status.svg)](<%= url %>/papers/<%= paper.sha %>)
+
+Status badge code:
+
+```
+HTML: <a href="<%= url %>/papers/<%= paper.sha %>"><img src="<%= url %>/papers/<%= paper.sha %>/status.svg"></a>
+Markdown: [![status](<%= url %>/papers/<%= paper.sha %>/status.svg)](<%= url %>/papers/<%= paper.sha %>)
+```
+
 **Author instructions**
 
 <%- abbreviation, reviewers = Rails.application.settings.values_at("abbreviation", "reviewers") %>


### PR DESCRIPTION
This adds the embeddable JOSS badge to the pre-review issues, like they are in the main review threads.