### PR TITLE
Development Environment Docs & Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,5 +48,30 @@ Please adhere to this code of conduct in any interactions you have in the JOSS c
 
 [PostgreSQL](https://www.postgresql.org/) and [Elasticsearch](https://www.elastic.co/elasticsearch/) should be installed and running locally for JOSS to work
 
-1. Create the database with `bin/rails db:create`
-2. Run `bin/rails s`
+1. Install packages with bundler - `bundle install`
+2. Set rails env in your shell (or prepend to each command): `export RAILS_ENV=development`
+3. Create the database with `bin/rails db:create`
+4. Run any pending db migrations `bin/rails db:migrate`
+5. (Optional) seed the data with demo data (see `db/seeds.rb`) `bin/rails db:seed`
+6. After running elasticsearch, create an index with `curl -X PUT http://localhost:9200/joss-production`
+   Note - you may need to disable the default security settings of elasticsearch by editing your `config/elasticsearch.yml`
+7. Create search indexes: `bin/rails searchkick:reindex:all`
+8. Run `bin/rails s`
+
+### MacOS Notes
+
+You may encounter an error on startup like:
+
+```
+Started GET "/" for 127.0.0.1 at 2024-08-15 13:03:02 -0700
+objc[41226]: +[__NSCFConstantString initialize] may have been in progress in another thread when fork() was called.
+objc[41226]: +[__NSCFConstantString initialize] may have been in progress in another thread when fork() was called. We cannot safely call it or ignore it in the fork() child process. Crashing instead. Set a breakpoint on objc_initializeAfterForkError to debug.
+```
+
+To resolve it, either in your shell file or in the shell itself add:
+
+```azure
+export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+```
+
+See [rails#38560](https://github.com/rails/rails/issues/38560)

--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -146,7 +146,7 @@ class Paper < ApplicationRecord
   validates :kind, inclusion: { in: Rails.application.settings["paper_types"] }, allow_nil: true
   validates :submission_kind, inclusion: { in: SUBMISSION_KINDS, message: "You must select a submission type" }, allow_nil: false
   validates_format_of :repository_url, with: /\Ahttps?:\/\//i, on: :create, message: "Repository URL is missing the protocol segment (http/https)"
-  validate :check_repository_address, on: :create, unless: Proc.new {|paper| paper.is_a_retraction_notice?}
+  validate :check_repository_address, on: :create, unless: Proc.new {|paper| Rails.env.development? || paper.is_a_retraction_notice?}
 
   def notify_editors
     Notifications.submission_email(self).deliver_now unless self.is_a_retraction_notice?

--- a/config/settings-development.yml
+++ b/config/settings-development.yml
@@ -23,7 +23,7 @@ submission_enquiry: |-
   **Project repository URL:** INSERT YOUR REPOSITORY LINK HERE
 
   Briefly describe your software, its research application and any questions you have about the JOSS submission criteria.
-paper_types: []
+paper_types: ["paper"]
 bot_username: editorialbot
 features:
   tracks: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -354,3 +354,66 @@ Editor.create(
     science-focused Python packages.
   STR
 )
+
+case Rails.env
+when "development"
+  aeic = Editor.create!(
+    kind: "board",
+    first_name: "Editor In Chief",
+    last_name: "Fakington",
+    login: "aeicfake",
+    email: "aeicfake@example.com",
+    categories: ["Astronomy"]
+  )
+  track = Track.create!(
+    code: 0,
+    name: "Railroad",
+    short_name: "rail",
+    aeics: [aeic]
+  )
+  editor = Editor.create!(
+    kind: "topic",
+    first_name: "Lord",
+    last_name: "Fakington",
+    login: "lordfake",
+    email: "lordfake@example.com",
+    categories: ["Astronomy"],
+    tracks: [track]
+  )
+  user = User.create!(
+    name: "Sneakers T. Rat",
+    email: "sneakers@example.com",
+    github_username: "fakeuser_namedoesnt_exist"
+  )
+
+  paper = Paper.create!(
+    editor: editor,
+    submitting_author: user,
+    title: "On the mysteries of draperies and various such textiles",
+    metadata: {'paper' => {
+      'languages' => ["Ruby", "Rust"],
+      'editor' => '@lordfake',
+      'title' => 'mystery/textiles',
+      'reviewers' => ["@fakereviewer1", "@fakereviewer2"],
+      'authors' => [
+        {'given_name' =>  'Mickey', 'last_name' => 'Mouse', 'orcid' => '0000-0002-7736-0000'},
+        {'given_name' => 'Walt', 'middle_name' => 'Elias', 'last_name' => 'Disney', 'orcid' => '0000-0002-7736-000X'},
+        {'given_name' => 'Sneakers', 'middle_name' => 'T.', 'last_name' => 'Rat', 'orcid' => '0000-9992-7736-000X'}
+      ]
+    }},
+    state: "accepted",
+    accepted_at: Time.now,
+    review_issue_id: 0,
+    doi: '10.21105/joss.00000',
+    repository_url: "https://example.com/fakeuser/fakerepo",
+    software_version: "v1.0.0",
+    body: "I am a big old paper about something very cool",
+    track: track,
+    kind: "paper",
+    submission_kind: "new",
+
+  )
+
+else
+  # prod-only seed data
+end


### PR DESCRIPTION
Redo: https://github.com/openjournals/joss/pull/1356 without model annotations

This PR:
- Add more docs on setting up development environment
- Don't validate review repository URLs on creating `Paper` objects if in the development environment so that it's possible to create fake papers/reviews for testing
- Add a "paper" type to dev environment config
- Create some basic seed data for dev environment. 

Questions:
- is the readme the right place? i also notice https://github.com/openjournals/joss/blob/main/docs/installing.md which seems more like if you were to want to do a secondary deployment for a different journal, but just checking
- I only added enough seed data to be able to test https://github.com/openjournals/joss/pull/1357 , so eg. I didn't put a full paper body in there. is there some way to use the factory classes in the `spec` directory like https://github.com/openjournals/joss/blob/main/spec/factories/papers_factory.rb in `db/seeds.rb`? I don't know enough about ruby environments, wasn't sure how to call that, but that would probably be preferable to use those, so then we could create a full seed dataset with all the types of models from the same sources that the tests use. If that is possible/desirable, i can follow on with another PR for that, seems like it would be a nice thing to do both for people checking this out if they wanted to do a secondary deployment and also for quick debugging purposes.