### PR TITLE
Remove option for authors to silently withdraw

### DIFF
--- a/app/views/papers/_actions.html.erb
+++ b/app/views/papers/_actions.html.erb
@@ -91,8 +91,9 @@
           <% end %>
         <% end %>
 
-        <% if (current_user == paper.submitting_author) || current_user.aeic? %>
+        <% if current_user.aeic? %>
           <div class="col-md-3">
+            Note that if you hit this button, you'll still have to manually close the review issue on GitHub.
             <%= link_to "Withdraw paper", withdraw_paper_path(paper), data: { turbo_method: :post, turbo_confirm: "Withdrawing. Are you sure?" }, form_class: "left", class: "btn btn-danger" %>
           </div>
         <% end %>

--- a/spec/views/papers/show.html.erb_spec.rb
+++ b/spec/views/papers/show.html.erb_spec.rb
@@ -93,7 +93,7 @@ describe 'papers/show.html.erb' do
       expect(rendered).to have_selector("a[data-turbo-method=post]", text: "Reject paper")
     end
 
-    it "shows only the withdraw to paper owners" do
+    it "shows does not show the withdraw (or other actions) to paper owners" do
       user = create(:user)
       allow(view).to receive_message_chain(:current_user).and_return(user)
       allow(view).to receive_message_chain(:current_editor).and_return(user)
@@ -102,7 +102,7 @@ describe 'papers/show.html.erb' do
       assign(:paper, paper)
 
       render template: "papers/show", formats: :html
-      expect(rendered).to have_selector("a[data-turbo-method=post]", text: "Withdraw paper")
+      expect(rendered).to_not have_selector("a[data-turbo-method=post]", text: "Withdraw paper")
       expect(rendered).to_not have_selector("a[data-turbo-method=post]", text: "Reject paper")
       expect(rendered).to_not have_selector("input[type=submit][value='Start pre review']")
     end


### PR DESCRIPTION
Fixes #1190

This PR removes the 'withdraw' button from the paper UI on the JOSS site for the submitting author. We're removing this to ensure that authors go through the editorialbot flow when withdrawing (i.e., asking an editor to do this for them on the pre-review or review issue).

I've left the button their for EICs as a backup, but now included a reminder to make sure they close the review issue too if they use this functionality.
