### PR TITLE
Capitalize "Need" in Statement of Need

### DIFF
--- a/docs/submitting.md
+++ b/docs/submitting.md
@@ -141,7 +141,7 @@ Aside from toy problems and demonstrations, the majority of problems require
 efficient numerical tools, many of which require the same base code (e.g., for
 performing numerical orbit integration).
 
-# Statement of need
+# Statement of Need
 
 `Gala` is an Astropy-affiliated Python package for galactic dynamics. Python
 enables wrapping low-level languages (e.g., C) for speed without losing


### PR DESCRIPTION
Change "Statement of need" into "Statement of Need" in the example paper on the documentation page. Without the capital "N", I got a warning from @editorialbot, saying:

> Failed to discover a `Statement of need` section in paper

This is actually the warning generated by:

https://github.com/openjournals/buffy/blob/912c2b0753c13ff750625c9d5ed49fd6fec53c2f/app/workers/repo_checks_worker.rb#L74

The code checks whether the text contains "Statement of Need".

Cheers ✓.