### PR TITLE
Add financial conflict of interest note

### DIFF
--- a/app/views/papers/_form.html.erb
+++ b/app/views/papers/_form.html.erb
@@ -53,7 +53,7 @@
 <div class="form-group">
   <%= f.label "Message to editors" %>
   <%= f.text_area :body, rows: "7",
-    placeholder: "Has any portion of the submitted work (which includes code and documentation) been published or submitted, or is planned for submission, to another peer-reviewed publication venue? If yes, please describe. Please also give short (1-2 line) description of your #{setting(:product)} including specific notes to the editor if this is a resubmission or a second paper in #{setting(:abbreviation)} about this #{setting(:product)}.", class: 'form-control' %>
+    placeholder: "Has any portion of the submitted work (which includes code and documentation) been published or submitted, or is planned for submission, to another peer-reviewed publication venue? If yes, please describe. Please also give short (1-2 line) description of your #{setting(:product)} including specific notes to the editor if this is a resubmission or a second paper in #{setting(:abbreviation)} about this #{setting(:product)}. Please disclose any potential conflicts of interest, including financial ones.", class: 'form-control' %>
 </div>
 
 <div class="form-group">


### PR DESCRIPTION
This adds an additional piece of text about potential conflicts of interest, including financial ones.

This PR is in preparation of the PMC application, and inspired by discussion with @arfon in google documents.