### PR TITLE
Clarify author metadata check

### DIFF
--- a/docs/editing.md
+++ b/docs/editing.md
@@ -104,7 +104,7 @@ Pre-publication steps:
 - Proof-read the paper and ask authors to fix any remaining typos, badly formed citations, awkward wording, etc..
 - Ask the author to make a tagged release and archive, and report the version number and archive DOI in the review thread.
 - Check the archive deposit has the correct metadata (title and author list)
-  - It is _preferred_ that the metadata author list matches the paper author list
+  - In most situations, the two author lists should match. Authors and editors should review the two, and any differences need to be explained.
     - Other contbutors can be present (and they should be marked as such, if possible)
   - Check that the all authors of the paper are in the archive metadata
   - Eventually, ask for the reason why the two lists differ

--- a/docs/editing.md
+++ b/docs/editing.md
@@ -97,12 +97,17 @@ When a submission is ready to be accepted, we ask that the authors issue a new t
 Optionally you can ask EditorialBot to generate a checklist with all the post-review steps running the command: `@editorialbot create post-review checklist`
 
 Pre-publication steps:
+- (Optional) Run `@editorialbot create post-review checklist`
 - Get a new proof with the `@editorialbot generate pdf` command.
 - Download the proof, check all references have DOIs, follow the links and check the references.
   - EditorialBot can help check references with the command `@editorialbot check references`
 - Proof-read the paper and ask authors to fix any remaining typos, badly formed citations, awkward wording, etc..
 - Ask the author to make a tagged release and archive, and report the version number and archive DOI in the review thread.
-- Check the archive deposit has the correct metadata (title and author list), and request the author edit it if it doesn’t match the paper.
+- Check the archive deposit has the correct metadata (title and author list)
+  - It is _preferred_ that the metadata author list matches the paper author list
+    - Other contbutors can be present (and they should be marked as such, if possible)
+  - Check that the all authors of the papers are in the archive metadata
+  - Eventually, ask for the reason why the two lists differ
 - Run `@editorialbot set <doi> as archive`.
 - Run `@editorialbot set <v1.x.x> as version` if the version was updated.
 - Run `@editorialbot recommend-accept` to generate the final proofs, which has EditorialBot notify the `@openjournals/joss-eics` team that the paper is ready for final processing.

--- a/docs/editing.md
+++ b/docs/editing.md
@@ -106,7 +106,7 @@ Pre-publication steps:
 - Check the archive deposit has the correct metadata (title and author list)
   - It is _preferred_ that the metadata author list matches the paper author list
     - Other contbutors can be present (and they should be marked as such, if possible)
-  - Check that the all authors of the papers are in the archive metadata
+  - Check that the all authors of the paper are in the archive metadata
   - Eventually, ask for the reason why the two lists differ
 - Run `@editorialbot set <doi> as archive`.
 - Run `@editorialbot set <v1.x.x> as version` if the version was updated.


### PR DESCRIPTION
I asked the following on Slack:

> Do the metadata on Zenodo need to match the paper exactly? Or the author list of the paper can be a subset of the authors on Zenodo?

and this PR changes the pre-publication steps according to the answers received.

My current understanding is that it is OK if the authors in the archive metadata don't match the authors on the paper as long as all the authors on the paper are included in the metadata (other contributors should be marked as such, if possible, instead of being marked as authors too).