### PR TITLE
Make editor find case insensitive

### DIFF
--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -358,7 +358,7 @@ class Paper < ApplicationRecord
   # Return false if the editor login doesn't match one of the known editors
   def create_review_issue(editor_handle, reviewers, branch=nil)
     return false if review_issue_id
-    return false unless editor = Editor.find_by_login(editor_handle)
+    return false unless editor = Editor.where("lower(login) = ?", editor_handle.downcase).first
 
     if labels.any?
       new_labels = labels.keys + ["review"] - ["pre-review"]


### PR DESCRIPTION
This pull request includes a change to the `review_body` method in the `app/models/paper.rb` file. The change modifies the way the method checks for the existence of an editor. Instead of using `Editor.find_by_login(editor_handle)`, it now uses `Editor.where("lower(login) = ?", editor_handle.downcase).first`, which is case-insensitive. 

This change makes the method more robust by ensuring that it can correctly identify an editor regardless of the case of the `editor_handle` input.

/ cc https://github.com/openjournals/joss-reviews/issues/6809#issuecomment-2228093259