### PR TITLE
Add initial correction and retraction to publication ethics

### DIFF
--- a/app/views/home/about.html.erb
+++ b/app/views/home/about.html.erb
@@ -151,7 +151,7 @@
           <li>Self-plagiarism (repeated publication of the same work) is not allowed.</li>
           <li>Author lists must be correct and complete. All listed authors must have made a contribution to the work, and all significant contributors should be included in the author list.</li>
           <li>Reviews should be accurate and non-fraudulent. Examples of concerns are: Authors should not suggest reviewers who are not real people or have conflicts. Reviewers and editors must disclose conflicts. Bribes for authors, reviewers, editors are not permitted.</li>
-          <li>Minor fixes are processed by the Editors in Chief (EiCs), and are publicly handled based on requests from the original authors (managed in the GitHub review linked to from the paper).</li>
+          <li>Minor fixes are processed by the Editors in Chief (EiCs), and are publicly handled based on requests from the original authors (managed in the GitHub review linked from the paper).</li>
           <li>Major corrections will be reviewed by the EiC and ethics team. If accepted, the paper will be re-published with an editorial note on the GitHub review (linked from the paper page).</li>
           <li>Retractions: EiC team and the ethics team review. If we deem that a retraction is warranted, we will update the paper and leave a retraction notice (<a href="https://joss.theoj.org/papers/c44313ada36f12eebbaff10eb0888071">see an example retraction for the linked paper</a>)</li>
           </ul>

--- a/app/views/home/about.html.erb
+++ b/app/views/home/about.html.erb
@@ -151,7 +151,10 @@
           <li>Self-plagiarism (repeated publication of the same work) is not allowed.</li>
           <li>Author lists must be correct and complete. All listed authors must have made a contribution to the work, and all significant contributors should be included in the author list.</li>
           <li>Reviews should be accurate and non-fraudulent. Examples of concerns are: Authors should not suggest reviewers who are not real people or have conflicts. Reviewers and editors must disclose conflicts. Bribes for authors, reviewers, editors are not permitted.</li>
-        </ul>
+          <li>Minor fixes are processed by the Editors in Chief (EiCs), and are publicly handled based on requests from the original authors (managed in the GitHub review linked to from the paper).</li>
+          <li>Major corrections will be reviewed by the EiC and ethics team. If accepted, the paper will be re-published with an editorial note on the GitHub review (linked from the paper page).</li>
+          <li>Retractions: EiC team and the ethics team review. If we deem that a retraction is warranted, we will update the paper and leave a retraction notice (<a href="https://joss.theoj.org/papers/c44313ada36f12eebbaff10eb0888071">see an example retraction for the linked paper</a>)</li>
+          </ul>
 
         <b>Copyright and Access</b>
         <ul>


### PR DESCRIPTION
This PR adds some basic information on the correction and retraction processes.

This was pre-discussed in the PMC procedure document and mostly based on @arfon's initial proposal. I added it to the Publication Ethics section as that seemed to be a logical and not too buried place to put it. Happy to consider other options as well!

I do note that this talks about an "ethics team" which I can't find more information about. Should we keep that in or take it out? Maybe the ethics team is documented somewhere else.

Also, do we issue retraction notices for the metadata of papers? This seems like the standard as far as I know so it might be a thing that gets picked up during the application screening. Might be a potential future improvement if we don't do it now, so that it's easier to propagate that information using the metadata only?