### PR TITLE
Draft: Statement of need: context of related work

### DIFF
--- a/app/views/content/github/_review_checklist.erb
+++ b/app/views/content/github/_review_checklist.erb
@@ -33,7 +33,7 @@
 ### Software paper
 
 - [ ] **Summary:** Has a clear description of the high-level functionality and purpose of the software for a diverse, non-specialist audience been provided?
-- [ ] **A statement of need:** Does the paper have a section titled 'Statement of Need' that clearly states what problems the software is designed to solve and who the target audience is?
+- [ ] **A statement of need:** Does the paper have a section titled 'Statement of need' that clearly states what problems the software is designed to solve, who the target audience is, and its relation to other work?
 - [ ] **State of the field:** Do the authors describe how this software compares to other commonly-used packages?
 - [ ] **Quality of writing:** Is the paper well written (i.e., it does not require editing for structure, language, or writing quality)?
 - [ ] **References:** Is the list of references complete, and is everything cited appropriately that should be cited (e.g., papers, datasets, software)? Do references in the text use the proper [citation syntax]( https://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html#citation_syntax)?

--- a/docs/review_checklist.md
+++ b/docs/review_checklist.md
@@ -40,7 +40,7 @@ Below is an example of the review checklist for the [Yellowbrick JOSS submission
 ### Software paper
 
 - **Summary:** Has a clear description of the high-level functionality and purpose of the software for a diverse, non-specialist audience been provided?
-- **A statement of need:** Does the paper have a section titled 'Statement of Need' that clearly states what problems the software is designed to solve and who the target audience is?
+- **A statement of need:** Does the paper have a section titled 'Statement of need' that clearly states what problems the software is designed to solve, who the target audience is, and its relation to other work?
 - **State of the field:** Do the authors describe how this software compares to other commonly-used packages?
 - **Quality of writing:** Is the paper well written (i.e., it does not require editing for structure, language, or writing quality)?
 - **References:** Is the list of references complete, and is everything cited appropriately that should be cited (e.g., papers, datasets, software)? Do references in the text use the proper [citation syntax]( https://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html#citation_syntax)?

--- a/docs/review_criteria.md
+++ b/docs/review_criteria.md
@@ -52,7 +52,7 @@ There should be sufficient documentation for you, the reviewer to understand the
 
 #### A statement of need
 
-The authors should clearly state what problems the software is designed to solve and who the target audience is.
+The authors should clearly state what problems the software is designed to solve, who the target audience is, and its relation to other work.
 
 #### Installation instructions
 

--- a/docs/submitting.md
+++ b/docs/submitting.md
@@ -78,12 +78,12 @@ Your paper should include:
 
 - A list of the authors of the software and their affiliations, using the correct format (see the example below).
 - A summary describing the high-level functionality and purpose of the software for a diverse, *non-specialist audience*.
-- A *Statement of Need* section that clearly illustrates the research purpose of the software.
+- A *Statement of need* section that clearly illustrates the research purpose of the software and places it in the context of related work.
 - A list of key references, including to other software addressing related needs. Note that the references should include full names of venues, e.g., journals and conferences, not abbreviations only understood in the context of a specific discipline.
 - Mention (if applicable) a representative set of past or ongoing research projects using the software and recent scholarly publications enabled by it.
 - Acknowledgement of any financial support.
 
-As this short list shows, JOSS papers are only expected to contain a limited set of metadata (see example below), a Statement of Need, Summary, Acknowledgements, and References sections. You can look at an [example accepted paper](http://bit.ly/2x22gxT). Given this format, a "full length" paper is not permitted, and software documentation such as API (Application Programming Interface) functionality should not be in the paper and instead should be outlined in the software documentation.
+As this short list shows, JOSS papers are only expected to contain a limited set of metadata (see example below), a Statement of need, Summary, Acknowledgements, and References sections. You can look at an [example accepted paper](http://bit.ly/2x22gxT). Given this format, a "full length" paper is not permitted, and software documentation such as API (Application Programming Interface) functionality should not be in the paper and instead should be outlined in the software documentation.
 
 ```eval_rst
 .. important:: Your paper will be reviewed by two or more reviewers in a public GitHub issue. Take a look at the `review checklist <review_checklist.html>`_ and  `review criteria <review_criteria.html>`_ to better understand how your submission will be reviewed.

--- a/docs/whedon.md
+++ b/docs/whedon.md
@@ -62,7 +62,7 @@ EDITORIAL TASKS
 @whedon check references
 
 # Ask Whedon to check repository statistics for the submitted software, for license, and
-# for Statement of Need section in paper
+# for Statement of need section in paper
 @whedon check repository
 
 EiC TASKS


### PR DESCRIPTION
I find it frustrating when software and JOSS submissions don't mention related work, which sometimes overlaps heavily with the new capability. While JOSS papers don't have a scientific novelty standard, I think we should be explicit that authors are expected to cite alternatives, especially well-known alternatives, and explain what they're bringing to the table.

This is `Draft` because the text is reproduced in various other places (perhaps generated files) and I'd like to get consensus wording before propagating.