### PR TITLE
Updating dashboard

### DIFF
--- a/app/helpers/editors_helper.rb
+++ b/app/helpers/editors_helper.rb
@@ -26,6 +26,13 @@ module EditorsHelper
     "<span class='#{availability_class}' title='#{comment}' %>#{display_count}</span>".html_safe
   end
 
+  def availability_remaining(editor)
+    active_assignments = @assignment_by_editor[editor.id].to_i - @paused_by_editor[editor.id].to_i
+    availability = editor.max_assignments - active_assignments
+
+    return "#{availability}"
+  end
+
   def in_progress_for_editor(editor)
     paused_count = @paused_by_editor[editor.id].to_i
     total_paper_count = @assignment_by_editor[editor.id].to_i

--- a/app/views/editors/index.html.erb
+++ b/app/views/editors/index.html.erb
@@ -14,13 +14,12 @@
 <%= render partial: "aeic_dashboard/menu" %>
 
 <div class="container">
-  <%= link_to 'New Editor', new_editor_path, class: 'btn action-btn float-right' %>
-
   <table class="dashboard-table sortable eic">
     <thead>
       <tr class="text-nowrap">
-        <th scope="col" width="15%">Editor</th>
-        <th scope="col">Categories</th>
+        <th scope="col">Name</th>
+        <th scope="col">Handle</th>
+        <th scope="col" width="30%" >Categories</th>
         <th scope="col" width="8%" class="text-center">Start date</th>
         <th scope="col" width="8%" class="text-center" title="Papers assigned (+ paused)">Editing</th>
         <th scope="col" width="8%" class="text-center">Capacity</th>
@@ -32,14 +31,15 @@
     <tbody>
       <%- @active_editors.each do |editor| %>
       <tr>
+        <td><%= link_to editor.full_name, editor %></td>
         <td sorttable_customkey=<%= editor.login.downcase %>>
-          <%= link_to(image_tag(avatar(editor.login), size: "24x24", class: "avatar", title: editor.full_name), github_user_link(editor.login), target: "_blank") %>
+          <%= link_to(image_tag(avatar(editor.login), size: "32x32", class: "avatar", title: editor.full_name), github_user_link(editor.login), target: "_blank") %>
           <%= link_to editor.login, editor, title: editor.full_name %>
         </td>
         <td style="max-width:250px"><%= editor.category_list %></td>
         <td class="text-center"><%= editor.created_at.strftime('%Y-%m-%d') %></td>
         <td class="text-center" title="Max: <%= editor.max_assignments %>"><%= link_to in_progress_for_editor(editor), "/dashboard/#{editor.login}" %></td>
-        <td class="text-center" title="Limit: <%= editor.max_assignments %>"><%= display_availability(editor) %></td>
+        <td sorttable_customkey=<%= availability_remaining(editor) %> class="text-center" title="Limit: <%= editor.max_assignments %>"><%= display_availability(editor) %></td>
         <td sorttable_customkey=<%= @pending_invitations_by_editor[editor.id].to_i %> class="text-center" title="Invites"><%= open_invites_for_editor(editor) %></td>
         <td><%= link_to 'Edit', edit_editor_path(editor), title: 'Edit' %></td>
       </tr>
@@ -55,38 +55,4 @@
 <br />
 <br />
 
-<div class="container">
-  <div class="col-7">
-    <div class="hero-small dashboard">
-      <div class="hero-title">
-        <%= image_tag "icon_papers.svg", height: "32px" %><h1>Editors Emeritus</h1>
-      </div>
-    </div>
-  </div>
-
-  <table class="dashboard-table">
-    <thead>
-      <tr>
-        <th scope="col" width="15%">Name</th>
-        <th scope="col" width="15%">Login</th>
-        <th scope="col">Categories</th>
-        <th scope="col" width="30%">Description</th>
-        <th scope="col" colspan="2"></th>
-      </tr>
-    </thead>
-
-    <tbody>
-      <%- @emeritus_editors.each do |editor| %>
-      <tr>
-        <td><%= link_to editor.full_name, editor %></td>
-        <td sorttable_customkey=<%= editor.login.downcase %>>
-          <%= link_to image_tag(avatar(editor.login), size: "24x24", class: "avatar", title: github_user_link(editor.login)), github_user_link(editor.login), target: "_blank" %>
-          <%= link_to editor.login, "/dashboard/#{editor.login}" %></td>
-        <td><%= editor.category_list %></td>
-        <td class="d-inline-block text-truncate" style="max-width:450px"><%= editor.description.html_safe %></td>
-        <td><%= link_to 'Edit', edit_editor_path(editor), title: 'Edit' %></td>
-      </tr>
-      <%- end %>
-    </tbody>
-  </table>
 </div>


### PR DESCRIPTION
- Removing "Editors Emeritus" away from the editor dashboard.
- Add the full names for the editorial board members.
- Sorting now is by remaining capacity for an editor rather than their max load.
- Picture icons 50% bigger.

/ cc @Kevin-Mattheus-Moerman 