### PR TITLE
Fixing timestamp on TOC

### DIFF
--- a/app/controllers/toc_controller.rb
+++ b/app/controllers/toc_controller.rb
@@ -54,7 +54,7 @@ class TocController < ApplicationController
   def filter_papers(param, field)
     redirect_to(action: :index) and return if param.blank?
 
-    @papers = Paper.search(param.to_i, fields: [{field.to_sym => :exact}], order: { page: :asc },
+    @papers = Paper.search(param.to_i, fields: [{field.to_sym => :exact}], order: { accepted_at: :desc },
                 page: params[:page], per_page: 50)
     @pagy = Pagy.new_from_searchkick(@papers)
   end

--- a/app/controllers/toc_controller.rb
+++ b/app/controllers/toc_controller.rb
@@ -54,7 +54,7 @@ class TocController < ApplicationController
   def filter_papers(param, field)
     redirect_to(action: :index) and return if param.blank?
 
-    @papers = Paper.search(param.to_i, fields: [{field.to_sym => :exact}], order: { accepted_at: :desc },
+    @papers = Paper.search(param.to_i, fields: [{field.to_sym => :exact}], order: { accepted_at: :asc },
                 page: params[:page], per_page: 50)
     @pagy = Pagy.new_from_searchkick(@papers)
   end

--- a/app/views/toc/_list.html.erb
+++ b/app/views/toc/_list.html.erb
@@ -7,7 +7,7 @@
           <%= link_to paper.title, paper.seo_url, title: paper.title, class: "d-inline-block text-truncate", style: "max-width: 450px;" %>
         </td>
         <td>
-          <div class="time">Published <%= paper.created_at.strftime("%d-%m-%Y") %> </div>
+          <div class="time">Published <%= paper.accepted_at.strftime("%d-%m-%Y") %> </div>
         </td>
         <td>
           <%= image_tag 'doi.svg' %><%= link_to paper.doi, paper.seo_url %>

--- a/app/views/toc/index.html.erb
+++ b/app/views/toc/index.html.erb
@@ -29,7 +29,7 @@
         </td>
         <td class="issue-paper">
           <% issues_in_v.each do |i| %>
-            <%= link_to("Issue #{i}".html_safe, toc_issue_path(issue: i), title: "Papers in issue #{i}", class: "d-inline-block text-truncate px-2", style: "max-width: 450px;") if i.present? %>
+            <%= link_to("Issue #{i.to_s.rjust(3, "0")}".html_safe, toc_issue_path(issue: i), title: "Papers in issue #{i}", class: "d-inline-block text-truncate px-2", style: "max-width: 450px;") if i.present? %>
           <% end %>
         </td>
         <td>

--- a/app/views/toc/index.html.erb
+++ b/app/views/toc/index.html.erb
@@ -27,7 +27,7 @@
         <td>
           <strong><%= link_to "Volume #{v} (#{@years[@volumes.index(v)]})", toc_volume_path(volume: v), title: "Papers from volume #{v}", class: "d-inline-block text-truncate", style: "max-width: 450px;" %></strong>
         </td>
-        <td>
+        <td class="issue-paper">
           <% issues_in_v.each do |i| %>
             <%= link_to("Issue #{i}".html_safe, toc_issue_path(issue: i), title: "Papers in issue #{i}", class: "d-inline-block text-truncate px-2", style: "max-width: 450px;") if i.present? %>
           <% end %>

--- a/spec/system/toc_spec.rb
+++ b/spec/system/toc_spec.rb
@@ -54,7 +54,7 @@ feature "Table of Contents" do
     end
 
     @issues.each do |issue|
-      expect(page).to have_link("Issue #{issue}", href: toc_issue_path(issue: issue))
+      expect(page).to have_link("Issue #{issue.to_s.rjust(3, "0")}", href: toc_issue_path(issue: issue))
     end
 
     expect(page).to have_link("Current issue", href: toc_current_issue_path)


### PR DESCRIPTION
The timestamp on the papers list is currently the submitted (`created_at`) time, rather than the accepted/published (`accepted_at`) time.

This PR fixes that!