### PR TITLE
Expire invitations to rejected papers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 ruby '3.0.0'
 
-gem 'aasm', '~> 5.0.5'
+gem 'aasm', '~> 5.2.0'
 gem 'chartkick'
 gem 'bootsnap'
 gem 'dotenv', '~> 2.7.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (1.1.0)
-    aasm (5.0.8)
+    aasm (5.2.0)
       concurrent-ruby (~> 1.0)
     actioncable (6.1.4.1)
       actionpack (= 6.1.4.1)
@@ -430,7 +430,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aasm (~> 5.0.5)
+  aasm (~> 5.2.0)
   active_link_to
   bootsnap
   bootstrap (~> 4.3.1)

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -39,4 +39,8 @@ class Invitation < ApplicationRecord
       end
     end
   end
+
+  def self.expire_all_for_paper(paper)
+    pending.where(paper: paper).update_all(state: "expired")
+  end
 end

--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -43,7 +43,7 @@ class Paper < ApplicationRecord
     state :withdrawn
 
     event :reject do
-      transitions to: :rejected
+      transitions to: :rejected, after: :expire_invitations
     end
 
     event :start_meta_review do
@@ -174,6 +174,10 @@ class Paper < ApplicationRecord
     return false unless editor = Editor.find_by_login(editor_handle)
     Notifications.editor_invite_email(self, editor).deliver_now
     invitations.create(editor: editor)
+  end
+
+  def expire_invitations
+    Invitation.expire_all_for_paper(self)
   end
 
   def scholar_title

--- a/spec/models/paper_spec.rb
+++ b/spec/models/paper_spec.rb
@@ -168,6 +168,18 @@ describe Paper do
 
       expect(paper.state).to eq('rejected')
     end
+
+    it "should expire all pending invitations" do
+      paper = create(:paper, state: "submitted")
+      invitation_1 = create(:invitation, :pending, paper: paper)
+      invitation_2 = create(:invitation, :pending, paper: paper)
+
+      paper.reject!
+
+      expect(invitation_1.reload).to be_expired
+      expect(invitation_2.reload).to be_expired
+      expect(paper.state).to eq('rejected')
+    end
   end
 
   context "when starting review" do


### PR DESCRIPTION
When a paper is rejected all the pending invitations to edit should be expired.