### PR TITLE
fix authors with periods in names

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,7 +57,7 @@ Rails.application.routes.draw do
   get '/editors/lookup/:login', to: "editors#lookup"
   get '/papers/lookup/:id', to: "papers#lookup"
   get '/papers/in/:language', to: "papers#filter", as: 'papers_by_language'
-  get '/papers/by/:author', to: "papers#filter", as: 'papers_by_author'
+  get '/papers/by/:author', to: "papers#filter", as: 'papers_by_author', constraints: { author: /.*(?<!\.html)(?<!\.json)(?<!\.atom)/ }
   get '/papers/edited_by/:editor', to: "papers#filter", as: 'papers_by_editor'
   get '/papers/reviewed_by/:reviewer', to: "papers#filter", as: 'papers_by_reviewer'
   get '/papers/tagged/:tag', to: "papers#filter", as: 'papers_by_tag'

--- a/spec/controllers/papers_controller_spec.rb
+++ b/spec/controllers/papers_controller_spec.rb
@@ -430,4 +430,39 @@ describe PapersController, type: :controller do
       expect(response.media_type).to eq("application/atom+xml")
     end
   end
+
+  describe "Paper/by/{author} route" do
+    it "handles author names with periods" do
+      {
+        :get => "/papers/by/Author%20T.%20Lastname"
+      }.should route_to(
+        controller: "papers",
+        action: "filter",
+        author: "Author T. Lastname"
+      )
+    end
+
+    %w[json atom html].each do |format|
+      it "still allows #{format} suffix to be interpreted as format" do
+        {
+          :get => "/papers/by/Author%20T.%20Lastname.#{format}"
+        }.should route_to(
+          controller: "papers",
+          action: "filter",
+          author: "Author T. Lastname",
+          format: format
+        )
+      end
+
+      it "doesn't choke on #{format} in the middle of a name" do
+        {
+          :get => "/papers/by/Author.#{format}name%20T.%20Lastname"
+        }.should route_to(
+           controller: "papers",
+           action: "filter",
+           author: "Author.#{format}name T. Lastname",
+         )
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fix: https://github.com/openjournals/joss/issues/1346

The problem was that names with periods in them were interpreted as being a file extension (perhaps reasonably?) by the router. So clicking on `"Author T. Lastname"` in a paper would be interpreted by rails as `{author: "Author T", format: " Lastname"}`

So i added a constraint that matches any string excluding the three formats that it looks like there were responders for and added tests - don't know if i put the tests in the right spot, there weren't any tests for the `papers/by/:author` route so i just put it with the controller.

edit: i find ruby's formatting norms to be bewildering and bad, and i didn't notice a linter config in this repo, so sorry if my indentation is weird, feel free to request edits.