### PR TITLE
Update to new checkout version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: secret
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
Removes Node js upgrade warning.

There may be documentation to be changed also for users who are setting up their own action for paper generation (how I found the issue)