### PR TITLE
Pre review not meta

### DIFF
--- a/app/views/papers/_actions.html.erb
+++ b/app/views/papers/_actions.html.erb
@@ -77,7 +77,7 @@
           <div class="col-md-5">
             <%= form_tag(start_meta_review_paper_url(paper), class: "left") do %>
               Editor: <%= select_tag :editor, options_for_select(Repository.editors, selected: nil), prompt: "Suggest editor (optional)", class: "form-control left" %>
-              <%= submit_tag "Start meta review", class: "btn btn-primary left start-review" %>
+              <%= submit_tag "Start pre review", class: "btn btn-primary left start-review" %>
             <% end %>
           </div>
           <div class="col-md-1">

--- a/app/views/papers/_show_unpublished.html.erb
+++ b/app/views/papers/_show_unpublished.html.erb
@@ -29,7 +29,7 @@
         <% if @paper.meta_review_issue_id %>
           <%= link_to @paper.meta_review_url, class: 'btn paper-btn' do %>
             <%= image_tag "icon_docs.svg" %>
-            Paper meta review
+            Paper pre review
           <% end %>
         <% end %>
 

--- a/spec/views/papers/show.html.erb_spec.rb
+++ b/spec/views/papers/show.html.erb_spec.rb
@@ -103,7 +103,7 @@ describe 'papers/show.html.erb' do
       render template: "papers/show", formats: :html
       expect(rendered).to have_selector("a[data-turbo-method=post]", text: "Withdraw paper")
       expect(rendered).to_not have_selector("a[data-turbo-method=post]", text: "Reject paper")
-      expect(rendered).to_not have_selector("input[type=submit][value='Start meta review']")
+      expect(rendered).to_not have_selector("input[type=submit][value='Start pre review']")
     end
 
     it "shows the withdraw/reject/start-meta-review buttons button to admins" do
@@ -119,7 +119,7 @@ describe 'papers/show.html.erb' do
       render template: "papers/show", formats: :html
       expect(rendered).to have_selector("a[data-turbo-method=post]", text: "Withdraw paper")
       expect(rendered).to have_selector("a[data-turbo-method=post]", text: "Reject paper")
-      expect(rendered).to have_selector("input[type=submit][value='Start meta review']")
+      expect(rendered).to have_selector("input[type=submit][value='Start pre review']")
       expect(rendered).to have_content(author.email)
     end
 
@@ -136,7 +136,7 @@ describe 'papers/show.html.erb' do
       render template: "papers/show", formats: :html
       expect(rendered).to_not have_selector("button[type=submit]", text: "Withdraw paper")
       expect(rendered).to_not have_selector("button[type=submit]", text: "Reject paper")
-      expect(rendered).to_not have_selector("input[type=submit][value='Start meta review']")
+      expect(rendered).to_not have_selector("input[type=submit][value='Start pre review']")
     end
 
     it "doesn't displays buttons when there's a GitHub issue" do


### PR DESCRIPTION
Removing references to 'meta review' when really it's called pre-review.

/ cc @oliviaguest for finding this with me :-)