### PR TITLE
Add required PMC policies

### DIFF
--- a/docs/policies.md
+++ b/docs/policies.md
@@ -9,7 +9,7 @@ We recommend that authors replace, reduce, and refine animal research as promote
 
 ## Data sharing policy
 
-If any original data analysis results are provided within the manuscript, this analysis has to be entirely reproducible by reviewers, including accessing the data. Submissions are by definition contained within a repository and we require authors to archive their software before we accept.
+If any original data analysis results are provided within the submitted work, such results have to be entirely reproducible by reviewers, including accessing the data. Submissions are, by definition, contained within a repository and we require authors to archive their software before we accept.
 
 ## Human participants research policy
 

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -9,7 +9,10 @@ We recommend that authors replace, reduce, and refine animal research as promote
 
 ## Data sharing policy
 
-If any original data analysis results are provided within the submitted work, such results have to be entirely reproducible by reviewers, including accessing the data. Submissions are, by definition, contained within a repository and we require authors to archive their software before we accept.
+If any original data analysis results are provided within the submitted work, such results have to be entirely reproducible by reviewers, including accessing the data.
+
+Submissions are, by definition, contained within one or multiple repositories, which we require authors to archive before we accept the submission. Any data contained within the software is made available accordingly.
+
 
 ## Human participants research policy
 

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -3,7 +3,7 @@ JOSS Policies
 
 ## Animal research policy
 
-In the exceptional case a JOSS submission contains original data on animal research, the corresponding author must confirm that the data was collected in accordance with the latest guidelines and applicable regulations. The manuscript must include complete reporting of the data, including the ways that the study was approved and relevant details of the sample. Authors are required to report either the [ARRIVE](https://arriveguidelines.org/) or PREPARE guidelines for animal research in the submission. 
+In the exceptional case a JOSS submission contains original data on animal research, the corresponding author must confirm that the data was collected in accordance with the latest guidelines and applicable regulations. The manuscript must include complete reporting of the data, including the ways that the study was approved and relevant details of the sample. Authors are required to report either the [ARRIVE](https://arriveguidelines.org/) or [PREPARE](https://doi.org/10.1177/0023677217724823) guidelines for animal research in the submission. 
 
 We recommend that authors replace, reduce, and refine animal research as promoted by the [N3RS](https://www.nc3rs.org.uk/).
 

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -5,7 +5,7 @@ JOSS Policies
 
 In the exceptional case a JOSS submission contains original data on animal research, the corresponding author must confirm that the data was collected in accordance with the latest guidelines and applicable regulations. The manuscript must include complete reporting of the data, including the ways that the study was approved and relevant details of the sample. Authors are required to report either the [ARRIVE](https://arriveguidelines.org/) or PREPARE guidelines for animal research in the submission. 
 
-We recommend authors to replace, reduce, and refine animal research as promoted by the [N3RS](https://www.nc3rs.org.uk/).
+We recommend that authors replace, reduce, and refine animal research as promoted by the [N3RS](https://www.nc3rs.org.uk/).
 
 ## Data sharing policy
 

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -1,0 +1,16 @@
+JOSS Policies
+==========================
+
+## Animal research policy
+
+In the exceptional case a JOSS submission contains original data on animal research, the corresponding author must confirm that the data was collected in accordance with the latest guidelines and applicable regulations. The manuscript must include complete reporting of the data, including the ways that the study was approved and relevant details of the sample. Authors are required to report either the [ARRIVE](https://arriveguidelines.org/) or PREPARE guidelines for animal research in the submission. 
+
+We recommend authors to replace, reduce, and refine animal research as promoted by the [N3RS](https://www.nc3rs.org.uk/).
+
+## Data sharing policy
+
+If any original data analysis results are provided within the manuscript, this analysis has to be entirely reproducible by reviewers, including accessing the data. Submissions are by definition contained within a repository and we require authors to archive their software before we accept.
+
+## Human participants research policy
+
+In the exceptional case a JOSS submission contains original data on human participants, the study must have been performed in accordance with the [Declaration of Helsinki](https://www.wma.net/policies-post/wma-declaration-of-helsinki-ethical-principles-for-medical-research-involving-human-subjects/). The manuscript must contain all relevant information regarding ethics approval, including but not limited to the responsible ethics committee and reference number. This also applies to ethics exemptions. Informed consent must be collected from all human research participants, and authors are required to state whether this occurred in the manuscript.


### PR DESCRIPTION
This PR adds a policies page to the docs, as a contained space to add some of the policies required by PubMed Central (PMC).

Specifically, this PR adds the following policies:

- Animal research
- Data sharing
- Human participants research

These are not necessarily super applicable to JOSS, but adding these may help our PMC indexing process along. Additionally, it can't hurt having these in the off-chance it might be(come) relevant one day.

I very much welcome feedback as I try to move the PMC indexing process along (see also #153 and the [Google Doc with the whole 6-step process](https://docs.google.com/document/d/1q9XyfmrmpKWwu3h3AQsykxxaYqLbM6eE1ZQbixXv2xA/edit?usp=sharing)). 😊 