### PR TITLE
Update link to Markdown citation syntax docs

### DIFF
--- a/docs/submitting.md
+++ b/docs/submitting.md
@@ -273,7 +273,7 @@ Example `paper.bib` file:
 }
 ```
 
-Note that the paper ends with a References heading, and the references are built automatically from the content in the `.bib` file. You should enter in-text citations in the paper body following correct [Markdown citation syntax](https://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html#citation_syntax).  Also note that the references include full names of venues, e.g., journals and conferences, not abbreviations only understood in the context of a specific discipline.
+Note that the paper ends with a References heading, and the references are built automatically from the content in the `.bib` file. You should enter in-text citations in the paper body following correct [Markdown citation syntax](https://pandoc.org/MANUAL.html#extension-citations).  Also note that the references include full names of venues, e.g., journals and conferences, not abbreviations only understood in the context of a specific discipline.
 
 ## Checking that your paper compiles
 


### PR DESCRIPTION
Since the previous link to rstudio docs now redirects to an unhelpful section of pandoc docs

Old: https://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html#citation_syntax -> https://pandoc.org/MANUAL.html#citations

New: https://pandoc.org/MANUAL.html#extension-citations