### PR TITLE
juliacon proceedings status update

### DIFF
--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -2,7 +2,7 @@
 name: "Proceedings of the JuliaCon Conferences"
 abbreviation: "JCON"
 issn: "2642-4029"
-tagline: "an open-access journal published in cooperation with the <a href='http://www.theoj.org/'>the Open Journals</a>.<br><br> The technical infrastructure of the JuliaCon proceedings are currently being overhauled. We will not be able to accept new submissions until the end of November.<br> We thank you for your understanding, and hope to see your submission then."
+tagline: "an open-access journal published in cooperation with the <a href='http://www.theoj.org/'>the Open Journals</a>.<br><br> The technical infrastructure of the JuliaCon proceedings are currently being overhauled. We will not be able to accept new submissions until the end of February 2024.<br> We thank you for your understanding, and hope to see your submission then."
 logo_url: "http://proceedings.juliacon.org/logo_large.jpg"
 url: "https://proceedings.juliacon.org"
 editor_email: "admin@theoj.org"


### PR DESCRIPTION
note that the previous PR (moving the data to 30th November) apparently did not deploy since the website still says 30th September https://proceedings.juliacon.org/

side note, I created finally the heroku instance @arfon @xuanxu maybe we can have a brief meeting to make the transition happen?

cheers
Luca