### PR TITLE
Add warning to users about figure file in draft paper example

### DIFF
--- a/docs/submitting.md
+++ b/docs/submitting.md
@@ -193,12 +193,16 @@ For a quick reference, the following citation commands can be used:
 
 # Figures
 
+<!-- Warning: The JOSS GitHub action will fail here if the figure.png file is not available. -->
+<!--          The following code is included to illustrate how to insert figures.
+<!--
 Figures can be included like this:
 ![Caption for example figure.\label{fig:example}](figure.png)
 and referenced from text using \autoref{fig:example}.
 
 Figure sizes can be customized by adding an optional second parameter:
 ![Caption for example figure.](figure.png){ width=20% }
+-->
 
 # Acknowledgements
 

--- a/docs/submitting.md
+++ b/docs/submitting.md
@@ -194,7 +194,7 @@ For a quick reference, the following citation commands can be used:
 # Figures
 
 <!-- Warning: The JOSS GitHub action will fail here if the figure.png file is not available. -->
-<!--          The following code is included to illustrate how to insert figures.
+<!--          The following code is included to illustrate how to insert figures. -->
 <!--
 Figures can be included like this:
 ![Caption for example figure.\label{fig:example}](figure.png)


### PR DESCRIPTION
See https://github.com/openjournals/openjournals-draft-action/issues/3. I suggested to comment out the figure code in the draft example for users who would like to try the github action. The code should remain to illustrate how to insert figures. 