### PR TITLE
Submitting.md: add a TiKZ example

### DIFF
--- a/docs/submitting.md
+++ b/docs/submitting.md
@@ -204,6 +204,30 @@ and referenced from text using \autoref{fig:example}.
 Figure sizes can be customized by adding an optional second parameter:
 ![Caption for example figure.](figure.png){ width=20% }
 
+You may use the `TiKZ` package as well, here is an example taken from 
+[the official pgfmanual](http://mirrors.ctan.org/graphics/pgf/base/doc/pgfmanual.pdf):
+
+\begin{figure}[h]
+  \centering
+  \usetikzlibrary {datavisualization.formats.functions}
+  \tikz \datavisualization [
+    scientific axes=clean,
+    y axis={ticks={style={
+    /pgf/number format/fixed,
+    /pgf/number format/fixed zerofill,
+    /pgf/number format/precision=2}}},
+    x axis={ticks={tick suffix=${}^\circ$}},
+    visualize as smooth line/.list={1,2,3,4,5,6},
+    style sheet=vary hue]
+  data [format=function] {
+  var set : {1,...,6};
+  var x : interval [0:50];
+  func y = sin(\value x * (\value{set}+10))/(\value{set}+5);
+  };
+  \caption{Example taken from the pgfmanual in section ``Providing Data for a Data Visualization''}
+\end{figure}
+
+
 # Acknowledgements
 
 We acknowledge contributions from Brigitta Sipocz, Syrtis Major, and Semyeong


### PR DESCRIPTION
Until now, readers were not informed about their access to the powerful TiKZ library _inside_ their own paper. This might lead them to using rasterized graphics inside their publication which cannot compete with the infinite resolution of vector graphics.

Also, some might try hacking different methods to produce the illustrations and inject them inside the 'paper.md' file with the markdown syntax. This leads to inconsistent typesetting inside the final paper.

With this commit, I've put a TiKZ example taken from the pgfmanual documentation for a demonstration. This example enjoys the same typesetting as the rest of the paper. For example, the figure caption has the same font as the body.