### PR TITLE
review_criteria: remove specific call-out of Travis-CI

### DIFF
--- a/docs/review_criteria.md
+++ b/docs/review_criteria.md
@@ -94,7 +94,7 @@ Reviewers are expected to install the software they are reviewing and to verify 
 
 Authors are strongly encouraged to include an automated test suite covering the core functionality of their software.
 
-> **Good:** An automated test suite hooked up to an external service such as Travis-CI or similar<br />
+> **Good:** An automated test suite hooked up to continuous integration<br />
 > **OK:** Documented manual steps that can be followed to objectively check the expected functionality of the software (e.g., a sample input file to assert behavior)<br />
 > **Bad (not acceptable):** No way for you, the reviewer, to objectively assess whether the software works
 

--- a/docs/review_criteria.md
+++ b/docs/review_criteria.md
@@ -94,7 +94,7 @@ Reviewers are expected to install the software they are reviewing and to verify 
 
 Authors are strongly encouraged to include an automated test suite covering the core functionality of their software.
 
-> **Good:** An automated test suite hooked up to continuous integration<br />
+> **Good:** An automated test suite hooked up to continuous integration (GitHub Actions, Circle CI, or similar)<br />
 > **OK:** Documented manual steps that can be followed to objectively check the expected functionality of the software (e.g., a sample input file to assert behavior)<br />
 > **Bad (not acceptable):** No way for you, the reviewer, to objectively assess whether the software works
 


### PR DESCRIPTION
There are many continuous integration providers, hosted and not.
Travis-CI changed their open source policy and many packages moved away.
GitHub Actions is the most convenient for projects on GitHub first
considering CI, but docs are accessible enough we don't need to plug
them specifically.