### PR TITLE
Update link to reviewers in the pre-review issue template

### DIFF
--- a/app/views/shared/meta_view_body.text.erb
+++ b/app/views/shared/meta_view_body.text.erb
@@ -20,7 +20,7 @@ Markdown: [![status](<%= url %>/papers/<%= paper.sha %>/status.svg)](<%= url %>/
 
 **Author instructions**
 
-<%- abbreviation, reviewers, botname = Rails.application.settings.values_at("abbreviation", "reviewers", "bot_username") %>
+<%- abbreviation, reviewers_signup_url, reviewers_url, botname = Rails.application.settings.values_at("abbreviation", "reviewers_signup_url", "reviewers_url", "bot_username") %>
 <% if suggested_editor == "Pending" %>
 Thanks for submitting your paper to <%= abbreviation %> <%= paper.submitting_author.github_username %>. **Currently, there isn't a <%= abbreviation %> editor assigned** to your paper.
 <% else %>
@@ -29,7 +29,7 @@ Thanks for submitting your paper to <%= abbreviation %> <%= paper.submitting_aut
 The AEiC suggestion for the handling editor is <%= suggested_editor %>.
 <% end %>
 
-<%= paper.submitting_author.github_username %> if you have any suggestions for potential reviewers then please mention them here in this thread (without tagging them with an @). In addition, [this list of people](<%= reviewers %>) have already agreed to review for <%= abbreviation %> and may be suitable for this submission (please start at the bottom of the list).
+<%= paper.submitting_author.github_username %> if you have any suggestions for potential reviewers then please mention them here in this thread (without tagging them with an @). In addition if you [volunteer to review for <%= abbreviation %>](<%= reviewers_signup_url %>), you can search [the list of people](<%= reviewers_url %>) that have already agreed to review and may be suitable for this submission.
 
 **Editor instructions**
 

--- a/app/views/shared/meta_view_body.text.erb
+++ b/app/views/shared/meta_view_body.text.erb
@@ -20,7 +20,7 @@ Markdown: [![status](<%= url %>/papers/<%= paper.sha %>/status.svg)](<%= url %>/
 
 **Author instructions**
 
-<%- abbreviation, reviewers_signup_url, reviewers_url, botname = Rails.application.settings.values_at("abbreviation", "reviewers_signup_url", "reviewers_url", "bot_username") %>
+<%- abbreviation, reviewers_lookup_url, botname = Rails.application.settings.values_at("abbreviation", "reviewers_lookup_url", "bot_username") %>
 <% if suggested_editor == "Pending" %>
 Thanks for submitting your paper to <%= abbreviation %> <%= paper.submitting_author.github_username %>. **Currently, there isn't a <%= abbreviation %> editor assigned** to your paper.
 <% else %>
@@ -29,7 +29,7 @@ Thanks for submitting your paper to <%= abbreviation %> <%= paper.submitting_aut
 The AEiC suggestion for the handling editor is <%= suggested_editor %>.
 <% end %>
 
-<%= paper.submitting_author.github_username %> if you have any suggestions for potential reviewers then please mention them here in this thread (without tagging them with an @). In addition if you [volunteer to review for <%= abbreviation %>](<%= reviewers_signup_url %>), you can search [the list of people](<%= reviewers_url %>) that have already agreed to review and may be suitable for this submission.
+<%= paper.submitting_author.github_username %> if you have any suggestions for potential reviewers then please mention them here in this thread (without tagging them with an @). You can search [the list of people](<%= reviewers_lookup_url %>) that have already agreed to review and may be suitable for this submission.
 
 **Editor instructions**
 

--- a/config/settings-development.yml
+++ b/config/settings-development.yml
@@ -16,6 +16,7 @@ papers_repo: "openjournals/joss-papers-testing"
 papers_html_url: "https://www.theoj.org/joss-papers"
 reviewers_url: "https://reviewers.joss.theoj.org"
 reviewers_signup_url: "https://reviewers.joss.theoj.org/join"
+reviewers_lookup_url: "https://reviewers.joss.theoj.org/lookup"
 product: "software" # the *thing* being submitted for review
 submission_enquiry: |-
   **Project repository URL:** INSERT YOUR REPOSITORY LINK HERE

--- a/config/settings-development.yml
+++ b/config/settings-development.yml
@@ -14,9 +14,9 @@ github: "openjournals/joss"
 reviews: "openjournals/joss-reviews-testing"
 papers_repo: "openjournals/joss-papers-testing"
 papers_html_url: "https://www.theoj.org/joss-papers"
+reviewers_url: "https://reviewers.joss.theoj.org"
 reviewers_signup_url: "https://reviewers.joss.theoj.org/join"
 product: "software" # the *thing* being submitted for review
-reviewers: "https://bit.ly/joss-reviewers"
 submission_enquiry: |-
   **Project repository URL:** INSERT YOUR REPOSITORY LINK HERE
 

--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -12,11 +12,11 @@ mastodon_url: "https://fosstodon.org/@JOSS"
 google_analytics: "UA-47852178-4"
 github: "openjournals/joss"
 reviews: "openjournals/joss-reviews"
-papers_html_url: "https://www.theoj.org/joss-papers"
-reviewers_signup_url: "https://reviewers.joss.theoj.org/join"
 papers_repo: "openjournals/joss-papers"
+papers_html_url: "https://www.theoj.org/joss-papers"
+reviewers_url: "https://reviewers.joss.theoj.org"
+reviewers_signup_url: "https://reviewers.joss.theoj.org/join"
 product: "software" # the *thing* being submitted for review
-reviewers: "https://bit.ly/joss-reviewers"
 submission_enquiry: |-
   **Project repository URL:** INSERT YOUR REPOSITORY LINK HERE
 

--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -16,6 +16,7 @@ papers_repo: "openjournals/joss-papers"
 papers_html_url: "https://www.theoj.org/joss-papers"
 reviewers_url: "https://reviewers.joss.theoj.org"
 reviewers_signup_url: "https://reviewers.joss.theoj.org/join"
+reviewers_lookup_url: "https://reviewers.joss.theoj.org/lookup"
 product: "software" # the *thing* being submitted for review
 submission_enquiry: |-
   **Project repository URL:** INSERT YOUR REPOSITORY LINK HERE

--- a/config/settings-test.yml
+++ b/config/settings-test.yml
@@ -16,6 +16,7 @@ papers_repo: "openjournals/joss-papers-testing"
 papers_html_url: "https://www.theoj.org/joss-papers"
 reviewers_url: "https://reviewers.joss.theoj.org"
 reviewers_signup_url: "https://reviewers.joss.theoj.org/join"
+reviewers_lookup_url: "https://reviewers.joss.theoj.org/lookup"
 product: "software" # the *thing* being submitted for review
 submission_enquiry: |-
   **Project repository URL:** INSERT YOUR REPOSITORY LINK HERE

--- a/config/settings-test.yml
+++ b/config/settings-test.yml
@@ -14,9 +14,9 @@ github: "openjournals/joss"
 reviews: "openjournals/joss-reviews-testing"
 papers_repo: "openjournals/joss-papers-testing"
 papers_html_url: "https://www.theoj.org/joss-papers"
+reviewers_url: "https://reviewers.joss.theoj.org"
 reviewers_signup_url: "https://reviewers.joss.theoj.org/join"
 product: "software" # the *thing* being submitted for review
-reviewers: "https://bit.ly/joss-reviewers"
 submission_enquiry: |-
   **Project repository URL:** INSERT YOUR REPOSITORY LINK HERE
 

--- a/spec/models/paper_spec.rb
+++ b/spec/models/paper_spec.rb
@@ -344,8 +344,7 @@ describe Paper do
       it "renders text" do
         is_expected.to match /#{paper.submitting_author.github_username}/
         is_expected.to match /#{paper.submitting_author.name}/
-        is_expected.to match /#{Rails.application.settings['reviewers_url']}/
-        is_expected.to match /#{Rails.application.settings['reviewers_signup_url']}/
+        is_expected.to match /#{Rails.application.settings['reviewers_lookup_url']}/
         is_expected.to match /Important Editor/
       end
 
@@ -358,8 +357,7 @@ describe Paper do
       it "renders text" do
         is_expected.to match /#{paper.submitting_author.github_username}/
         is_expected.to match /#{paper.submitting_author.name}/
-        is_expected.to match /#{Rails.application.settings['reviewers_url']}/
-        is_expected.to match /#{Rails.application.settings['reviewers_signup_url']}/
+        is_expected.to match /#{Rails.application.settings['reviewers_lookup_url']}/
       end
 
       it { is_expected.to match "Currently, there isn't a JOSS editor assigned" }

--- a/spec/models/paper_spec.rb
+++ b/spec/models/paper_spec.rb
@@ -344,7 +344,8 @@ describe Paper do
       it "renders text" do
         is_expected.to match /#{paper.submitting_author.github_username}/
         is_expected.to match /#{paper.submitting_author.name}/
-        is_expected.to match /#{Rails.application.settings['reviewers']}/
+        is_expected.to match /#{Rails.application.settings['reviewers_url']}/
+        is_expected.to match /#{Rails.application.settings['reviewers_signup_url']}/
         is_expected.to match /Important Editor/
       end
 
@@ -357,7 +358,8 @@ describe Paper do
       it "renders text" do
         is_expected.to match /#{paper.submitting_author.github_username}/
         is_expected.to match /#{paper.submitting_author.name}/
-        is_expected.to match /#{Rails.application.settings['reviewers']}/
+        is_expected.to match /#{Rails.application.settings['reviewers_url']}/
+        is_expected.to match /#{Rails.application.settings['reviewers_signup_url']}/
       end
 
       it { is_expected.to match "Currently, there isn't a JOSS editor assigned" }


### PR DESCRIPTION
This PR updates the text in the body of the [PRE REVIEW] issues suggesting authors to go to the JOSS Reviewers new site instead of the old spreadsheet. In the Reviewers web searching for reviewers is now available to all logged in users.
 