### PR TITLE
add mention of generate preprint command in preprint policy

### DIFF
--- a/docs/submitting.md
+++ b/docs/submitting.md
@@ -663,6 +663,13 @@ Authors are welcome to submit their papers to a preprint server ([arXiv](https:/
 
 Submission to a preprint server is _not_ considered a previous publication.
 
+```eval_rst
+.. tip::
+
+    To generate a .tex version of your JOSS paper, use the `editorial bot <editorial_bot>`_'s `generate preprint` command from your review issue: ``@editorialbot generate preprint``
+
+````
+
 ## Authorship
 
 Purely financial (such as being named on an award) and organizational (such as general supervision of a research group) contributions are not considered sufficient for co-authorship of JOSS submissions, but active project direction and other forms of non-code contributions are. The authors themselves assume responsibility for deciding who should be credited with co-authorship, and co-authors must always agree to be listed. In addition, co-authors agree to be accountable for all aspects of the work, and to notify JOSS if any retraction or correction of mistakes are needed after publication.


### PR DESCRIPTION
Fix: https://github.com/openjournals/joss/issues/132#issuecomment-1992292617

Add a mention of `@editorialbot generate preprint` to author-facing guides - seems worth doing since the only other place i can see it mentioned is in the editorialbot docs :)