### PR TITLE
Add requirement of free and open accounts

### DIFF
--- a/docs/review_criteria.md
+++ b/docs/review_criteria.md
@@ -119,3 +119,7 @@ We ask that reviewers grade submissions in one of three categories: 1) Accept 2)
 As outlined in our author guidelines, submissions that rely upon a proprietary/closed source language or development environment are acceptable provided that they meet the other submission requirements and that you, the reviewer, are able to install the software & verify the functionality of the submission as required by our reviewer guidelines.
 
 If an open source or free variant of the programming language exists, feel free to encourage the submitting author to consider making their software compatible with the open source/free variant.
+
+### Where can I host the repository?
+
+We ask that repositories are hosted at a location that allows outside users to freely open issues and make pull requests, such as BitBucket or GitHub. Submissions will not be accepted if the repository is at a location where users must pay to open issues or make pull requests, or where accounts must be manually approved, regardless of if this approval is done by the owners of the repository or some other entity. 

--- a/docs/review_criteria.md
+++ b/docs/review_criteria.md
@@ -122,4 +122,4 @@ If an open source or free variant of the programming language exists, feel free 
 
 ### Where can I host the repository?
 
-Repositories must be hosted at a location that allows outside users to freely open issues and propose changes, such as GitHub, GitLab, Bitbucket, etc. Submissions will not be accepted if the repository is hosted at a location where where accounts must be manually approved (or paid for), regardless of if this approval is done by the owners of the repository or some other entity. 
+Repositories must be hosted at a location that allows outside users to freely open issues and propose code changes, such as GitHub, GitLab, Bitbucket, etc. Submissions will not be accepted if the repository is hosted at a location where where accounts must be manually approved (or paid for), regardless of if this approval is done by the owners of the repository or some other entity. 

--- a/docs/review_criteria.md
+++ b/docs/review_criteria.md
@@ -122,4 +122,4 @@ If an open source or free variant of the programming language exists, feel free 
 
 ### Where can I host the repository?
 
-We ask that repositories are hosted at a location that allows outside users to freely open issues and make pull requests, such as BitBucket or GitHub. Submissions will not be accepted if the repository is at a location where users must pay to open issues or make pull requests, or where accounts must be manually approved, regardless of if this approval is done by the owners of the repository or some other entity. 
+We ask that repositories are hosted at a location that allows outside users to freely open issues and make pull requests, such as GitHub, GitLab, Bitbucket, etc. Submissions will not be accepted if the repository is at a location where users must pay to open issues or make pull requests, or where accounts must be manually approved, regardless of if this approval is done by the owners of the repository or some other entity. 

--- a/docs/review_criteria.md
+++ b/docs/review_criteria.md
@@ -122,4 +122,4 @@ If an open source or free variant of the programming language exists, feel free 
 
 ### Where can I host the repository?
 
-We ask that repositories are hosted at a location that allows outside users to freely open issues and make pull requests, such as GitHub, GitLab, Bitbucket, etc. Submissions will not be accepted if the repository is at a location where users must pay to open issues or make pull requests, or where accounts must be manually approved, regardless of if this approval is done by the owners of the repository or some other entity. 
+Repositories must be hosted at a location that allows outside users to freely open issues and propose changes, such as GitHub, GitLab, Bitbucket, etc. Submissions will not be accepted if the repository is hosted at a location where where accounts must be manually approved (or paid for), regardless of if this approval is done by the owners of the repository or some other entity. 

--- a/docs/submitting.md
+++ b/docs/submitting.md
@@ -7,6 +7,7 @@ But please read these instructions carefully for a streamlined submission.
 ## Submission requirements
 
 - The software must be open source as per the [OSI definition](https://opensource.org/osd).
+- The software must be hosted at a location where users can open issues and submit pull requests for free and without manual approval of accounts.
 - The software must have an **obvious** research application.
 - You must be a major contributor to the software you are submitting, and have a GitHub account to participate in the review process.
 - Your paper must not focus on new research results accomplished with the software.

--- a/docs/submitting.md
+++ b/docs/submitting.md
@@ -7,7 +7,7 @@ But please read these instructions carefully for a streamlined submission.
 ## Submission requirements
 
 - The software must be open source as per the [OSI definition](https://opensource.org/osd).
-- The software must be hosted at a location where users can open issues and propose changes without manual approval (or payment) of accounts.
+- The software must be hosted at a location where users can open issues and propose code changes without manual approval (or payment) of accounts.
 - The software must have an **obvious** research application.
 - You must be a major contributor to the software you are submitting, and have a GitHub account to participate in the review process.
 - Your paper must not focus on new research results accomplished with the software.

--- a/docs/submitting.md
+++ b/docs/submitting.md
@@ -7,7 +7,7 @@ But please read these instructions carefully for a streamlined submission.
 ## Submission requirements
 
 - The software must be open source as per the [OSI definition](https://opensource.org/osd).
-- The software must be hosted at a location where users can open issues and submit pull requests for free and without manual approval of accounts.
+- The software must be hosted at a location where users can open issues and propose changes without manual approval (or payment) of accounts.
 - The software must have an **obvious** research application.
 - You must be a major contributor to the software you are submitting, and have a GitHub account to participate in the review process.
 - Your paper must not focus on new research results accomplished with the software.


### PR DESCRIPTION
This PR adds the requirement that submissions must include repositories hosted at locations that have free account creation without manual verification, e.g. BitBucket or GitHub. These changes are meant to convey that it is not okay to host the code at a place where outside users cannot contribute, or user accounts must be manually approved before they can open issues or pull requests, even if the code is free to access. In my opinion, barriers to user participation should be discouraged, and this should be explicitly stated as one of our guidelines.

Looking forward to the discussion.