### PR TITLE
Add validation for repository URL

### DIFF
--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -145,6 +145,7 @@ class Paper < ApplicationRecord
   validates_presence_of :track_id, on: :create, message: "You must select a valid subject for the paper", if: Proc.new { JournalFeatures.tracks? }
   validates :kind, inclusion: { in: Rails.application.settings["paper_types"] }, allow_nil: true
   validates :submission_kind, inclusion: { in: SUBMISSION_KINDS, message: "You must select a submission type" }, allow_nil: false
+  validates_format_of :repository_url, with: /\Ahttps?:\/\//i, on: :create, message: "Repository URL is missing the protocol segment (http/https)"
   validate :check_repository_address, on: :create, unless: Proc.new {|paper| paper.is_a_retraction_notice?}
 
   def notify_editors

--- a/spec/models/paper_spec.rb
+++ b/spec/models/paper_spec.rb
@@ -47,14 +47,31 @@ describe Paper do
     expect(paper.submitting_author).to eq(user)
   end
 
+  it "should have a complete value for repository url" do
+    params = { title: 'Test paper',
+               body: 'A test paper description',
+               repository_url: 'github.com/arfon/fidgit',
+               software_version: 'v1.0.0',
+               submitting_author: create(:user),
+               submission_kind: 'new',
+               track: create(:track) }
+
+    paper = Paper.create(params)
+    expect(paper).to_not be_valid
+    expect(paper.errors.messages[:repository_url].first).to eq("Repository URL is missing the protocol segment (http/https)")
+
+    paper = Paper.create(params.merge(repository_url: 'http://github.com/arfon/fidgit'))
+    expect(paper).to be_valid
+  end
+
   it "must have a track assigned on creation if tracks are enabled" do
     enable_feature(:tracks) do
       no_track_params = { title: 'Test paper',
-                         body: 'A test paper description',
-                         repository_url: 'http://github.com/arfon/fidgit',
-                         software_version: 'v1.0.0',
-                         submitting_author: create(:user),
-                         submission_kind: 'new' }
+                          body: 'A test paper description',
+                          repository_url: 'http://github.com/arfon/fidgit',
+                          software_version: 'v1.0.0',
+                          submitting_author: create(:user),
+                          submission_kind: 'new' }
 
       valid_params = no_track_params.merge track: create(:track)
 


### PR DESCRIPTION
New submissions must include a complete value for the git repository URL.

