### PR TITLE
Dashboard: list query scoped submissions

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -294,7 +294,7 @@ TODO
 }
 
 .tabnav-tab {
-    padding: 1em 2em;
+    padding: 1em 1.6em;
     background: #fff;
     color: #2E294E;
     transition: background-color .3s ease-out;

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -55,6 +55,11 @@
   }
 }
 
+.grey-emoji {
+  color: transparent;
+  text-shadow: 0 0 0 #aaa;
+}
+
 table.dashboard-table, table.comments-table, table.toc-table{
   margin-top: 1em;
   width: 100%;

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -78,9 +78,9 @@ class HomeController < ApplicationController
       @pagy, @papers = pagy(incoming_scope.order(created_at: @order))
     end
 
-    load_pending_invitations_for_papers(@papers)
-
     @editor = current_user.editor
+    set_votes_by_paper_from_editor(@editor, @papers)
+    load_pending_invitations_for_papers(@papers)
 
     render template: "home/reviews"
   end
@@ -98,6 +98,7 @@ class HomeController < ApplicationController
       @pagy, @papers = pagy(in_progress_scope.order(created_at: @order))
     end
 
+    set_votes_by_paper_from_editor(@editor, @papers)
     load_pending_invitations_for_papers(@papers)
 
     render template: "home/reviews"
@@ -116,6 +117,7 @@ class HomeController < ApplicationController
       @pagy, @papers = pagy(in_progress_query_scoped.order(created_at: @order))
     end
 
+    set_votes_by_paper_from_editor(@editor, @papers)
     load_pending_invitations_for_papers(@papers)
 
     render template: "home/reviews"
@@ -134,6 +136,7 @@ class HomeController < ApplicationController
       @pagy, @papers = pagy(all_scope.order(created_at: @order))
     end
 
+    set_votes_by_paper_from_editor(@editor, @papers)
     load_pending_invitations_for_papers(@papers)
 
     render template: "home/reviews"
@@ -171,6 +174,11 @@ private
   end
 
   def set_track
-      @track = Track.find(params[:track_id]) if params[:track_id].present?
-    end
+    @track = Track.find(params[:track_id]) if params[:track_id].present?
+  end
+
+  def set_votes_by_paper_from_editor(editor, papers)
+    in_scope_papers = papers.select {|p| p.labels.keys.include?("query-scope")}
+    @votes_by_paper_from_editor = in_scope_papers.any? ? Vote.where(editor: editor).where(paper: in_scope_papers).index_by(&:paper_id) : {}
+  end
 end

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -27,11 +27,18 @@ module HomeHelper
     'tabnav-tab'
   end
 
-  def vote_summary(paper)
+  def vote_summary(paper, votes_by_paper)
     if paper.labels.keys.include?("query-scope")
-      capture do
-        concat(content_tag(:small, "👍(#{paper.votes.in_scope.count}) / 👎 (#{paper.votes.out_of_scope.count})"))
+      summary = ""
+      vote = votes_by_paper[paper.id]
+      summary = if vote.nil? || vote.comment?
+        content_tag(:small, "👍(#{paper.in_scope_votes.count}) / 👎 (#{paper.votes.out_of_scope.count})")
+      elsif vote.in_scope?
+        content_tag(:small, "👍(#{paper.in_scope_votes.count}) / <span class='grey-emoji'>👎</span> (#{paper.out_of_scope_votes.count})".html_safe)
+      elsif vote.out_of_scope?
+        content_tag(:small, "<span class='grey-emoji'>👍</span>(#{paper.in_scope_votes.count}) / 👎 (#{paper.out_of_scope_votes.count})".html_safe)
       end
+      summary.html_safe
     else
       'OK'
     end

--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -131,6 +131,7 @@ class Paper < ApplicationRecord
   scope :search_import, -> { where(state: VISIBLE_STATES) }
   scope :not_archived, -> { where('archived = ?', false) }
   scope :by_track, -> (track_id) { where('track_id = ?', track_id) }
+  scope :query_scoped, -> { where("labels->>'query-scope' IS NOT NULL") }
 
   before_create :set_sha, :set_last_activity
   after_create :notify_editors, :notify_author

--- a/app/views/home/_menu.html.erb
+++ b/app/views/home/_menu.html.erb
@@ -12,6 +12,9 @@
     In progress papers
     <div class="count-badge"><%= raw Paper.unscoped.in_progress.count %></div>
     <% end %>
+    <%= link_to dashboard_query_scoped_path(track_id: @track), class: current_class?(dashboard_query_scoped_path) do %>
+    👍👎
+    <% end %>
     <%= link_to dashboard_all_path(track_id: @track), class: current_class?(dashboard_all_path) do %>
     All papers
     <div class="count-badge"><%= raw Paper.unscoped.all.count %></div>
@@ -21,7 +24,7 @@
     <% end %>
   </div>
 
-  <% if [dashboard_incoming_path, dashboard_in_progress_path, dashboard_all_path].include?(request.path) && JournalFeatures.tracks? %>
+  <% if [dashboard_incoming_path, dashboard_in_progress_path, dashboard_query_scoped_path, dashboard_all_path].include?(request.path) && JournalFeatures.tracks? %>
   <div class="float-right">
     <%= select_tag :track_id, options_from_collection_for_select(Track.all, "id", "name", params[:track_id].presence), include_blank: "All tracks", class: "form-control left", style: "font-size:81%", onchange: "top.location.href='?track_id=' + this.options[this.selectedIndex].value;" %>
   </div>

--- a/app/views/home/reviews.html.erb
+++ b/app/views/home/reviews.html.erb
@@ -58,7 +58,7 @@
         <td class="state"><%= paper.state.titleize %></td>
         <td><%= link_to paper.title, paper_url(paper), title: paper.title, class: "d-inline-block text-truncate", style: "max-width: 450px;" %><div class="time">Submitted <%= time_ago_in_words(paper.created_at) %> ago <%= pretty_labels_for(paper) %></div></td>
         <% unless params[:editor]%>
-        <td class="text-center"><%= vote_summary(paper).html_safe %></td>
+        <td class="text-center"><%= vote_summary(paper, @votes_by_paper_from_editor) %></td>
         <td class="text-center"><%= open_invites_for_paper(paper) %></td>   
         <% end %>
         <td class="text-center"><%= review_issue_links(paper) %></td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,7 @@ Rails.application.routes.draw do
   get '/dashboard/all', to: "home#all", as: "dashboard_all"
   get '/dashboard/incoming', to: "home#incoming", as: "dashboard_incoming"
   get '/dashboard/in_progress', to: "home#in_progress", as: "dashboard_in_progress"
+  get '/dashboard/query_scoped', to: "home#query_scoped", as: "dashboard_query_scoped"
   get '/dashboard', to: "home#dashboard"
 
   get '/dashboard/*editor', to: "home#reviews"

--- a/spec/models/paper_spec.rb
+++ b/spec/models/paper_spec.rb
@@ -118,6 +118,17 @@ describe Paper do
       expect(track_A_papers.include?(paper_A1)).to be true
       expect(track_A_papers.include?(paper_A2)).to be true
     end
+
+    it "should find query scoped papers" do
+      paper_1, paper_2, paper_3, paper_4, paper_5 = create_list(:paper, 5)
+      paper_2.update labels: {"query-scope" => "FF0000"}
+      paper_4.update labels: {"query-scope" => "CC00CC"}
+
+      query_scoped_papers = Paper.query_scoped
+      expect(query_scoped_papers.size).to eq(2)
+      expect(query_scoped_papers.include?(paper_2)).to be true
+      expect(query_scoped_papers.include?(paper_4)).to be true
+    end
   end
 
   # GitHub stuff

--- a/spec/system/dashboard_spec.rb
+++ b/spec/system/dashboard_spec.rb
@@ -44,9 +44,9 @@ feature "Dashboard" do
     before do
       editor = create(:editor, login: "editor1")
       @track = create(:track, name: "TestingTrack")
-      create(:paper, state: "submitted", title: "Paper Submitted", editor: nil)
+      create(:paper, state: "submitted", title: "Paper Submitted", labels:{"query-scope" => "C0C"}, editor: nil)
       create(:paper, state: "under_review", title: "Paper Under Review", editor: editor)
-      create(:paper, state: "review_pending", title: "Paper Review Pending No Editor", editor: nil, track: @track)
+      create(:paper, state: "review_pending", title: "Paper Review Pending No Editor", labels:{"query-scope" => "C0C"}, editor: nil, track: @track)
       create(:paper, state: "review_pending", title: "Paper Review Pending With Editor", editor: editor, track: @track)
       create(:accepted_paper, title: "Paper Accepted", editor: editor, track: @track)
       create(:rejected_paper, title: "Paper Rejected")
@@ -70,6 +70,16 @@ feature "Dashboard" do
       expect(page).to have_content("Paper Review Pending No Editor")
       expect(page).to have_content("Paper Under Review")
       expect(page).to have_content("Paper Review Pending With Editor")
+      expect(page).to_not have_content("Paper Accepted")
+      expect(page).to_not have_content("Paper Rejected")
+    end
+
+    scenario "List query scoped papers" do
+      click_link "👍👎"
+      expect(page).to have_content("Paper Submitted")
+      expect(page).to have_content("Paper Review Pending No Editor")
+      expect(page).to_not have_content("Paper Under Review")
+      expect(page).to_not have_content("Paper Review Pending With Editor")
       expect(page).to_not have_content("Paper Accepted")
       expect(page).to_not have_content("Paper Rejected")
     end
@@ -112,7 +122,7 @@ feature "Dashboard" do
         end
       end
 
-      scenario "Dropdown is visible only in incoming/in_progress/all_papers tabs" do
+      scenario "Dropdown is visible only in incoming/in_progress/query_scoped/all_papers tabs" do
         expect(page).to_not have_css("select#track_id")
 
         visit dashboard_incoming_path
@@ -122,6 +132,9 @@ feature "Dashboard" do
         expect(page).to_not have_css("select#track_id")
 
         visit dashboard_in_progress_path
+        expect(page).to have_css("select#track_id")
+
+        visit dashboard_query_scoped_path
         expect(page).to have_css("select#track_id")
 
         visit "/dashboard"
@@ -147,6 +160,15 @@ feature "Dashboard" do
         expect(page).to have_content("Paper Review Pending No Editor")
         expect(page).to_not have_content("Paper Under Review")
         expect(page).to have_content("Paper Review Pending With Editor")
+        expect(page).to_not have_content("Paper Accepted")
+        expect(page).to_not have_content("Paper Rejected")
+
+        visit dashboard_query_scoped_path(track_id: @track.id)
+
+        expect(page).to_not have_content("Paper Submitted")
+        expect(page).to have_content("Paper Review Pending No Editor")
+        expect(page).to_not have_content("Paper Under Review")
+        expect(page).to_not have_content("Paper Review Pending With Editor")
         expect(page).to_not have_content("Paper Accepted")
         expect(page).to_not have_content("Paper Rejected")
 

--- a/spec/system/dashboard_spec.rb
+++ b/spec/system/dashboard_spec.rb
@@ -44,7 +44,8 @@ feature "Dashboard" do
     before do
       editor = create(:editor, login: "editor1")
       @track = create(:track, name: "TestingTrack")
-      create(:paper, state: "submitted", title: "Paper Submitted", labels:{"query-scope" => "C0C"}, editor: nil)
+      query_scoped_paper = create(:paper, state: "submitted", title: "Paper Submitted", labels:{"query-scope" => "C0C"}, editor: nil)
+      create(:in_scope_vote, editor: editor, paper: query_scoped_paper)
       create(:paper, state: "under_review", title: "Paper Under Review", editor: editor)
       create(:paper, state: "review_pending", title: "Paper Review Pending No Editor", labels:{"query-scope" => "C0C"}, editor: nil, track: @track)
       create(:paper, state: "review_pending", title: "Paper Review Pending With Editor", editor: editor, track: @track)


### PR DESCRIPTION
This PR adds a new option to the editor dashboard to list only query scoped submissions (filterable by track)

![Captura de pantalla 2023-09-14 a las 12 21 17](https://github.com/openjournals/joss/assets/6528/2f02261b-ed8e-452e-b0b7-7db69e183887)
