### PR TITLE
Add conflict policy link to ethics guidelines

### DIFF
--- a/app/views/home/about.html.erb
+++ b/app/views/home/about.html.erb
@@ -96,7 +96,7 @@
             <li>Plagiarism (e.g., violation of another author's copyright), for both software and papers, is not allowed.</li>
             <li>Self-plagiarism (repeated publication of the same work) is not allowed.</li>
             <li>Author lists must be correct and complete. All listed authors must have made a contribution to the work, and all significant contributors should be included in the author list.</li>
-            <li>Reviews should be accurate and non-fraudulent. Examples of concerns are: Authors should not suggest reviewers who are not real people or have conflicts. Reviewers and editors must disclose conflicts. Bribes for authors, reviewers, editors are not permitted.</li>
+            <li>Reviews should be accurate and non-fraudulent. Examples of concerns are: Authors should not suggest reviewers who are not real people or have conflicts (see <a href="https://joss.readthedocs.io/en/latest/reviewer_guidelines.html#joss-conflict-of-interest-policy" target="_blank">conflict of interest policy</a> for details). Reviewers and editors must disclose conflicts. Bribes for authors, reviewers, editors are not permitted.</li>
           </ul>
         </p>
 


### PR DESCRIPTION
This PR adds a link in the Ethics guidelines section of the about page, to further clarify the conflict policy of JOSS.

This is important as the PMC application will review whether these policies are there. This is my attempt to improve discoverability for the people who will be checking the application but also in general 😊