### PR TITLE
Copy and paste editor feedback

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -21,9 +21,14 @@
 $(document).ready(function(){
   var clipboard = new Clipboard('.clipboard-btn', {
     text: function(trigger) {
-      target = trigger.getAttribute('data-clipboard-target').substring(1);
-      console.log(target);
-      return document.getElementById(target).innerHTML;
+      if (trigger.getAttribute('data-clipboard-target')) {
+        target = trigger.getAttribute('data-clipboard-target').substring(1);
+        console.log(target);
+        return document.getElementById(target).innerHTML;
+      } 
+      else if (trigger.getAttribute('data-clipboard-text')) {
+        return trigger.getAttribute('data-clipboard-text');
+      } 
     }
   });
 });

--- a/app/views/papers/_vote_summary.html.erb
+++ b/app/views/papers/_vote_summary.html.erb
@@ -53,7 +53,7 @@
               <% end %>
             </td>
             <td><small><%= vote.editor.user.name %> (<%= vote.editor.login %>)</small></td>
-            <td><small><%= vote_comment_preview(vote) %></small></td>
+            <td><small><%= octicon "clippy", "data-clipboard-action": "copy", "data-clipboard-text": "#{vote.comment}", height: 16, class: "clipboard-btn", style: "cursor: pointer;" %> <%= vote_comment_preview(vote) %></small></td>
             <td><small><%= time_ago_in_words(vote.created_at) %> ago</small></td>
           </tr>
           <% end %>


### PR DESCRIPTION
This PR adds a button to make it possible to copy editor scope review feedback.

![Screenshot_2021-12-03_at_06_46_00](https://user-images.githubusercontent.com/4483/144557918-de2c7785-595f-4794-a184-e4fb44b7f683.jpg)

/ cc @openjournals/joss-eics 