### PR TITLE
Adding packaging requirement to submission docs

### DIFF
--- a/docs/review_criteria.md
+++ b/docs/review_criteria.md
@@ -56,7 +56,7 @@ The authors should clearly state what problems the software is designed to solve
 
 #### Installation instructions
 
-Software depdendencies should be clearly documented and their installation handled by an automated proceedure. Where possible, software installation should be managed with a package manager. However, this criterion depends upon the maturity and availability of software packaging and distribution in the programming language being used. For example, Python packages should be `pip install`able, and have adopted [packaging conventions](https://packaging.python.org), while Fortran submissions with a Makefile may be sufficient.
+Software dependencies should be clearly documented and their installation handled by an automated proceedure. Where possible, software installation should be managed with a package manager. However, this criterion depends upon the maturity and availability of software packaging and distribution in the programming language being used. For example, Python packages should be `pip install`able, and have adopted [packaging conventions](https://packaging.python.org), while Fortran submissions with a Makefile may be sufficient.
 
 > **Good:** The software is simple to install, and follows established distribution and dependency management approaches for the language being used<br />
 > **OK:** A list of dependencies to install, together with some kind of script to handle their installation (e.g., a Makefile<br />

--- a/docs/review_criteria.md
+++ b/docs/review_criteria.md
@@ -56,11 +56,11 @@ The authors should clearly state what problems the software is designed to solve
 
 #### Installation instructions
 
-There should be a clearly-stated list of dependencies. Ideally these should be handled with an automated package management solution.
+Software depdendencies should be clearly documented and their installation handled by an automated proceedure. Where possible software installation should be managed with a package manager, however this criterion depends upon the maturity and availability of software packaging and distribution in the programming language being used. For example, Python packages should be `pip install`able, and have adopted [packaging conventions](https://packaging.python.org), Fortran submissions with a Makefile may be sufficient.
 
-> **Good:** A package management file such as a Gemfile or package.json or equivalent<br />
-> **OK:** A list of dependencies to install<br />
-> **Bad (not acceptable):** Reliance on other software not listed by the authors
+> **Good:** The software is simple to install, and follows established distribution and dependency management approaches for the language being used<br />
+> **OK:** A list of dependencies to install, together with some kind of script to handle their installation (e.g., a Makefile<br />
+> **Bad (not acceptable):** Dependencies are unclear, and/or installation process lacks automation
 
 #### Example usage
 

--- a/docs/review_criteria.md
+++ b/docs/review_criteria.md
@@ -56,7 +56,7 @@ The authors should clearly state what problems the software is designed to solve
 
 #### Installation instructions
 
-Software depdendencies should be clearly documented and their installation handled by an automated proceedure. Where possible software installation should be managed with a package manager, however this criterion depends upon the maturity and availability of software packaging and distribution in the programming language being used. For example, Python packages should be `pip install`able, and have adopted [packaging conventions](https://packaging.python.org), Fortran submissions with a Makefile may be sufficient.
+Software depdendencies should be clearly documented and their installation handled by an automated proceedure. Where possible, software installation should be managed with a package manager. However, this criterion depends upon the maturity and availability of software packaging and distribution in the programming language being used. For example, Python packages should be `pip install`able, and have adopted [packaging conventions](https://packaging.python.org), while Fortran submissions with a Makefile may be sufficient.
 
 > **Good:** The software is simple to install, and follows established distribution and dependency management approaches for the language being used<br />
 > **OK:** A list of dependencies to install, together with some kind of script to handle their installation (e.g., a Makefile<br />

--- a/docs/submitting.md
+++ b/docs/submitting.md
@@ -36,7 +36,7 @@ As a rule of thumb, JOSS' minimum allowable contribution should represent **not 
 - Whether the software has already been cited in academic papers.
 - Whether the software is sufficiently useful that it is _likely to be cited_ by your peer group.
 
-In addition, JOSS requires that software should be feature-complete (i.e., no half-baked solutions), packaged appropriately according to common community standards for the programming language being used, and designed for maintainable extension (not one-off modifications of existing tools). "Minor utility" packages, including "thin" API clients, and single-function packages are not acceptable.
+In addition, JOSS requires that software should be feature-complete (i.e., no half-baked solutions), packaged appropriately according to common community standards for the programming language being used (e.g., [Python](https://packaging.python.org), [R](https://r-pkgs.org/index.html)), and designed for maintainable extension (not one-off modifications of existing tools). "Minor utility" packages, including "thin" API clients, and single-function packages are not acceptable.
 
 ### Co-publication of science, methods, and software
 

--- a/docs/submitting.md
+++ b/docs/submitting.md
@@ -36,7 +36,7 @@ As a rule of thumb, JOSS' minimum allowable contribution should represent **not 
 - Whether the software has already been cited in academic papers.
 - Whether the software is sufficiently useful that it is _likely to be cited_ by your peer group.
 
-In addition, JOSS requires that software should be feature-complete (i.e. no half-baked solutions) and designed for maintainable extension (not one-off modifications of existing tools). "Minor utility" packages, including "thin" API clients, and single-function packages are not acceptable.
+In addition, JOSS requires that software should be feature-complete (i.e., no half-baked solutions), packaged appropriately according to common community standards for the programming language being used, and designed for maintainable extension (not one-off modifications of existing tools). "Minor utility" packages, including "thin" API clients, and single-function packages are not acceptable.
 
 ### Co-publication of science, methods, and software
 


### PR DESCRIPTION
Many submissions to JOSS require significant work to improve their packaging. We don't really want reviewers to have to point this out to authors, instead we should catch this at the pre-review stage and hold back from review until the software is appropriately packaged.

Examples of guidelines we could point authors to include:

- https://packaging.python.org
- https://r-pkgs.org/index.html
- https://www.digitalocean.com/community/tutorials/how-to-package-and-distribute-ruby-applications-as-a-gem-using-rubygems

Related to https://github.com/openjournals/joss/issues/680 and https://github.com/openjournals/joss/issues/469