### PR TITLE
Handle case of missing user (ORCID)

### DIFF
--- a/app/views/papers/show.json.jbuilder
+++ b/app/views/papers/show.json.jbuilder
@@ -14,7 +14,7 @@ if @paper.published?
   if @paper.editor
     json.editor_name @paper.editor.full_name
     json.editor_url @paper.editor.url if @paper.editor.url
-    json.editor_orcid @paper.editor.orcid
+    json.editor_orcid @paper.editor.orcid if @paper.editor.user
   end
   json.reviewers @paper.metadata_reviewers
   json.languages @paper.language_tags.join(', ')


### PR DESCRIPTION
For a few old papers, we don't have a user record associated with he editor. This means the current logic raises an exception...