### PR TITLE
On submission form - inform user to start typing

### DIFF
--- a/app/views/papers/_form.html.erb
+++ b/app/views/papers/_form.html.erb
@@ -51,7 +51,7 @@
     </div>
     <div class="col" data-controller="autocomplete" data-autocomplete-url-value="<%= search_subjects_path %>">
       <%= f.label "Main subject of the paper" %>
-      <%= f.text_field :suggested_subject, placeholder: "Select the subject that best applies to your paper", class: "form-control", style: "margin-right: 12px;", data: {"autocomplete-target" => "input"} %>
+      <%= f.text_field :suggested_subject, placeholder: "Start typing and select the subject that best applies to your paper", class: "form-control", style: "margin-right: 12px;", data: {"autocomplete-target" => "input"} %>
       <%= f.hidden_field :track_id, data: {"autocomplete-target" => "hidden"} %>
       <ul class="list-group subjects-options" data-autocomplete-target="results"></ul>
     </div>


### PR DESCRIPTION
In my case, having seeing no options given (just an editbox), I just quickly typed "neuroimaging" and no alert was given but I failed to submit since error said that I should choose a valid subject. So I removed "neuroimaging" but no choices has come about. I searched the internet on what subjects it could be -- no hint was given.  Only when I started to type slowly "neu" choices start to come up.

Hence, I think for the sake of people smoother experience, I think the hint there should be extended