### PR TITLE
Reworking auth on papers#show

### DIFF
--- a/app/controllers/papers_controller.rb
+++ b/app/controllers/papers_controller.rb
@@ -221,7 +221,18 @@ class PapersController < ApplicationController
     # Don't show the paper to anyone other than the submitting author or an
     # admin.
     if @paper.invisible?
-      head 404 and return unless can_see_hidden_paper?(@paper)
+      # Redirect to login if not logged in
+      if !current_user
+        session[:redirect_to] = request.fullpath
+        redirect_to 'sessions#create', allow_other_host: true and return
+      end
+      
+      # Redirect to root if not an admin or the submitting author
+      # With notice that the paper is not visible
+      unless can_see_hidden_paper?(@paper)
+        flash[:notice] = "You don't have the permissions to view this paper."
+        redirect_to root_path and return
+      end
     end
 
     # The behaviour here for PDFs is to make it possible for the PDF to appear

--- a/app/controllers/papers_controller.rb
+++ b/app/controllers/papers_controller.rb
@@ -223,8 +223,8 @@ class PapersController < ApplicationController
     if @paper.invisible?
       # Redirect to login if not logged in
       if !current_user
-        session[:redirect_to] = request.fullpath
-        redirect_to 'sessions#create', allow_other_host: true and return
+        flash[:notice] = "You need to log in before viewing this paper."
+        redirect_to root_path and return
       end
       
       # Redirect to root if not an admin or the submitting author

--- a/spec/controllers/papers_controller_spec.rb
+++ b/spec/controllers/papers_controller_spec.rb
@@ -190,13 +190,13 @@ describe PapersController, type: :controller do
     it "should 404 for a paper that has been rejected" do
       rejected_paper = create(:paper, state: 'rejected')
       get :show, params: {id: rejected_paper.sha}, format: "html"
-      expect(response.status).to eq(404)
+      expect(response.status).to eq(302)
     end
 
     it "should 404 for a paper that has just been submitted" do
       submitted_paper = create(:paper, state: 'submitted')
       get :show, params: {id: submitted_paper.sha}, format: "html"
-      expect(response.status).to eq(404)
+      expect(response.status).to eq(302)
     end
 
     it "should be visible for a user who owns the paper" do


### PR DESCRIPTION
Authors, editors, EiCs (pretty much everyone) complain often that the link for a paper (pre-accept) is dead. That's because we require authors to be logged in when viewing a (not-yet-accepted) paper so we can check if they have permissions to view it.

This PR attempts to change the behaviour such that if a user is not logged in, we will redirect them to auth first.

I can't get the app running locally for some reason so I've not been able to check these changes properly yet. Opening up for a quick review from @xuanxu to see if this looks like a reasonable direction.