### PR TITLE
[i18n] Add initial stubs for translating the docs

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -1,0 +1,42 @@
+name: Update i18n
+# Ensure that i18n files (for docs and website) are up to date
+# with any changes to the source docs
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  update-i18n-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install deps
+        working-directory: docs
+        run: pip install -r requirements.txt
+
+      - name: Update .po files
+        working-directory: docs
+        run: make i18n
+
+      - name: Test for uncommitted changes
+        run: |
+          if [ -z "$(git status --porcelain)" ];
+          then
+            echo "No changes detected, translations are up to date!" >> $GITHUB_STEP_SUMMARY
+            exit 0
+          else
+            echo "Changes to .po files detected, please run `make i18n` to reflect changes to source text" >> $GITHUB_STEP_SUMMARY
+            echo "$(git status)"
+            echo "$(git diff)"
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ latest.dump*
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+
+__pycache__
+venv

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -14,6 +14,9 @@ help:
 
 .PHONY: help Makefile
 
+i18n:
+	@python ./update_i18n.py
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -133,3 +133,14 @@ myst_enable_extensions = [
     "linkify",
     "strikethrough"
 ]
+
+# -- Internationalization ----------------------------------------------------
+locale_dirs = ['locale/']
+gettext_uuid=True
+
+# All languages to generate .po files for
+languages = [
+    "es", # Spanish
+    "nb", # Norwegian
+    "pl", # Polish
+]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,3 +68,4 @@ JOSS is a proud affiliate of the `Open Source Initiative <https://opensource.org
   :maxdepth: 2
 
   installing
+  translating

--- a/docs/locale/es/LC_MESSAGES/editing.po
+++ b/docs/locale/es/LC_MESSAGES/editing.po
@@ -1,0 +1,799 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: es\n"
+"Language-Team: es <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../editing.md:1 ba75e061942846b39d6400279abb3237
+msgid "Editorial Guide"
+msgstr ""
+
+#: ../../editing.md:3 4425ba5e1b67491e91d218933ae1bedc
+msgid ""
+"The Journal of Open Source Software (JOSS) conducts all peer review and "
+"editorial processes in the open, on the GitHub issue tracker."
+msgstr ""
+
+#: ../../editing.md:5 588c730a7e6140ea92d7ef96a144ba34
+msgid ""
+"JOSS editors manage the review workflow with the help of our bot, "
+"`@editorialbot`. The bot is summoned with commands typed directly on the "
+"GitHub review issues. For a list of commands, type: `@editorialbot "
+"commands`."
+msgstr ""
+
+#: ../../editing.md:8 ea507efa5e7c4203af483f907285e322
+msgid ""
+"To learn more about `@editorialbot`'s functionalities, take a look at our"
+" [dedicated guide](editorial_bot)."
+msgstr ""
+
+#: ../../editing.md:11 01a2380aa2e84215bf133d231a693ea1
+msgid "Overview of editorial process"
+msgstr ""
+
+#: ../../editing.md:13 1d0e9c7d61634731889074477da77a8e
+msgid "**Step 1: An author submits a paper.**"
+msgstr ""
+
+#: ../../editing.md:15 be3c1216b0ef4b4eb0ce620c0486ce3a
+msgid ""
+"The author can choose to select an preferred editor based on the "
+"information available in our biographies. This can be changed later."
+msgstr ""
+
+#: ../../editing.md:17 e89317316a414f3997d43046e0ebca4f
+msgid ""
+"**Step 2: If you are selected as an editor you get @-mentioned in the "
+"pre-review issue.**"
+msgstr ""
+
+#: ../../editing.md:19 7dfb3122440545e2abf13fbce2590990
+msgid ""
+"This doesn’t mean that you’re the editor, just that you’ve been suggested"
+" by the author."
+msgstr ""
+
+#: ../../editing.md:21 3bd75b6544eb40f4a8632660039bfe66
+msgid ""
+"**Step 3: Once you are the editor, find the link to the code repository "
+"in the `pre-review` issue**"
+msgstr ""
+
+#: ../../editing.md:23 5d43095e44a14c4793ad6f4495a55247
+msgid ""
+"If the paper is not in the default branch, add it to the issue with the "
+"command: `@editorialbot set branch-where-paper-is as branch`."
+msgstr ""
+
+#: ../../editing.md:25 dc2a2117853f4cf98427079ca7959f87
+msgid ""
+"**Step 4: The editor looks at the software submitted and checks to see "
+"if:**"
+msgstr ""
+
+#: ../../editing.md:27 c2fa085a985240b5a09962904479e0b5
+msgid "There’s a general description of the software"
+msgstr ""
+
+#: ../../editing.md:28 d08990aef10944a29ce0c0ff47222780
+msgid "The software is within scope as research software"
+msgstr ""
+
+#: ../../editing.md:29 aa784fe1458146bcbf4a6357a20aa4dd
+msgid "It has an OSI-approved license"
+msgstr ""
+
+#: ../../editing.md:31 1616e7978406420985cb59579086bdc9
+msgid ""
+"**Step 5: The editor responds to the author saying that things look in "
+"line (or not) and will search for reviewer**"
+msgstr ""
+
+#: ../../editing.md:33 8d341ffd2d5748a7a2873fe78c1f54f3
+msgid "**Step 6: The editor finds >= 2 reviewers**"
+msgstr ""
+
+#: ../../editing.md:35 f6e3b8184f6448b7987dc9d1856febae
+msgid ""
+"Use the list of reviewers: type the command `@editorialbot list "
+"reviewers` or look at use the [Reviewers Management "
+"System](https://reviewers.joss.theoj.org)"
+msgstr ""
+
+#: ../../editing.md:37 9d1e2e91340549c5a7115b4781afd5ae
+msgid ""
+"If people are in the review list, the editor can @-mention them on the "
+"issue to see if they will review: e.g. `@person1 @person2 can you review "
+"this submission for JOSS?`"
+msgstr ""
+
+#: ../../editing.md:38 bc55566434724ed9bca98d34b52fdead
+msgid ""
+"Or solicit reviewers outside the list. Send an email to people describing"
+" what JOSS is and asking if they would be interested in reviewing."
+msgstr ""
+
+#: ../../editing.md:39 80c9c8dfcae14f43bfc7ff51dfe90c78
+msgid ""
+"If you ask the author to suggest potential reviewers, please be sure to "
+"tell the author not to @-tag their suggestions."
+msgstr ""
+
+#: ../../editing.md:41 50d524d4d91242d89e3d8b53172027c0
+msgid "**Step 7: Editor tells EditorialBot to assign the reviewers to the paper**"
+msgstr ""
+
+#: ../../editing.md:43 ee6ceff15aec4326a765b27464e4e151
+msgid "Use `@editorialbot add @reviewer as reviewer`"
+msgstr ""
+
+#: ../../editing.md:44 faacbbf290f04780b04687fc697eb7a7
+msgid "To add a second reviewer use `@editorialbot add @reviewer2 as reviewer`"
+msgstr ""
+
+#: ../../editing.md:46 2247f7a372ad4610860360322b89a8b9
+msgid "**Step 8: Create the actual review issue**"
+msgstr ""
+
+#: ../../editing.md:48 9f059ce78963480fb5630d0619c405fc
+msgid "Use `@editorialbot start review`"
+msgstr ""
+
+#: ../../editing.md:49 5cce03e372f348b2bbd2bc8bb7ea4255
+msgid ""
+"An issue is created with the review checklist, one per reviewer, e.g. "
+"https://github.com/openjournals/joss-reviews/issues/717"
+msgstr ""
+
+#: ../../editing.md:51 8fec36d962204eb08ac273f7d87f4a91
+msgid "**Step 9: Close the pre-review issue**"
+msgstr ""
+
+#: ../../editing.md:53 8dfb216bd6594395a11a5a73a0ab0665
+msgid "**Step 10: The actual JOSS review**"
+msgstr ""
+
+#: ../../editing.md:55 afd01c95bf5e465d80168253137007ae
+msgid ""
+"The reviewer reviews the paper and has a conversation with the author. "
+"The editor lurks on this conversation and comes in if needed for "
+"questions (or CoC issues)."
+msgstr ""
+
+#: ../../editing.md:56 298bde930f5540d794bb912008afea98
+msgid ""
+"The reviewer potentially asks for changes and the author makes changes. "
+"Everyone agrees it’s ready."
+msgstr ""
+
+#: ../../editing.md:58 e82ce62ae4434ce8a860d7e380585acd
+msgid "**Step 11: The editor pings the EiC team to get the paper published**"
+msgstr ""
+
+#: ../../editing.md:60 3c0819139b644e1090266a2c3f8dfb09
+msgid ""
+"Make a final check of the paper with `@editorialbot generate pdf` and "
+"that all references have DOIs (where appropriate) with `@editorialbot "
+"check references`."
+msgstr ""
+
+#: ../../editing.md:61 8e1bcc08da4f45a3ad2cd0cc88eccb53
+msgid ""
+"If everything looks good, ask the author to make a new release (if "
+"possible) of the software being reviewed and deposit a new archive the "
+"software with Zenodo/figshare. Update the review thread with this archive"
+" DOI: `@editorialbot set 10.5281/zenodo.xxxxxx as archive`."
+msgstr ""
+
+#: ../../editing.md:62 3bdfdd0fffbe4486b9d3eaa0fcc285e5
+msgid ""
+"Editors can get a checklist of the final steps using the `@editorialbot "
+"create post-review checklist` command"
+msgstr ""
+
+#: ../../editing.md:63 dc8a53ae589b4714b782d44e169c6eb4
+msgid ""
+"Finally, use `@editorialbot recommend-accept` on the review thread to "
+"ping the `@openjournals/joss-eics` team letting them know the paper is "
+"ready to be accepted."
+msgstr ""
+
+#: ../../editing.md:65 4ef13c64642d4dddb985e7d7443b615c
+msgid ""
+"**Step 12: Celebrate publication! Tweet! Thank reviewers! Say thank you "
+"on issue.**"
+msgstr ""
+
+#: ../../editing.md:67 abc94aab3bb847aaabd9b314068f769e
+msgid "Visualization of editorial flow"
+msgstr ""
+
+#: ../../editing.md:69 780171765db2498cbffedd0d64336c5f
+msgid "![Editorial flow](images/JOSS-flowchart.png)"
+msgstr ""
+
+#: ../../editing.md:69 49ebbf2f618b4e4aa1d887ee92d811c1
+msgid "Editorial flow"
+msgstr ""
+
+#: ../../editing.md:72 da842b437107499d9f5f02d98142d0ca
+msgid "Pre-review"
+msgstr ""
+
+#: ../../editing.md:74 0dea21b9176141998658732613afcbae
+msgid ""
+"Once a submission comes in, it will be in the queue for a quick check by "
+"the Track Editor-in-chief (TEiC). From there, it moves to a `PRE-REVIEW` "
+"issue, where the TEiC will assign a handling editor, and the author can "
+"suggest reviewers. Initial direction to the authors for improving the "
+"paper can already happen here, especially if the paper lacks some "
+"requested sections."
+msgstr ""
+
+#: ../../editing.md:77 804139f147a14d7a8494d05a58fbda97
+msgid ""
+"If the paper is out-of-scope for JOSS, editors assess this and notify the"
+" author in the ``PRE-REVIEW`` issue."
+msgstr ""
+
+#: ../../editing.md:80 98e964c5547b4becbcdaf2f51775354e
+msgid ""
+"Editors can flag submissions of questionable scope using the command "
+"`@editorialbot query scope`."
+msgstr ""
+
+#: ../../editing.md:82 44c33ad2bbfa430ba1d2ec0031f3d8ed
+msgid ""
+"The TEiC assigns an editor (or a volunteering editor self-assigns) with "
+"the command `@editorialbot assign @username as editor` in a comment."
+msgstr ""
+
+#: ../../editing.md:85 92e566f78ff84e148a7e62170b2b8b6e
+msgid ""
+"Please check in on the "
+"[dashboard](https://joss.theoj.org/dashboard/incoming) semi-regularly to "
+"see which papers are currently without an editor, and if possible, "
+"volunteer to edit papers that look to be in your domain. If you choose to"
+" be an editor in the issue thread type the command `@editorialbot assign "
+"@yourhandle as editor` or simply `@editorialbot assign me as editor`"
+msgstr ""
+
+#: ../../editing.md:88 96324eec2dff4339a9097d19f4f88dbe
+msgid "How papers are assigned to editors"
+msgstr ""
+
+#: ../../editing.md:90 014c09095aeb4cf1b5bc42650b1d168e
+msgid ""
+"By default, unless an editor volunteers, the Track Editor-in-chief (TEiC)"
+" on duty will attempt to assign an incoming paper to the most suitable "
+"handling editor. While TEiC will make every effort to match a submission "
+"with the most appropriate editor, there are a number of situations where "
+"an TEiC may assign a paper to an editor that doesn't fit entirely within "
+"the editor's research domains:"
+msgstr ""
+
+#: ../../editing.md:92 fac8f2d244fd41759d31f0b68f21272f
+msgid "If there's no obvious fit to _any_ of the JOSS editors"
+msgstr ""
+
+#: ../../editing.md:93 87f3e1b98650471fac5779492f60f6c2
+msgid "If the most suitable editor is already handling a large number of papers"
+msgstr ""
+
+#: ../../editing.md:94 6af7d1f654964f4a81937920c4f81453
+msgid "If the chosen editor has a lighter editorial load than other editors"
+msgstr ""
+
+#: ../../editing.md:96 fcee040231ea469a98208739ff188df8
+msgid ""
+"In most cases, the TEiC will ask one or more editors to edit a submission"
+" (e.g. `@editor1, @editor 2 - would one of you be willing to edit this "
+"submission for JOSS`). If the editor doesn't respond within ~3 working "
+"days, the TEiC may assign the paper to the editor regardless."
+msgstr ""
+
+#: ../../editing.md:98 7ead8edc335b4f539c9b9f2b2e18fc0c
+msgid ""
+"Editors may also be invited to edit over email when an TEiC runs the "
+"command `@editorialbot invite @editor1 as editor`."
+msgstr ""
+
+#: ../../editing.md:100 3bf16fb790074ada87a3d4aeb9f427ea
+msgid "Finding reviewers"
+msgstr ""
+
+#: ../../editing.md:102 8dc3490e7abd4a8186526a8eb64fb943
+msgid ""
+"At this point, the handling editor's job is to identify reviewers who "
+"have sufficient expertise in the field of software and in the field of "
+"the submission. JOSS papers have to have a minimum of two reviewers per "
+"submission, except for papers that have previously been peer-reviewed via"
+" rOpenSci. In some cases, the editor also might want to formally add "
+"themselves as one of the reviewers. If the editor feels particularly "
+"unsure of the submission, a third (or fourth) reviewer can be recruited."
+msgstr ""
+
+#: ../../editing.md:104 4bad7fcd46c7403aa7758ed50bd77e66
+msgid ""
+"To recruit reviewers, the handling editor can mention them in the `PRE-"
+"REVIEW` issue with their GitHub handle, ping them on Twitter, or email "
+"them. After expressing initial interest, candidate reviewers may need a "
+"longer explanation via email. See sample reviewer invitation email, "
+"below."
+msgstr ""
+
+#: ../../editing.md:106 682e99ffe4e241eaaf9e3993356ab10a
+msgid "**Reviewer Considerations**"
+msgstr ""
+
+#: ../../editing.md:108 edf7d8efffb045e0965b6b9293648a03
+msgid ""
+"It is rare that all reviewers have the expertise to cover all aspects of "
+"a submission (e.g., knows the language really well and knows the "
+"scientific discipline well). As such, a good practice is to try and make "
+"sure that between the two or three reviewers, all aspects of the "
+"submission are covered."
+msgstr ""
+
+#: ../../editing.md:109 4f10a84abdd14117a2a3152e849c5be5
+msgid ""
+"Selection and assignment of reviewers should adhere to the [JOSS COI "
+"policy](https://joss.theoj.org/about#ethics)."
+msgstr ""
+
+#: ../../editing.md:111 2104a69a5a9042bead939ae983b3c7a0
+msgid "**Potential ways to find reviewers**"
+msgstr ""
+
+#: ../../editing.md:113 136014fdf9e547db8f7b3be69cbd5f00
+msgid ""
+"Finding reviewers can be challenging, especially if a submission is "
+"outside of your immediate area of expertise. Some strategies you can use "
+"to identify potential candidates:"
+msgstr ""
+
+#: ../../editing.md:115 1d3468cc8f104c929ec80034bec03e35
+msgid ""
+"Search the [reviewer application](https://reviewers.joss.theoj.org) of "
+"volunteer reviewers."
+msgstr ""
+
+#: ../../editing.md:116 24b24f22566b400e9d984588466bb29a
+msgid ""
+"When using this spreadsheet, pay attention to the number of reviews this "
+"individual is already doing to avoid overloading them."
+msgstr ""
+
+#: ../../editing.md:117 5ecccfbb623042939b0e2825f92f9b3c
+msgid ""
+"It can be helpful to use the \"Data > Filter Views\" capability to "
+"temporarily filter the table view to include only people with language or"
+" domain expertise matching the paper."
+msgstr ""
+
+#: ../../editing.md:118 89e4d0c5f2c54f5bab1af508c97869c2
+msgid ""
+"Ask the author(s): You are free to ask the submitting author to suggest "
+"possible reviewers by using the [reviewer "
+"application](https://reviewers.joss.theoj.org) and also people from their"
+" professional network. In this situation, the editor still needs to "
+"verify that their suggestions are appropriate."
+msgstr ""
+
+#: ../../editing.md:119 c1f2ce44cb154c3682ace1d6796a6aaa
+msgid ""
+"Use your professional network: You're welcome to invite people you know "
+"of who might be able to give a good review."
+msgstr ""
+
+#: ../../editing.md:120 e49dc26b10b943eea7f86075231528c2
+msgid ""
+"Search Google and GitHub for related work, and write to the authors of "
+"that related work."
+msgstr ""
+
+#: ../../editing.md:121 c8c6d4f9aec24548be6f2a2d26ad284f
+msgid ""
+"Ask on social networks: Sometimes asking on Twitter for reviewers can "
+"identify good candidates."
+msgstr ""
+
+#: ../../editing.md:122 29ba76f084644361b591486d0c4661ab
+msgid "Check the work being referenced in the submission:"
+msgstr ""
+
+#: ../../editing.md:123 8f788d2e5ed34216a7e0434cd7931844
+msgid ""
+"Authors of software that is being built on might be interested in "
+"reviewing the submission."
+msgstr ""
+
+#: ../../editing.md:124 aecd3f6132b548138055f4b72f5ed1ff
+msgid ""
+"Users of the software that is being submission be interested in reviewing"
+" the submission"
+msgstr ""
+
+#: ../../editing.md:125 294125b1c6654509a55a4a87e71bd443
+msgid ""
+"Avoid asking JOSS editors to review: If at all possible, avoid asking "
+"JOSS editors to review as they are generally very busy editing their own "
+"papers."
+msgstr ""
+
+#: ../../editing.md:127 79d5e0b0ef3b486fb67f3fe0511645b2
+msgid ""
+"Once a reviewer accepts, the handling editor runs the command "
+"`@editorialbot add @username as reviewer` in the `PRE-REVIEW` issue. Add "
+"more reviewers with the same command. Under the uncommon circumstance "
+"that a review must be started before all reviewers have been identified "
+"(e.g., if finding a second reviewer is taking a long time and the first "
+"reviewer wants to get started), an editor may elect to start the review "
+"and add the remaining reviewers later. To accomplish this, the editor "
+"will need to hand-edit the review checklist to create space for the "
+"reviewers added after the review issues is created."
+msgstr ""
+
+#: ../../editing.md:130 16ba9cbed3c94a629a7aff1bd90c6291
+msgid "Starting the review"
+msgstr ""
+
+#: ../../editing.md:132 ccd53f6c37f242b1b911877fa7e9c1b9
+msgid ""
+"Next, run the command `@editorialbot start review`. If you haven't "
+"assigned an editor and reviewer, this command will fail and "
+"`@editorialbot` will tell you this. This will open the `REVIEW` issue, "
+"with prepared review checklists for each reviewer, and instructions. The "
+"editor should move the conversation to the separate `REVIEW` issue."
+msgstr ""
+
+#: ../../editing.md:134 3cbe8574ab8f4792ae7f8fe839e05c89
+msgid "Review"
+msgstr ""
+
+#: ../../editing.md:136 bf31464bd63349f3ba503187408dac67
+msgid ""
+"The `REVIEW` issue contains some instructions for the reviewers to get a "
+"checklist using the command `@editorialbot generate my checklist`. The "
+"reviewer(s) should check off items of the checklist one-by-one, until "
+"done. In the meantime, reviewers can engage the authors freely in a "
+"conversation aimed at improving the paper."
+msgstr ""
+
+#: ../../editing.md:138 dcd070b1d78e440099f479ff0a2a7e9e
+msgid ""
+"If a reviewer recants their commitment or is unresponsive, editors can "
+"remove them with the command `@editorialbot remove @username from "
+"reviewers`. You can also add new reviewers in the `REVIEW` issue."
+msgstr ""
+
+#: ../../editing.md:140 e3e6abaa736c4364b7a380072fbdefe9
+msgid ""
+"Comments in the `REVIEW` issue should be kept brief, as much as possible,"
+" with more lengthy suggestions or requests posted as separate issues, "
+"directly in the submission repository. A link-back to those issues in the"
+" `REVIEW` is helpful."
+msgstr ""
+
+#: ../../editing.md:142 6dc3f0fe1e9c4c8bae2c397282f35570
+msgid ""
+"When the reviewers are satisfied with the improvements, we ask that they "
+"confirm their recommendation to accept the submission."
+msgstr ""
+
+#: ../../editing.md:144 3d33796171b4423b9498b2019870a5bb
+msgid "Adding a new reviewer once the review has started"
+msgstr ""
+
+#: ../../editing.md:146 223e9320e2f241fbad473c96d116ec25
+msgid ""
+"Sometimes you'll need to add a new reviewer once the main review (i.e. "
+"post pre-review) is already underway. In this situation you should do the"
+" following:"
+msgstr ""
+
+#: ../../editing.md:148 2c32f175245f49e4bbfb7b9cbba3f175
+msgid "In the review thread, do `@editorialbot add @newreviewer as reviewer`."
+msgstr ""
+
+#: ../../editing.md:149 ee79dc393c664659a4630aae28ac15cf
+msgid ""
+"The new reviewer must use the command `@editorialbot generate my "
+"checklist` to get a checklist."
+msgstr ""
+
+#: ../../editing.md:152 98b3a290d25d4f2b81fe1a2c529f8aaa
+msgid "Post-review"
+msgstr ""
+
+#: ../../editing.md:154 b0385263d4914f7f95ad0ba80654bda3
+msgid ""
+"When a submission is ready to be accepted, we ask that the authors issue "
+"a new tagged release of the software (if changed), and archive it (on "
+"[Zenodo](https://zenodo.org/), [fig**share**](https://figshare.com/), or "
+"other). The authors then post the version number and archive DOI in the "
+"`REVIEW` issue. The handling editor executes the pre-publication steps, "
+"and pings the Track Editor-in-Chief for final processing."
+msgstr ""
+
+#: ../../editing.md:156 dd52392784634b948e15a964b80cc429
+msgid ""
+"Optionally you can ask EditorialBot to generate a checklist with all the "
+"post-review steps running the command: `@editorialbot create post-review "
+"checklist`"
+msgstr ""
+
+#: ../../editing.md:158 ee9fcf7e3bce4bf68049aa27061cfa26
+msgid "Pre-publication steps:"
+msgstr ""
+
+#: ../../editing.md:159 c1789b1a6ebd45de969fdd00d51e3384
+msgid "(Optional) Run `@editorialbot create post-review checklist`"
+msgstr ""
+
+#: ../../editing.md:160 ab121be0a95345ea93212c99be108c04
+msgid "Get a new proof with the `@editorialbot generate pdf` command."
+msgstr ""
+
+#: ../../editing.md:161 fe48b1e1bb3b4016a571de52fcb8acdb
+msgid ""
+"Download the proof, check all references have DOIs, follow the links and "
+"check the references."
+msgstr ""
+
+#: ../../editing.md:162 96ff3f242de14c91b1b16b870cf57190
+msgid ""
+"EditorialBot can help check references with the command `@editorialbot "
+"check references`"
+msgstr ""
+
+#: ../../editing.md:163 d101dc7a7cf44f42b1435e34cd9945a8
+msgid ""
+"Proof-read the paper and ask authors to fix any remaining typos, badly "
+"formed citations, awkward wording, etc.."
+msgstr ""
+
+#: ../../editing.md:164 2ffdfd41c5d34a12b80a07a8be7255ab
+msgid ""
+"Ask the author to make a tagged release and archive, and report the "
+"version number and archive DOI in the review thread."
+msgstr ""
+
+#: ../../editing.md:165 3051b32771ed4fa6beb9efa4f8bc99da
+msgid "Check the archive deposit has the correct metadata (title and author list)"
+msgstr ""
+
+#: ../../editing.md:166 ccf9d0666940483f8d57c5642b830627
+msgid ""
+"In most situations, the two author lists should match. Authors and "
+"editors should review the two, and any differences need to be explained."
+msgstr ""
+
+#: ../../editing.md:167 ac196a6ce5104305ad119ebce0706214
+msgid ""
+"Other contributors can be present (and they should be marked as such, if "
+"possible)"
+msgstr ""
+
+#: ../../editing.md:168 7c48124d7b1f42a1a82476eb5fc66d14
+msgid "Check that the all authors of the paper are in the archive metadata"
+msgstr ""
+
+#: ../../editing.md:169 40166d1d39d24148a9100d4360f6ca19
+msgid "Eventually, ask for the reason why the two lists differ"
+msgstr ""
+
+#: ../../editing.md:170 cd935c631a74446bbfc43553b9bb07e6
+msgid "Run `@editorialbot set <doi> as archive`."
+msgstr ""
+
+#: ../../editing.md:171 368d9095453b4bd18c092dc6e21e04c1
+msgid "Run `@editorialbot set <v1.x.x> as version` if the version was updated."
+msgstr ""
+
+#: ../../editing.md:172 9ac44e6c0edb46868744955ea9c0150d
+msgid ""
+"Run `@editorialbot recommend-accept` to generate the final proofs, which "
+"has EditorialBot notify the `@openjournals/joss-eics` team that the paper"
+" is ready for final processing."
+msgstr ""
+
+#: ../../editing.md:174 badc1c00d346425281eade6905e889fd
+msgid ""
+"At this point, the EiC/AEiC will take over to make final checks and "
+"publish the paper."
+msgstr ""
+
+#: ../../editing.md:176 77f1a1c6606547e3ab5ea9ca88f7d7dd
+msgid ""
+"It’s also a good idea to ask the authors to check the proof. We’ve had a "
+"few papers request a post-publication change of author list, for "
+"example—this requires a manual download/compile/deposit cycle and should "
+"be a rare event."
+msgstr ""
+
+#: ../../editing.md:179 c5a921af2ecc436eb220853ae603677a
+msgid "Rejecting a paper"
+msgstr ""
+
+#: ../../editing.md:181 8efdd60bb1cb44bdb5051d9d1a7566aa
+msgid ""
+"If you believe a submission should be rejected, for example, because it "
+"is out of scope for JOSS, then you should:"
+msgstr ""
+
+#: ../../editing.md:183 cf41a6d5b66d4a5987759324687f6bcc
+msgid ""
+"Ask EditorialBot to flag the submission as potentially out of scope with "
+"the command `@editorialbot query scope`. This command adds the `query-"
+"scope` label to the issue."
+msgstr ""
+
+#: ../../editing.md:184 fae66735afaa4048a0dbf3c52e71361a
+msgid ""
+"Mention to the author your reasons for flagging the submission as "
+"possibly out of scope, and _optionally_ give them an opportunity to "
+"defend their submission."
+msgstr ""
+
+#: ../../editing.md:185 f8412a3f08914dbd85c5da0f52ebe973
+msgid ""
+"During the scope review process, the editorial team may ask the authors "
+"to provide additional information about their submission to assist the "
+"editorial board with their decision."
+msgstr ""
+
+#: ../../editing.md:186 968111ab343f41ce81c9d602c9b5278f
+msgid ""
+"The TEiC will make a final determination of whether a submission is in "
+"scope, taking into account the feedback of other editors."
+msgstr ""
+
+#: ../../editing.md:188 6ec183d943404235a37ba3d47089981f
+msgid "**Scope reviews for resubmissions**"
+msgstr ""
+
+#: ../../editing.md:190 68327f04c16a46fbb0d61cb884365a69
+msgid ""
+"In the event that an author re-submits a paper to JOSS that was "
+"previously rejected, the TEiC will use their discretion to determine: 1) "
+"whether a full scope review by the entire editorial team is necessary, 2)"
+" if the previous reasons for rejection remain valid, or 3) if there have "
+"been enough updates to warrant sending the submission out for review."
+msgstr ""
+
+#: ../../editing.md:192 d326cebcc2c645e78ff94af22dd9cedd
+msgid "JOSS Collaborations"
+msgstr ""
+
+#: ../../editing.md:194 f99912839e0344578a143c27763823ae
+msgid "AAS publishing"
+msgstr ""
+
+#: ../../editing.md:196 e3b861edaece45999cf91c771506c552
+msgid ""
+"JOSS is collaborating with [AAS publishing](https://journals.aas.org/) to"
+" offer software review for some of the papers submitted to their "
+"journals. A detailed overview of the motivations/background is available "
+"in the [announcement blog post](https://blog.joss.theoj.org/2018/12/a"
+"-new-collaboration-with-aas-publishing), here we document the additional "
+"editorial steps that are necessary for JOSS to follow:"
+msgstr ""
+
+#: ../../editing.md:198 430ed54db1b84ce3b8fc3454c026de24
+msgid "**Before/during review**"
+msgstr ""
+
+#: ../../editing.md:200 2824e9d988df40d39bd555ab5021a72b
+#, python-format
+msgid ""
+"If the paper is a joint publication, make sure you apply the "
+"[`AAS`](https://github.com/openjournals/joss-"
+"reviews/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3AAAS+) label to both "
+"the `pre-review` and the `review` issues."
+msgstr ""
+
+#: ../../editing.md:201 fbab9c2ddbf24bc3be059c5caff98168
+msgid ""
+"Before moving the JOSS paper from `pre-review` to `review`, ensure that "
+"you (the JOSS editor) make the reviewers aware that JOSS will be "
+"receiving a small financial donation from AAS publishing for this review "
+"(e.g. [like this](https://github.com/openjournals/joss-"
+"reviews/issues/1852#issuecomment-553203738))."
+msgstr ""
+
+#: ../../editing.md:203 bd6a4d0ce06b4ef992111f0b0fab8ec9
+msgid "**After the paper has been accepted by JOSS**"
+msgstr ""
+
+#: ../../editing.md:205 15fc7b6817dd4a34a3738b6ddf38803f
+msgid ""
+"Once the JOSS review is complete, ask the author for the status of their "
+"AAS publication, specifically if they have the AAS paper DOI yet."
+msgstr ""
+
+#: ../../editing.md:206 1f05887484b3458c919fb4e94c3d54a7
+msgid ""
+"Once this is available, ask the author to add this information to their "
+"`paper.md` YAML header as documented in the [submission "
+"guidelines](paper.md#what-should-my-paper-contain)."
+msgstr ""
+
+#: ../../editing.md:215 451308dd5cd24ada9f6722ba8c1a0af9
+msgid ""
+"Pause the review (by applying the `paused` label) to await notification "
+"that the AAS paper is published."
+msgstr ""
+
+#: ../../editing.md:217 4ff28cbd250c4fceb96de378b856ac9b
+msgid "**Once the AAS paper is published**"
+msgstr ""
+
+#: ../../editing.md:219 bf3b62f96e854102825cd412df62de48
+msgid ""
+"Ask the EiC on rotation to publish the paper as normal (by tagging "
+"`@openjournals/joss-eics`)."
+msgstr ""
+
+#: ../../editing.md:221 a93e797d3cf34ede894cb4b3b3c8b0b4
+msgid "rOpenSci-reviewed or pyOpenSci-reviewed and accepted submissions"
+msgstr ""
+
+#: ../../editing.md:223 d405d6dec9e14b038b65cfc2b48521be
+msgid ""
+"If a paper has already been reviewed and accepted by rOpenSci or "
+"pyOpenSci, the streamlined JOSS review process is:"
+msgstr ""
+
+#: ../../editing.md:225 428f938147824290aaaed1b3fc54a753
+msgid "Assign yourself as editor and reviewer"
+msgstr ""
+
+#: ../../editing.md:226 564417ceb9e649d2bd8c9a9bfb405a6b
+msgid ""
+"Add a comment in the pre-review issue pointing to the rOpenSci or "
+"pyOpenSci review"
+msgstr ""
+
+#: ../../editing.md:227 8b7f7c94e76441c6ae25d3737691114d
+msgid "Add the rOpenSci/pyOpenSci label to the pre-review issue"
+msgstr ""
+
+#: ../../editing.md:228 cfd6fcb87a664d24993490dbb413a97f
+msgid "Start the review issue"
+msgstr ""
+
+#: ../../editing.md:229 cf1a6126e15a4f00acbde92f4ecda2f6
+msgid ""
+"Add a comment in the review issue pointing to the rOpenSci or pyOpenSci "
+"review"
+msgstr ""
+
+#: ../../editing.md:230 e6326b05c5ce4cce8be342399b12699a
+msgid "Compile the paper and check it looks OK"
+msgstr ""
+
+#: ../../editing.md:231 4054dfb927f34f0ebb7728cb76dcf2c2
+msgid "Go to to the source code repo and grab the Zenodo DOI"
+msgstr ""
+
+#: ../../editing.md:232 4be4829b0bc740f293b518b74c728de1
+msgid "Accept and publish the paper"
+msgstr ""
+

--- a/docs/locale/es/LC_MESSAGES/editor_onboarding.po
+++ b/docs/locale/es/LC_MESSAGES/editor_onboarding.po
@@ -1,0 +1,501 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: es\n"
+"Language-Team: es <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../editor_onboarding.md:1 ddb34aa291fa467782c10edc4e35d8ec
+msgid "Editor Onboarding"
+msgstr ""
+
+#: ../../editor_onboarding.md:3 4470f6e71d994a41bc3b0be762b41e49
+msgid "Onboarding a new JOSS editor"
+msgstr ""
+
+#: ../../editor_onboarding.md:5 7a2a0c328d17494296e4f01b7422db62
+msgid ""
+"All new editors at JOSS have an onboarding call with an Editor-in-Chief. "
+"You can use the structure below to make sure you highlight the most "
+"important aspects of being an editor."
+msgstr ""
+
+#: ../../editor_onboarding.md:7 f980df4541fe4b068ece12e9398edac7
+msgid "**Thing to check before the call**"
+msgstr ""
+
+#: ../../editor_onboarding.md:9 af4253ba4430455bb650d2f4cb581162
+msgid ""
+"Have they reviewed or published in JOSS before? If not, you'll need to "
+"spend significantly more time explaining how the review process works."
+msgstr ""
+
+#: ../../editor_onboarding.md:10 367afd43cfd54e6c86cde5bae5877cdd
+msgid ""
+"Check on their research background (e.g., what tracks they might edit "
+"most actively in)."
+msgstr ""
+
+#: ../../editor_onboarding.md:11 dcfc47c7f9804d4f8b882ab744958e48
+msgid ""
+"Make sure to send them the [editorial "
+"guide](https://joss.readthedocs.io/en/latest/editing.html) to read before"
+" the call."
+msgstr ""
+
+#: ../../editor_onboarding.md:13 e284abf557264473b259da6e015f2cea
+msgid "The onboarding call"
+msgstr ""
+
+#: ../../editor_onboarding.md:15 26bc3820950d4500bc9e20f4c4414eb1
+msgid "**Preamble/introductions**"
+msgstr ""
+
+#: ../../editor_onboarding.md:17 0288d672dd644d869574fe8651ef8880
+msgid "Welcome! Thank them for their application to join the team."
+msgstr ""
+
+#: ../../editor_onboarding.md:18 fc4b238db8ee4f83be7ba4ca0bc59fb9
+msgid ""
+"Point out that this isn't an interview. Rather, this is an informational "
+"call designed to give the candidate the information they need to make an "
+"informed decision about editing at JOSS."
+msgstr ""
+
+#: ../../editor_onboarding.md:19 da6f67fa611c48c6bad424c28d3951a9
+msgid ""
+"90-day trial period/try out. Editor or JOSS editorial board can decide to"
+" part ways after that period."
+msgstr ""
+
+#: ../../editor_onboarding.md:20 0e10b197ceca4bfc86456fb0c1192d23
+msgid ""
+"No strict term limits. Some editors have been with us for 7+ years, "
+"others do 1-2 years. Most important thing is to be proactive with your "
+"editing responsibilities and communicating any issues with the EiCs."
+msgstr ""
+
+#: ../../editor_onboarding.md:21 d154b8c176bf47159aaddb9e58e4452c
+msgid "Confirm with them their level of familiarity with JOSS/our review process."
+msgstr ""
+
+#: ../../editor_onboarding.md:22 660c4e8cc8d042e08cedb31cff5d0dcb
+msgid ""
+"Point out that they *do not* need to make a decision on the call today. "
+"They are welcome to have a think about joining and get back to us."
+msgstr ""
+
+#: ../../editor_onboarding.md:24 ff266d9d359d4404b1f7d46e7bfa3f6e
+msgid "**Share your screen**"
+msgstr ""
+
+#: ../../editor_onboarding.md:26 90c995e80f744e3f85b69f1af85caae6
+msgid "Visit JOSS (https://joss.theoj.org)"
+msgstr ""
+
+#: ../../editor_onboarding.md:27 df997b30aea14f7bae260fb0f87e5a2b
+msgid ""
+"Pick a recently-published paper (you might want to identify this before "
+"the call one that shows off the review process well)."
+msgstr ""
+
+#: ../../editor_onboarding.md:28 e0bf12eb96994b469b6478049c9d70b0
+msgid "Show the paper on the JOSS site, and then go to the linked review issue."
+msgstr ""
+
+#: ../../editor_onboarding.md:29 c04aa708d2ba4de787763ba25b8460a8
+msgid ""
+"Explain that there are *two* issues per submission – the pre-review issue"
+" and the main review issue."
+msgstr ""
+
+#: ../../editor_onboarding.md:31 ebedb7d569f143b7901d1e5920d334ab
+msgid "**The pre-review issue**"
+msgstr ""
+
+#: ../../editor_onboarding.md:33 6c3464eb92a14c1ea6d4b264b68baaa7
+msgid ""
+"The 'meeting room for the paper'. Where author meets editor, and "
+"reviewers are identified."
+msgstr ""
+
+#: ../../editor_onboarding.md:34 43f5cee5fd4040fbb79f098fe9809d54
+msgid ""
+"Note that the EiC may have initiated a scope review. The editor should "
+"not start editing until this has completed. Also, editors are able to "
+"query the scope (as are reviewers) if they think the EiC should have (but"
+" didn't)."
+msgstr ""
+
+#: ../../editor_onboarding.md:35 411abf04587a4cbf8f75697715c489a9
+msgid "Walk them through what is happening in the pre-review issue..."
+msgstr ""
+
+#: ../../editor_onboarding.md:36 b737b32ada224c4bb1f3257819a037cf
+msgid ""
+"Editor is invited (likely with GitHub mention but also via email invite "
+"(`@editorialbot invite @editor as editor`))"
+msgstr ""
+
+#: ../../editor_onboarding.md:37 e7cb4bb86a9344e6b3c83a57b8295014
+msgid "Once editor accepts they start looking for reviewers."
+msgstr ""
+
+#: ../../editor_onboarding.md:39 2241d7556d9344b0bf3d888fbd589f75
+msgid "**Finding reviewers**"
+msgstr ""
+
+#: ../../editor_onboarding.md:41 bc39c6a124ce4ab9bb5966d25e08574f
+msgid "Explain that this is one of the more time-intensive aspects of editing."
+msgstr ""
+
+#: ../../editor_onboarding.md:42 4d11d78ab4224553b74d70cf8c81b1c9
+msgid ""
+"Explain where you can look for editors (your own professional network, "
+"asking the authors for recommendations, the [reviewers "
+"application](https://reviewers.joss.theoj.org/), similar papers "
+"identified by Editorialbot, )"
+msgstr ""
+
+#: ../../editor_onboarding.md:43 257f9d1b6ede475da45d8dfd2b8cd0e4
+msgid ""
+"Point out that we have a minimum of two reviewers, but if more than that "
+"accept (e.g., 3/4 then take them all – this gives you redundancy if one "
+"drops out)."
+msgstr ""
+
+#: ../../editor_onboarding.md:44 b9b7f5b236234980b8338708625b6c99
+msgid ""
+"Don't invite only one reviewer at a time! If you do this, it may take "
+"many weeks to find two reviewers who accept. Try 3/4/5 invites "
+"simultaneously."
+msgstr ""
+
+#: ../../editor_onboarding.md:45 958063b5e00d409986233f3c63a01288
+msgid ""
+"The [sample messages](sample_messages) section of the documentation has "
+"some example language you can use."
+msgstr ""
+
+#: ../../editor_onboarding.md:47 32dd245a660d4f8f9f9a6f0dd237a14b
+msgid "**The review**"
+msgstr ""
+
+#: ../../editor_onboarding.md:49 6e2a3f7b1656412dbb572f635fcf461c
+msgid "Once at least two reviewers are assigned, time to get going!"
+msgstr ""
+
+#: ../../editor_onboarding.md:50 5fba2497e6b1466a85ae9172fce563e0
+msgid "Encourage reviewers to complete their review in 4-6 weeks."
+msgstr ""
+
+#: ../../editor_onboarding.md:51 81a249a1d7ea458d86906e025a10c1ca
+msgid ""
+"Make sure to check in on the review – if reviewers haven't started after "
+"~1-2 weeks, time to remind them."
+msgstr ""
+
+#: ../../editor_onboarding.md:52 08f9e20221544c80be398b68741ca9f2
+msgid ""
+"Your role as editor is not to do the review yourself, rather, your job is"
+" to ensure that both reviewers give a good review and to facilitate "
+"discussion and consensus on what the author needs to do."
+msgstr ""
+
+#: ../../editor_onboarding.md:53 4a7a2460acb24ceeb3ffabd0f91b46fe
+msgid ""
+"Walk the editor through the various review artifacts: The checklist, "
+"comments/questions/discussion between reviewers and author, issues opened"
+" on the upstream repository (and cross-linked into the review thread)."
+msgstr ""
+
+#: ../../editor_onboarding.md:54 37291112d1d24315a1986185a1889f9b
+msgid ""
+"Point editors to the ['top tips'](editor_tips) section of our docs. Much "
+"of what makes an editor successful is regular check-ins on the review, "
+"and nudging people if nothing is happening."
+msgstr ""
+
+#: ../../editor_onboarding.md:55 81b8bcab7a7c4866a1ce5d80f36f21a0
+msgid "Do *not* let a review go multiple weeks without checking in."
+msgstr ""
+
+#: ../../editor_onboarding.md:57 55f437eb8c484edc8358b4b68812fe8b
+msgid "**Wrapping up the review**"
+msgstr ""
+
+#: ../../editor_onboarding.md:59 e24ad8981bcd4ea7a3ed82eabeb35cdf
+msgid ""
+"Once the review is wrapping up, show the candidate the checks that an "
+"editor should be doing (reading the paper, suggested edits, asking for an"
+" archive etc.)"
+msgstr ""
+
+#: ../../editor_onboarding.md:60 a7dc51a9e76d46dbbaf8382844910310
+msgid ""
+"Show the `recommend-accept` step which is the formal hand-off between "
+"editor and editor-in-chief."
+msgstr ""
+
+#: ../../editor_onboarding.md:61 cc1e0eb549fc462088805e50b4310680
+msgid ""
+"The [sample messages](sample_messages) section of the documentation has a"
+" checklist for the last steps of the review (for both authors and "
+"editors)."
+msgstr ""
+
+#: ../../editor_onboarding.md:64 de4909e22b204f90b674d316ada8efab
+msgid "**Show them the dashboard on the JOSS site**"
+msgstr ""
+
+#: ../../editor_onboarding.md:66 1646494e0e7f438fb5ae2ae411724336
+msgid ""
+"Point out that this means you *do not* need to stay on top of all of your"
+" notifications (the dashboard has the latest information)."
+msgstr ""
+
+#: ../../editor_onboarding.md:67 fd5cb0e8de564c4cb29ebd8f1c8af3df
+msgid ""
+"Highlight here that we ask editors to handle 8-12 submissions per year on"
+" average."
+msgstr ""
+
+#: ../../editor_onboarding.md:68 3583962d5d484e40a914d1e7686d4f6e
+msgid ""
+"...and that means 3-4 submissions on their desk at any one time (once "
+"they have completed their initial probationary period)."
+msgstr ""
+
+#: ../../editor_onboarding.md:69 4cf41efd823e4bbfa2379b5ea90ce9d9
+msgid ""
+"Show them the backlog for a track, and how they are welcome to pick "
+"papers from it (ideally oldest first)."
+msgstr ""
+
+#: ../../editor_onboarding.md:70 cc536af2918645c290f873f07dbfd5b7
+msgid ""
+"Show them their profile page, and how they can list their tracks there, "
+"and also what their availability is."
+msgstr ""
+
+#: ../../editor_onboarding.md:72 532406aae528432c8e6b8da2538281cf
+msgid "**Other important things to highlight**"
+msgstr ""
+
+#: ../../editor_onboarding.md:74 0d82dd40846f4a688a25ef91c634db8d
+msgid ""
+"Don't invite other editors as reviewers. We're all busy editing our own "
+"papers..."
+msgstr ""
+
+#: ../../editor_onboarding.md:75 2b19e938b20648679ccb8b70188f7c45
+msgid ""
+"Please be willing to edit outside of your specialisms. This helps JOSS "
+"run smoothly – often we don't have the 'ideal' editor for a submission "
+"and someone has to take it."
+msgstr ""
+
+#: ../../editor_onboarding.md:76 311d1b82d8e845f790edd906dc77e098
+msgid ""
+"Highlight that editors will have a buddy to work with for the first few "
+"months, and that it's very common for editors to ask questions in Slack "
+"(and people generally respond quickly)."
+msgstr ""
+
+#: ../../editor_onboarding.md:77 f8d7387c02164ea5b55945c48a7a6e25
+msgid ""
+"Scope reviews only work if editors vote! Please respond and vote on the "
+"weekly scope review email if you can. The process is private (authors "
+"don't know what editors are saying). Detailed comments are really helpful"
+" for the EiCs."
+msgstr ""
+
+#: ../../editor_onboarding.md:79 76170cd543ae4bc988d3e904381a1a35
+msgid "**Wrapping up**"
+msgstr ""
+
+#: ../../editor_onboarding.md:81 ec717aaa4f5c413a94e6b5246b09f47c
+msgid ""
+"Make sure you've highlighted everything in the ['top tips'](editor_tips) "
+"section of our docs."
+msgstr ""
+
+#: ../../editor_onboarding.md:82 ed7d3ee869a74d3ab0a208774debdcce
+msgid ""
+"Reinforce that this is a commitment, and thay regular attention to their "
+"submissions is absolutely critical (i.e., check in a couple of times per "
+"week)."
+msgstr ""
+
+#: ../../editor_onboarding.md:83 7f4f97f224a9454a89fcad728d2aec7c
+msgid ""
+"Ask if they would like to move forward or would like time to consider the"
+" opportunity."
+msgstr ""
+
+#: ../../editor_onboarding.md:84 1d4a5693fcf0457297ce32e038486299
+msgid ""
+"If they want to move forward, highlight they will receive a small number "
+"of invites: One to the JOSS editors GitHub team, a Slack invite, a Google"
+" Group invite, and an invite to the JOSS website to fill out their "
+"profile."
+msgstr ""
+
+#: ../../editor_onboarding.md:85 ad062cf91d9140008983e44436bf16bf
+msgid ""
+"If they are joining the team, make sure they mark themselves as "
+"unavailable in the [JOSS reviewers "
+"database](https://reviewers.joss.theoj.org/) (so they don't get asked to "
+"review any longer)."
+msgstr ""
+
+#: ../../editor_onboarding.md:86 959c06266b3340ccb404aa56a4515168
+msgid "Thank them again, and welcome them to the team."
+msgstr ""
+
+#: ../../editor_onboarding.md:88 57e5e7cc9d8c45a98704e42774733642
+msgid "**Communicate outcome to EiC**"
+msgstr ""
+
+#: ../../editor_onboarding.md:90 2695b240ae514e95b277e796e01d9d52
+msgid ""
+"Let the EiC know what the outcome was, and ask them to send out the "
+"invites to our various systems."
+msgstr ""
+
+#: ../../editor_onboarding.md:91 d3d7f5c61f004cd3831fc98199465ea9
+msgid "Work with EiC to identify onboarding buddy."
+msgstr ""
+
+#: ../../editor_onboarding.md:92 47c06ec3ec51411e85136587a501d84f
+msgid ""
+"Decide who is going to identify the first couple of papers for the editor"
+" to work on."
+msgstr ""
+
+#: ../../editor_onboarding.md:94 9103afd226aa4cfb93da986195af690d
+msgid "Editorial buddy"
+msgstr ""
+
+#: ../../editor_onboarding.md:96 52cc074f70f0452eb7aa5a54f58904e8
+msgid ""
+"New editors are assigned an editorial 'buddy' from the existing editorial"
+" team. The buddy is there to help the new editor onboard successfully and"
+" to provide a dedicated resource for any questions they might have but "
+"don't feel comfortable posting to the editor mailing list."
+msgstr ""
+
+#: ../../editor_onboarding.md:98 9b402229e4634e12a3be6084b380eb10
+msgid ""
+"Buddy assignments don't have a fixed term but generally require a "
+"commitment for 1-2 months."
+msgstr ""
+
+#: ../../editor_onboarding.md:100 c2e8c9ac253c48e08bf6919d135ec14d
+msgid "Some things you might need to do as a buddy for a new editor:"
+msgstr ""
+
+#: ../../editor_onboarding.md:102 93318044114a41c1a48256c92ba8839b
+msgid "Respond to questions via email or on GitHub review issues."
+msgstr ""
+
+#: ../../editor_onboarding.md:103 cf3e5a5a01464d21a0b380bb217202cf
+msgid ""
+"Check in with the new editor every couple of weeks if there hasn't been "
+"any other communication."
+msgstr ""
+
+#: ../../editor_onboarding.md:104 985001ec82aa4d67b2cb85a902d46531
+msgid "(Optionally) keep an eye on the new editor's submissions."
+msgstr ""
+
+#: ../../editor_onboarding.md:106 8b15cb26b49a482ab1161d587f7b4e85
+msgid "Managing notifications"
+msgstr ""
+
+#: ../../editor_onboarding.md:108 4b7b9807a9144dbba387399414759885
+msgid ""
+"Being on the JOSS editorial team means that there can be a _lot_ of "
+"notifications from GitHub if you don't take some proactive steps to "
+"minimize noise from the reviews repository."
+msgstr ""
+
+#: ../../editor_onboarding.md:110 4192d1ba00c44387b937cfe75bb00346
+msgid "Things you should do when joining the editorial team"
+msgstr ""
+
+#: ../../editor_onboarding.md:112 ff696e608e4a489abe1e1b1940566fc6
+msgid "**Curate your GitHub notifications experience**"
+msgstr ""
+
+#: ../../editor_onboarding.md:114 5651eddd6cc447a189ce01c753bd5263
+msgid ""
+"GitHub has extensive documentation on [managing "
+"notifications](https://help.github.com/en/articles/managing-your-"
+"notifications) which explains when and why different notifications are "
+"sent from a repository."
+msgstr ""
+
+#: ../../editor_onboarding.md:116 a51c81c5cf2f4c5b9d3678f6cfd63265
+msgid "**Set up email filters**"
+msgstr ""
+
+#: ../../editor_onboarding.md:118 aff07e303eb9460b9287e949edd244ec
+msgid ""
+"Email filters can be very useful for managing incoming email "
+"notifications, here are some recommended resources:"
+msgstr ""
+
+#: ../../editor_onboarding.md:120 b0784e8ba926473ab47e6b805ef7e761
+msgid ""
+"A GitHub blog post describing how to set up [email "
+"filters](https://github.blog/2017-07-18-managing-large-numbers-of-github-"
+"notifications/)."
+msgstr ""
+
+#: ../../editor_onboarding.md:122 3997825197d447a0b948aeaedd3cdc6c
+msgid "If you use Gmail:"
+msgstr ""
+
+#: ../../editor_onboarding.md:124 8e302db6f0ec4c139627255bd76d26e7
+msgid "https://gist.github.com/ldez/bd6e6401ad0855e6c0de6da19a8c50b5"
+msgstr ""
+
+#: ../../editor_onboarding.md:125 5b45a6e44a9d4546bb68495a5d6e8c53
+msgid "https://github.com/jessfraz/gmailfilters"
+msgstr ""
+
+#: ../../editor_onboarding.md:126 6fc0008f6d0f42ab89e74241d5c27c27
+msgid "https://hackernoon.com/how-to-never-miss-a-github-mention-fdd5a0f9ab6d"
+msgstr ""
+
+#: ../../editor_onboarding.md:128 dc6303ca879a468d810e323257f2ce35
+msgid "**Use a dedicated tool**"
+msgstr ""
+
+#: ../../editor_onboarding.md:130 a97e0e369ba64c18813e95ad318a2824
+msgid ""
+"For papers that you are already assigned to edit, the dedicated JOSS "
+"dashboard aggregates notifications associated with each paper. The "
+"dashboard is available at: "
+"`https://joss.theoj.org/dashboard/<yourgithubusername>`"
+msgstr ""
+
+#: ../../editor_onboarding.md:132 3337ea7412484660a8d38fad4340e16c
+msgid "Another tool you might want to try out is [Octobox](https://octobox.io/)."
+msgstr ""
+

--- a/docs/locale/es/LC_MESSAGES/editor_tips.po
+++ b/docs/locale/es/LC_MESSAGES/editor_tips.po
@@ -1,0 +1,142 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: es\n"
+"Language-Team: es <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../editor_tips.md:1 d749fc4d1210491180004f137656a576
+msgid "Top tips for JOSS editors"
+msgstr ""
+
+#: ../../editor_tips.md:3 fe01b068c66a4640b184ee34313798a8
+msgid "**Aim for reviewer redundancy**"
+msgstr ""
+
+#: ../../editor_tips.md:5 506d698bf9d74715b3e2a51baa97cb82
+msgid ""
+"If you have 3 people agree to review, take them up on their offer(s), "
+"that way if one person drops out, you'll have a backup and won't have to "
+"look for more reviewers. Also, when sending invites, try pinging a number"
+" of people at the same time rather than doing it one-by-one."
+msgstr ""
+
+#: ../../editor_tips.md:7 ba637b6b74fc45a5ad0802cba296d3b6
+msgid "**Email is a good backup**"
+msgstr ""
+
+#: ../../editor_tips.md:9 82b8d154d4ac4140b8ddca53676a282f
+msgid ""
+"Email is often the most reliable way of contacting people. Whether it's "
+"inviting reviewers, following up with reviewers or authors etc., if "
+"you've not heard back from someone on GitHub, try emailing them (their "
+"email is often available on their GitHub profile page)."
+msgstr ""
+
+#: ../../editor_tips.md:11 f6cb9d52f5ae488a8abb2ff29c8d32df
+msgid "**Default to over-communicating**"
+msgstr ""
+
+#: ../../editor_tips.md:13 6695c4e228e346d4a75e591262ae45cf
+msgid ""
+"When you take an action (even if it isn't on GitHub), share on the review"
+" thready what you're up to. For example, if you're looking for reviewers "
+"and are sending emails – leave a note on the review thread saying as "
+"much."
+msgstr ""
+
+#: ../../editor_tips.md:15 62e357fb51d3494499791cc65e29e31c
+msgid "**Use the JOSS Slack**"
+msgstr ""
+
+#: ../../editor_tips.md:17 2772614bb80c4087a5440566297059c8
+msgid ""
+"There's lots of historical knowledge in our Slack, and it's a great way "
+"to get questions answered."
+msgstr ""
+
+#: ../../editor_tips.md:19 efa88c0a4ded4ea8abe31c1351399c81
+msgid "**Ask reviewers to complete their review in 4-6 weeks**"
+msgstr ""
+
+#: ../../editor_tips.md:21 d77e168b384e4e0fbaf8d3f737851eea
+msgid ""
+"We aim for a total submission ... publication time of ~3 months. This "
+"means we ideally want reviewers to complete their review in 4-6 weeks "
+"(max)."
+msgstr ""
+
+#: ../../editor_tips.md:23 91ac07068efa4dcc9fd140f4dd07881a
+msgid "**Use saved replies on GitHub**"
+msgstr ""
+
+#: ../../editor_tips.md:25 66f9b3c7639c4d4c9be2e7e2a8b75f9e
+msgid ""
+"[Saved replies](https://docs.github.com/en/get-started/writing-on-github"
+"/working-with-saved-replies/using-saved-replies) on GitHub can be a huge "
+"productivity boost. Try making some using the example messages listed "
+"above."
+msgstr ""
+
+#: ../../editor_tips.md:27 08a7192f079847eaaad81d0d5681b1d4
+msgid "**Ping reviewers if they’ve not started after 2 weeks**"
+msgstr ""
+
+#: ../../editor_tips.md:29 78d6ae87e79744fe8295e3a4cdf254e1
+msgid ""
+"If a reviewer hasn't started within 1-2 weeks, you should probably give "
+"them a nudge. People often agree to review, and then forget about the "
+"review."
+msgstr ""
+
+#: ../../editor_tips.md:31 859a2e9877c4438ca943f94468d4a53b
+msgid "**Learn how to nudge gently, and often**"
+msgstr ""
+
+#: ../../editor_tips.md:33 2c1a7dbeb8c64edba0a8265789489cd4
+msgid ""
+"One of your jobs as the editor is to ensure the review keeps moving at a "
+"reasonable pace. If nothing has happened for a week or so, consider "
+"nudging the author or reviewers (depending upon who you're waiting for). "
+"A friendly _\"👋 reviewer, how are you getting along here\"_ can often be "
+"sufficient to get things moving again."
+msgstr ""
+
+#: ../../editor_tips.md:35 b1065cb4816f4cc08d9b63e4224432f0
+msgid "**Check in twice a week**"
+msgstr ""
+
+#: ../../editor_tips.md:37 effa9ac74ffc4db9bd03690bc60a1928
+msgid ""
+"Try to check in on your JOSS submissions twice per week, even if only for"
+" 5 minutes. Use your dashboard to stay on top of the current status of "
+"your submissions (i.e., who was the last person to comment on the "
+"thread)."
+msgstr ""
+
+#: ../../editor_tips.md:39 543a54fa561342b994523649f42b3ff4
+msgid "**Leave feedback on reviewers**"
+msgstr ""
+
+#: ../../editor_tips.md:41 6902b4e9f521488a900866b1592721cd
+msgid ""
+"Leave feedback on the [reviewers "
+"application](https://reviewers.joss.theoj.org/) at the end of the review."
+" This helps future editors when they're seeking out good reviewer "
+"candidates."
+msgstr ""
+

--- a/docs/locale/es/LC_MESSAGES/editorial_bot.po
+++ b/docs/locale/es/LC_MESSAGES/editorial_bot.po
@@ -1,0 +1,394 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: es\n"
+"Language-Team: es <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../editorial_bot.md:1 39acd70d3890461db4a421caea70b586
+msgid "Interacting with EditorialBot"
+msgstr ""
+
+#: ../../editorial_bot.md:3 6e5c118315d347549b4b783c80abe26f
+msgid ""
+"The Open Journals' editorial bot or `@editorialbot` on GitHub, is our "
+"editorial bot that interacts with authors, reviewers, and editors on JOSS"
+" reviews."
+msgstr ""
+
+#: ../../editorial_bot.md:5 034ec24930fa442282487029999399c2
+msgid ""
+"`@editorialbot` can do a bunch of different things. If you want to ask "
+"`@editorialbot` what it can do, simply type the following in a JOSS "
+"`review` or `pre-review` issue:"
+msgstr ""
+
+#: ../../editorial_bot.md:13 37c4358c69094920959adba7179a6576
+msgid ""
+"EditorialBot commands must be placed in the first line of a comment. "
+"Other text can be added after the first line with the command. Multiple "
+"commands are not allowed in the same comment, only the first one will be "
+"interpreted."
+msgstr ""
+
+#: ../../editorial_bot.md:16 79d66b5ff2a44ec58b6fe2582590f359
+msgid "Author and reviewers commands"
+msgstr ""
+
+#: ../../editorial_bot.md:18 722a20053ba74dd5bf80c265dcd7370e
+msgid ""
+"A subset of the EditorialBot commands are available to authors and "
+"reviewers:"
+msgstr ""
+
+#: ../../editorial_bot.md:20 3d4709ba4cc040d39be82497e5264a8f
+msgid "Compiling papers"
+msgstr ""
+
+#: ../../editorial_bot.md:22 329087aa872f4a2d86347f06dcd6f9df
+msgid ""
+"When a `pre-review` or `review` issue is opened, `@editorialbot` will try"
+" to compile the JOSS paper by looking for a `paper.md` file in the "
+"repository specified when the paper was submitted."
+msgstr ""
+
+#: ../../editorial_bot.md:24 5fe3cebe75d04022a072ef339b2909fe
+msgid ""
+"If it can't find the `paper.md` file it will say as much in the review "
+"issue. If it can't compile the paper (i.e. there's some kind of Pandoc "
+"error), it will try and report that error back in the thread too."
+msgstr ""
+
+#: ../../editorial_bot.md:27 beff48a007e444379df50e58937f3d27
+msgid ""
+"To compile the papers ``@editorialbot`` is running this `Docker image "
+"<https://github.com/openjournals/inara>`_."
+msgstr ""
+
+#: ../../editorial_bot.md:30 681cd9ecb4084a8aaa3d5a8f79c6f9e6
+msgid ""
+"Anyone can ask `@editorialbot` to compile the paper again (e.g. after a "
+"change has been made). To do this simply comment on the review thread as "
+"follows:"
+msgstr ""
+
+#: ../../editorial_bot.md:36 3f33e1ce9c8c4ac184f223dfba1a26d9
+msgid "Compiling papers from a specific branch"
+msgstr ""
+
+#: ../../editorial_bot.md:38 de44ff34a34848afb471e92e2b39db01
+msgid ""
+"By default, EditorialBot will look for papers in the branch set in the "
+"body of the issue (or in the default git branch if none is present). If "
+"you want to compile a paper from a specific branch (for instance: `my-"
+"custom-branch-name`), change that value with:"
+msgstr ""
+
+#: ../../editorial_bot.md:44 91b288f445cd45b6801f6ba4131e2737
+msgid "And then compile the paper normally:"
+msgstr ""
+
+#: ../../editorial_bot.md:50 5f048407817d418587b4069d5ae52baa
+msgid "Compiling preprint files"
+msgstr ""
+
+#: ../../editorial_bot.md:52 9218493b1e6c4a30b0f342357ed2e094
+msgid ""
+"If you need a generic paper file suitable for preprint servers (arXiv-"
+"like) you can use the following command that will generate a LaTeX file:"
+msgstr ""
+
+#: ../../editorial_bot.md:58 63abe318e90744bcabb914be85dbc8c8
+msgid "Finding reviewers"
+msgstr ""
+
+#: ../../editorial_bot.md:60 cb4985c235854d50a0b4632dfbafbee7
+msgid ""
+"Sometimes submitting authors suggest people the think might be "
+"appropriate to review their submission. If you want the link to the "
+"current list of JOSS reviewers, type the following in the review thread:"
+msgstr ""
+
+#: ../../editorial_bot.md:66 a53475cbbe5c4e829a5128eec29788eb
+msgid "Reviewers checklist command"
+msgstr ""
+
+#: ../../editorial_bot.md:68 59d7682aad184964b92f6e9e5b4e9e1f
+msgid ""
+"Once a user is assigned as reviewer and the review has started, the "
+"reviewer must type the following to get a review checklist:"
+msgstr ""
+
+#: ../../editorial_bot.md:74 b7c1bec8c7074b74b49214547c90b2ea
+msgid "Editorial commands"
+msgstr ""
+
+#: ../../editorial_bot.md:76 e8ee53cf551a428290fed02a51ca30dd
+msgid ""
+"Most of `@editorialbot`'s functionality can only be used by the journal "
+"editors."
+msgstr ""
+
+#: ../../editorial_bot.md:78 3649ad4afea04045888f03b418a67e49
+msgid "Assigning an editor"
+msgstr ""
+
+#: ../../editorial_bot.md:80 ccef8cbe57744489b3132de9e9bf0c4b
+msgid ""
+"Editors can either assign themselves or other editors as the editor of a "
+"submission as follows:"
+msgstr ""
+
+#: ../../editorial_bot.md:86 9f41cbfc147744f3a258c12f0b484fd5
+msgid "Inviting an editor"
+msgstr ""
+
+#: ../../editorial_bot.md:88 8459a863cecc41fdb46a1a6784a0b112
+msgid ""
+"EditorialBot can be used by EiCs to send email invites to registered "
+"editors as follows:"
+msgstr ""
+
+#: ../../editorial_bot.md:94 8efddf6295c04e1ba82440965ef33679
+msgid ""
+"This will send an automated email to the editor with a link to the GitHub"
+" `pre-review` issue."
+msgstr ""
+
+#: ../../editorial_bot.md:96 754bad1fbee2420482fbb9ab72b76cd1
+msgid "Adding and removing reviewers"
+msgstr ""
+
+#: ../../editorial_bot.md:98 926e3bce14ea48fc9b7259d6f1f455ac
+msgid "Reviewers should be assigned by using the following commands:"
+msgstr ""
+
+#: ../../editorial_bot.md:110 2689fcd6d2c64984a4d15988b0800a0d
+msgid "Starting the review"
+msgstr ""
+
+#: ../../editorial_bot.md:112 623edf03a5c644c2ad3585a866f58188
+msgid ""
+"Once the reviewer(s) and editor have been assigned in the `pre-review` "
+"issue, the editor starts the review with:"
+msgstr ""
+
+#: ../../editorial_bot.md:119 2962cbfb38a1482ca1cbb0d9ff40eb35
+msgid ""
+"If a reviewer recants their commitment or is unresponsive, editors can "
+"remove them with the command `@editorialbot remove @username from "
+"reviewers`. You can then delete that reviewer's checklist. You can also "
+"add new reviewers in the `REVIEW` issue with the command `@editorialbot "
+"add @username to reviewers`."
+msgstr ""
+
+#: ../../editorial_bot.md:122 7fd6f88a15de4d62a481cbf13d924336
+msgid "Reminding reviewers and authors"
+msgstr ""
+
+#: ../../editorial_bot.md:124 91f3ec6e1e9c4e61a87f4327e47c1114
+msgid ""
+"EditorialBot can remind authors and reviewers after a specified amount of"
+" time to return to the review issue. Reminders can only be set by "
+"editors, and only for REVIEW issues. For example:"
+msgstr ""
+
+#: ../../editorial_bot.md:142 53deec31cc8540399b9d6e5b36673991
+msgid ""
+"Most units of times are understood by EditorialBot e.g. "
+"`hour/hours/day/days/week/weeks`."
+msgstr ""
+
+#: ../../editorial_bot.md:145 160a106675bf4687a54aee81d86341b1
+msgid "Setting the software archive"
+msgstr ""
+
+#: ../../editorial_bot.md:147 8cde5b01e4d94b4dbfda848ec1a6f4e0
+msgid ""
+"When a submission is accepted, we ask that the authors to create an "
+"archive (on [Zenodo](https://zenodo.org/), "
+"[fig**share**](https://figshare.com/), or other) and post the archive DOI"
+" in the `REVIEW` issue. The editor should ask `@editorialbot` to add the "
+"archive to the issue as follows:"
+msgstr ""
+
+#: ../../editorial_bot.md:153 ddf0409112b744dca692a08eea0ce55d
+msgid "Changing the software version"
+msgstr ""
+
+#: ../../editorial_bot.md:155 d7163a45946e48398dfe080ea40bd5f0
+msgid ""
+"Sometimes the version of the software changes as a consequence of the "
+"review process. To update the version of the software do the following:"
+msgstr ""
+
+#: ../../editorial_bot.md:161 b8b4d78c6f264b8eb9f892c729c742ca
+msgid "Changing the git branch"
+msgstr ""
+
+#: ../../editorial_bot.md:163 a358f3205adb476caac745d1f609922c
+msgid ""
+"Sometimes the paper-md file is located in a topic branch. In order to "
+"have the PDF compiled from that branch it should be added to the issue. "
+"To update the branch value do the following (in the example, the name of "
+"the topic branch is _topic-branch-name_):"
+msgstr ""
+
+#: ../../editorial_bot.md:169 99cfd86ac4334d3a93a6fe6d5f468a0b
+msgid "Changing the repository"
+msgstr ""
+
+#: ../../editorial_bot.md:171 cc86ca0a157b4fba8180dec0b11e90f2
+msgid ""
+"Sometimes authors will move their software repository during the review. "
+"To update the value of the repository URL do the following:"
+msgstr ""
+
+#: ../../editorial_bot.md:178 55a044b6c92e4a6c9b2084a46ceef02c
+msgid "Check references"
+msgstr ""
+
+#: ../../editorial_bot.md:180 5b5719f0438e40a68b081b911b715d3a
+msgid ""
+"Editors can ask EditorialBot to check if the DOIs in the bib file are "
+"valid with the command:"
+msgstr ""
+
+#: ../../editorial_bot.md:187 3d85bd0c5ba54e51908722e5b1920804
+msgid ""
+"EditorialBot can verify that DOIs resolve, but cannot verify that the DOI"
+" associated with a paper is actually correct. In addition, DOI "
+"suggestions from EditorialBot are just that - i.e. they may not be "
+"correct."
+msgstr ""
+
+#: ../../editorial_bot.md:190 bcbc437df84e45e5ad79d999f957cc8e
+msgid "Repository checks"
+msgstr ""
+
+#: ../../editorial_bot.md:192 8727ffd998de498fb2c6e7de6051573a
+msgid ""
+"A series of checks can be run on the submitted repository with the "
+"command:"
+msgstr ""
+
+#: ../../editorial_bot.md:198 d5c1e29abff2449cac32014dd6116ec4
+msgid ""
+"EditorialBot will report back with an analysis of the source code and "
+"list authorship, contributions and file types information. EditorialBot "
+"will also label the issue with the top languages used in the repository, "
+"will count the number of words in the paper file, will look for an Open "
+"Source License and for a *Statement of need* section in the paper."
+msgstr ""
+
+#: ../../editorial_bot.md:200 0c6fbe9c4498459b83ec0b6951c8d470
+msgid "Post-review checklist"
+msgstr ""
+
+#: ../../editorial_bot.md:202 da7d497e843b46e59a81e65d3808a672
+msgid ""
+"Editors can get a checklist to remind all steps to do after the reviewers"
+" have finished their reviews and recommended the paper for acceptance:"
+msgstr ""
+
+#: ../../editorial_bot.md:208 0394e00296be44d5b93688847b8d13c5
+msgid "Flag a paper with query-scope"
+msgstr ""
+
+#: ../../editorial_bot.md:210 2e33d12745074fac95310cb1f8cd3b63
+msgid "Editors can flag a paper with query-scope with the command:"
+msgstr ""
+
+#: ../../editorial_bot.md:216 393ebbe4407b4ca0a0bdc945d22709d2
+msgid "Recommending a paper for acceptance"
+msgstr ""
+
+#: ../../editorial_bot.md:218 9bfe35851e6e450b8521b25cab769abe
+msgid ""
+"JOSS topic editors can recommend a paper for acceptance and ask for the "
+"final proofs to be created by EditorialBot with the following command:"
+msgstr ""
+
+#: ../../editorial_bot.md:224 18349f55da174b52b064ec5dcb3a04ab
+msgid ""
+"On issuing this command, EditorialBot will also check the references of "
+"the paper for any missing DOIs."
+msgstr ""
+
+#: ../../editorial_bot.md:227 f220421f146240b58642fb15e97d1782
+msgid "EiC-only commands"
+msgstr ""
+
+#: ../../editorial_bot.md:229 b274ce6a1fbe4e5c8a80fad4eaa00c12
+msgid "Only the JOSS editors-in-chief can accept, reject or withdraw papers."
+msgstr ""
+
+#: ../../editorial_bot.md:231 4d58a998d70e48e9b9dbc0b77f5fe48c
+msgid "Accepting a paper"
+msgstr ""
+
+#: ../../editorial_bot.md:233 a2e501ceaa9a486b903c55e39a9f27bd
+msgid ""
+"If everything looks good with the draft proofs from the `@editorialbot "
+"recommend acceptance` command, JOSS editors-in-chief can take the "
+"additional step of actually accepting the JOSS paper with the following "
+"command:"
+msgstr ""
+
+#: ../../editorial_bot.md:239 5ea840fce95540cea3e91e45ed2e42f8
+msgid ""
+"EditorialBot will accept the paper, assign it a DOI, deposit it and "
+"publish the paper."
+msgstr ""
+
+#: ../../editorial_bot.md:241 46d0d23563df44bdb17a9912edfc0c50
+msgid "Updating an already accepted paper"
+msgstr ""
+
+#: ../../editorial_bot.md:243 4e5a9ca95ae445dbbd0332c73ba5935b
+msgid ""
+"If the draft has been updated after a paper has been published, JOSS "
+"editors-in-chief can update the published info and PDF with the following"
+" command:"
+msgstr ""
+
+#: ../../editorial_bot.md:249 04866575ba564de58b51ae707d511c0a
+msgid "EditorialBot will update the published paper and re-deposit it."
+msgstr ""
+
+#: ../../editorial_bot.md:252 3036fdc2749f423591013b7a4a6725b6
+msgid "Rejecting a paper"
+msgstr ""
+
+#: ../../editorial_bot.md:254 1cb520f32bbe433eb78a87cedf1748cf
+msgid "JOSS editors-in-chief can reject a submission with the following command:"
+msgstr ""
+
+#: ../../editorial_bot.md:260 032b9e37e6494fe4aa2b29628f808f9b
+msgid "Withdrawing a paper"
+msgstr ""
+
+#: ../../editorial_bot.md:262 fc0a1690d4ec445596aaf5b5f2ac7723
+msgid ""
+"JOSS editors-in-chief can withdraw a submission with the following "
+"command:"
+msgstr ""
+
+#: ../../editorial_bot.md:268 5123958928554baeb31c1b3427955b7b
+msgid "The complete list of available commands"
+msgstr ""
+

--- a/docs/locale/es/LC_MESSAGES/example_paper.po
+++ b/docs/locale/es/LC_MESSAGES/example_paper.po
@@ -1,0 +1,54 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: es\n"
+"Language-Team: es <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../example_paper.md:1 8ca6579dcbc0405081c9234e3e25ddf9
+msgid "Example Paper"
+msgstr ""
+
+#: ../../example_paper.md:3 76c8bf09b0184b24810e7149e806adf0
+msgid ""
+"This example `paper.md` is adapted from _Gala: A Python package for "
+"galactic dynamics_ by Adrian M. Price-Whelan "
+"[http://doi.org/10.21105/joss.00388](http://doi.org/10.21105/joss.00388)."
+msgstr ""
+
+#: ../../example_paper.md:5 e6b48075e1114ec68c01114af4a4a757
+msgid ""
+"For a complete description of available options to describe author names "
+"[see here](author-names)."
+msgstr ""
+
+#: ../../example_paper.md:130 5f39e01834894da382cd056596155e04
+msgid "Example `paper.bib` file:"
+msgstr ""
+
+#: ../../example_paper.md:194 5bea5b8035d3406db5ea07d8efbff3c4
+msgid ""
+"Note that the paper begins by a metadata section (the enclosing --- lines"
+" are mandatory) and ends with a References heading, and the references "
+"are built automatically from the content in the `.bib` file. You should "
+"enter in-text citations in the paper body following correct [Markdown "
+"citation syntax](https://pandoc.org/MANUAL.html#extension-citations).  "
+"Also note that the references include full names of venues, e.g., "
+"journals and conferences, not abbreviations only understood in the "
+"context of a specific discipline."
+msgstr ""
+

--- a/docs/locale/es/LC_MESSAGES/expectations.po
+++ b/docs/locale/es/LC_MESSAGES/expectations.po
@@ -1,0 +1,172 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: es\n"
+"Language-Team: es <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../expectations.md:1 4c8612f8e66a48b494a730e3596c2063
+msgid "Expectations on JOSS editors"
+msgstr ""
+
+#: ../../expectations.md:3 0a07f881dd4f40f691a8af9001834a83
+msgid "Editorial load"
+msgstr ""
+
+#: ../../expectations.md:5 d2189641ac4f41f8b523f52a27043dff
+msgid ""
+"Our goal is for editors to handle between 3-4 submissions at any one "
+"time, and 8-12 submissions per year. During the trial period for editors "
+"(usually the first 90 days), we recommend new editors handle 1-2 "
+"submissions as they learn the JOSS editorial system and processes."
+msgstr ""
+
+#: ../../expectations.md:7 d17595ec867642bfa639f878662e2347
+msgid "Completing the trial period"
+msgstr ""
+
+#: ../../expectations.md:9 97492a5a6ec34c2580cba9bc426985ad
+msgid ""
+"JOSS has a 90-day trial period for new editors. At the end of the trial, "
+"the editor or JOSS editorial board can decide to part ways if either "
+"party determines editing for JOSS isn't a good fit for the editor. The "
+"most important traits the editorial board will be looking for with new "
+"editors are:"
+msgstr ""
+
+#: ../../expectations.md:11 caab6a9de39249d0af2b78753cb9447a
+msgid ""
+"Demonstrating professionalism in communications with authors, reviewers, "
+"and the wider editorial team."
+msgstr ""
+
+#: ../../expectations.md:12 36d289f2a08a402c864dc3d05c39051e
+msgid ""
+"Editorial responsibility, including [keeping up with their assigned "
+"submissions](#continued-attention-to-assigned-submissions)."
+msgstr ""
+
+#: ../../expectations.md:13 469696bcccdf43f985569eeefd85c7f2
+msgid ""
+"Encouraging good social (software community) practices. For example, "
+"thanking reviewers and making them feel like they are part of a team "
+"working together."
+msgstr ""
+
+#: ../../expectations.md:15 68060dfafa604f85a420dee7f417dd53
+msgid ""
+"If you're struggling with your editorial work, please let your buddy or "
+"an EiC know."
+msgstr ""
+
+#: ../../expectations.md:17 71f361156a5f442ab487707e693e9305
+msgid "Responding to editorial assignments"
+msgstr ""
+
+#: ../../expectations.md:19 7f904950b4314e0abbdff99c03a35775
+msgid ""
+"As documented above, usually, papers will be assigned to you by one of "
+"the TEiCs. We ask that editors do their best to respond in a timely "
+"fashion (~ 3 working days) to invites to edit a new submission."
+msgstr ""
+
+#: ../../expectations.md:21 861a33e26bf3481d8918b2f1a39cb670
+msgid "Continued attention to assigned submissions"
+msgstr ""
+
+#: ../../expectations.md:23 5c9cf961643b414a8c0759d3674c96b4
+msgid ""
+"As an editor, part of your role is to ensure that submissions you're "
+"responsible for are progressing smoothly through the editorial process. "
+"This means that:"
+msgstr ""
+
+#: ../../expectations.md:25 a3fe16f8e2094ea8a3be43e6f7625264
+msgid ""
+"During pre-review, and before reviewers have been identified, editors "
+"should be checking on their submissions twice per week to ensure "
+"reviewers are identified in a timely fashion."
+msgstr ""
+
+#: ../../expectations.md:26 104b72a966c94a8c8041ce1b4a4e9922
+msgid ""
+"During review, editors should check on their submissions once or twice "
+"per week (even for just a few minutes) to see if their input is required "
+"(e.g., if someone has asked a question that requires your input)."
+msgstr ""
+
+#: ../../expectations.md:28 509ff01f88764b589654025ead0d7107
+msgid ""
+"Your editorial dashboard (e.g. "
+"`https://joss.theoj.org/dashboard/youreditorname`) is the best place to "
+"check if there have been any updates to the papers you are editing."
+msgstr ""
+
+#: ../../expectations.md:30 7974f302790c43b38fe49a52acf17e44
+msgid "**If reviews go stale**"
+msgstr ""
+
+#: ../../expectations.md:32 1f2b12f8ff0f40f8ad2e1ed2376ecd82
+msgid ""
+"Sometimes reviews go quiet, either because a reviewer has failed to "
+"complete their review or an author has been slow to respond to a "
+"reviewer's feedback. **As the editor, we need you to prompt the author/or"
+" reviewer(s) to revisit the submission if there has been no response "
+"within 7-10 days unless there's a clear statement in the review thread "
+"that says an action is coming at a slightly later time, perhaps because a"
+" reviewer committed to a review by a certain date, or an author is making"
+" changes and says they will be done by a certain date.**"
+msgstr ""
+
+#: ../../expectations.md:34 6a6df7801ec74702aa36001f0787561f
+msgid ""
+"[EditorialBot has "
+"functionality](https://joss.readthedocs.io/en/latest/editorial_bot.html"
+"#reminding-reviewers-and-authors) to remind an author or review to return"
+" to a review at a certain point in the future. For example:"
+msgstr ""
+
+#: ../../expectations.md:40 9ef806aaf3114de4815903b063038340
+msgid "Out of office"
+msgstr ""
+
+#: ../../expectations.md:42 22b5920a8827483e87c893584ff63e86
+msgid ""
+"Sometimes we need time away from our editing duties at JOSS. If you're "
+"planning on being out of the office for more than two weeks, please let "
+"the JOSS editorial team know."
+msgstr ""
+
+#: ../../expectations.md:44 6796f6c4ca0944fdbf897e126f25a6f2
+msgid "Voting on papers flagged as potentially out of scope"
+msgstr ""
+
+#: ../../expectations.md:46 7fe0a02c7e70472d87e2cbea3e629f3d
+msgid ""
+"Once per week, an email is sent to all JOSS editors with a summary of the"
+" papers that are currently flagged as potentially out of scope. Editors "
+"are asked to review these submissions and vote on the JOSS website if "
+"they have an opinion about a submission."
+msgstr ""
+
+#: ../../expectations.md:49 f45c808931ce408c8b24362d20907faf
+msgid ""
+"Your input (vote) on submissions that are undergoing a scope review is "
+"incredibly valuable to the EiC team. Please try and vote early, and "
+"often!"
+msgstr ""
+

--- a/docs/locale/es/LC_MESSAGES/index.po
+++ b/docs/locale/es/LC_MESSAGES/index.po
@@ -1,0 +1,124 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: es\n"
+"Language-Team: es <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../index.rst:33
+msgid "Author Guides"
+msgstr ""
+
+#: ../../index.rst:42
+msgid "Reviewer Guides"
+msgstr ""
+
+#: ../../index.rst:50
+msgid "Editor Guides"
+msgstr ""
+
+#: ../../index.rst:60
+msgid "The Editorial Bot"
+msgstr ""
+
+#: ../../index.rst:66
+msgid "Developer Guides"
+msgstr ""
+
+#: ../../index.rst:2 0f9fd00d10994bde9487df77c173647c
+msgid "Journal of Open Source Software"
+msgstr ""
+
+#: ../../index.rst:4 b7f84e5ae46b4d7c9156aad67fb7cd0f
+msgid ""
+"The `Journal of Open Source Software <http://joss.theoj.org/>`_ (JOSS) is"
+" a developer friendly journal for research software packages."
+msgstr ""
+
+#: ../../index.rst:6 84ad65da2fbb4df4a39cf8defc685cf8
+msgid ""
+"JOSS is an academic journal (ISSN 2475-9066) with a formal peer-review "
+"process that is designed to *improve the quality of the software "
+"submitted*. Upon acceptance into JOSS, we mint a CrossRef DOI for your "
+"paper and we list it on the `JOSS website <http://joss.theoj.org/>`_."
+msgstr ""
+
+#: ../../index.rst:9 e44acbe63269418b90fa19eb9f3386a2
+msgid "About this site"
+msgstr ""
+
+#: ../../index.rst:11 1b295ccddd04446ca6ffd9d426fe18dd
+msgid ""
+"This site contains documentation for authors interested in submitting to "
+"JOSS, reviewers who have generously volunteered their time to review "
+"submissions, and editors who manage the JOSS editorial process."
+msgstr ""
+
+#: ../../index.rst:13 7bed16ea6e82428aa844436412867a22
+msgid "If you're interested in learning more about JOSS, you might want to read:"
+msgstr ""
+
+#: ../../index.rst:15 04b24557f26b44478abbf87be2c3f806
+msgid ""
+"`Our announcement blog post <http://www.arfon.org/announcing-the-journal-"
+"of-open-source-software>`_ describing some of the motivations for "
+"starting a new journal"
+msgstr ""
+
+#: ../../index.rst:16 56f0574fde3741419c77e3ded31340c4
+msgid ""
+"`The paper in Computing in Science and Engineering "
+"<https://doi.org/10.1109/MCSE.2018.03221930>`_ introducing JOSS"
+msgstr ""
+
+#: ../../index.rst:17 9d3759ade4a64885ae3954a27158631d
+msgid ""
+"`The paper in PeerJ CS <https://doi.org/10.7717/peerj-cs.147>`_ "
+"describing the first year of JOSS"
+msgstr ""
+
+#: ../../index.rst:18 fad5565d41484771ba10d89b2c5e3fbb
+msgid "The `about page <http://joss.theoj.org/about>`_ on the main JOSS site"
+msgstr ""
+
+#: ../../index.rst:21 22b4cf2291034a42bd88703454ed27a2
+msgid "Submitting a paper to JOSS"
+msgstr ""
+
+#: ../../index.rst:23 d79c0a72ff284f9dba237c4555df0303
+msgid ""
+"If you'd like to submit a paper to JOSS, please read the author "
+"submission guidelines in the :doc:`submitting` section."
+msgstr ""
+
+#: ../../index.rst:26 605a08afc01447dbb3f9ac1b93addf05
+msgid "Sponsors and affiliates"
+msgstr ""
+
+#: ../../index.rst:-1 9436c00eef0143748d00afeb40768f3b
+msgid "OSI & NumFOCUS"
+msgstr ""
+
+#: ../../index.rst:31 acf3af62f1724ef39d48d9109e26e4d6
+msgid ""
+"JOSS is a proud affiliate of the `Open Source Initiative "
+"<https://opensource.org/>`_. As such, we are committed to public support "
+"for open source software and the role OSI plays therein. In addition, "
+"Open Journals (the parent entity behind JOSS) is a `NumFOCUS-sponsored "
+"project <https://www.numfocus.org/project/open-journals>`_."
+msgstr ""
+

--- a/docs/locale/es/LC_MESSAGES/installing.po
+++ b/docs/locale/es/LC_MESSAGES/installing.po
@@ -1,0 +1,488 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: es\n"
+"Language-Team: es <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../installing.md:1 4f774171c24246e78329728517f8b9e7
+msgid "Installing the JOSS application"
+msgstr ""
+
+#: ../../installing.md:3 7c2d4ade22274352a9f442fae212c0c4
+msgid "Any Open Journal (JOSS, JOSE, etc.) can be considered in three parts:"
+msgstr ""
+
+#: ../../installing.md:5 e36bd80c5ce14615a804f4b4ba13cadf
+msgid "The website"
+msgstr ""
+
+#: ../../installing.md:6 a751dc18b8454069a019feca0b975ec1
+msgid "The Buffy gem to interface with GitHub"
+msgstr ""
+
+#: ../../installing.md:7 99d0865bd8244adc8104ef83a7094976
+msgid ""
+"Inara, a docker image to compile papers being used in GitHub actions and "
+"workflows"
+msgstr ""
+
+#: ../../installing.md:9 f3cb4da41c3641b793f534cbda979d72
+msgid "For JOSS, these correspond to the:"
+msgstr ""
+
+#: ../../installing.md:11 7706d290708e4215a0d1066c12ba8b70
+msgid "[JOSS](https://github.com/openjournals/joss),"
+msgstr ""
+
+#: ../../installing.md:12 9ce88ee192d74d75b21ff6c6473d9d57
+msgid "[Buffy](https://github.com/openjournals/buffy), and"
+msgstr ""
+
+#: ../../installing.md:13 18023f6691a24aed9f10eb211f20df23
+msgid "[Inara](https://github.com/openjournals/inara)"
+msgstr ""
+
+#: ../../installing.md:15 2af763723dec4b06a80b90108edc4a0a
+msgid "code bases."
+msgstr ""
+
+#: ../../installing.md:17 bfd72b4ceb2143f4a80dd5192fea6c84
+msgid "Setting up a local development environment"
+msgstr ""
+
+#: ../../installing.md:19 839f08a37e6643ddb15901d390c8db6a
+msgid ""
+"All Open Journals are coded in Ruby, with the website and Buffy developed"
+" as [Ruby on Rails](https://rubyonrails.org/inst) applications."
+msgstr ""
+
+#: ../../installing.md:23 448f1857fb7547b38869e65bece919a2
+msgid ""
+"If you'd like to develop these locally, you'll need a working Ruby on "
+"Rails development environment. For more information, please see [this "
+"official "
+"guide](https://guides.rubyonrails.org/getting_started.html#creating-a"
+"-new-rails-project-installing-rails)."
+msgstr ""
+
+#: ../../installing.md:28 6fceb023c1d140acb6aa84378b97a599
+msgid "Deploying your JOSS application"
+msgstr ""
+
+#: ../../installing.md:30 c36c4bc7d6b64237bb2041a5cea49030
+msgid ""
+"To deploy JOSS, you'll need a [Heroku "
+"account](https://signup.heroku.com/). We also recommend you gather the "
+"following information before deploying your application to Heroku:"
+msgstr ""
+
+#: ../../installing.md:34 bdd6ac4a32864b17a401073501a896ab
+msgid "A [public ORCID API](https://members.orcid.org/api/about-public-api) key"
+msgstr ""
+
+#: ../../installing.md:35 d3fea2ad0ad141f3823f465a1be8cb38
+msgid ""
+"A GitHub [Personal Access Token](https://docs.github.com/en/free-pro-"
+"team@latest/github/authenticating-to-github/creating-a-personal-access-"
+"token) for the automated account that users will interact with (e.g., "
+"`@editorialbot`, `@RoboNeuro`). In order to be able to send invitations "
+"to reviewers and collaborators, the automated GitHub account must be an "
+"admin of the organization the reviews take place at. And the Personal "
+"Access Token should include the `admin:org` scope."
+msgstr ""
+
+#: ../../installing.md:36 87d6be2a8ed349d2ae6ec252d618a94d
+msgid ""
+"An email address registered on a domain you control (i.e., not `gmail` or"
+" a related service)"
+msgstr ""
+
+#: ../../installing.md:39 ec245b6af1114e8c9c6b43dab184be7c
+msgid ""
+"Do not put these secrets directly into your code base! It is important "
+"that these keys are not under version control."
+msgstr ""
+
+#: ../../installing.md:42 6c24f4a22b9e4efda5ec5bf0a58d1c45
+msgid ""
+"There are different ways to make sure your application has access to "
+"these keys, depending on whether your code is being developed locally or "
+"on Heroku. Locally, you can store these locally in a .env file. The "
+".gitignore in JOSS is already set to ignore this file type."
+msgstr ""
+
+#: ../../installing.md:47 ac957a56a2f0488584b50444d074c0a4
+msgid ""
+"On Heroku, they will be config variables that you can set either with the"
+" Heroku CLI or directly on your application's dashboard. See [this guide "
+"from Heroku](https://devcenter.heroku.com/articles/config-vars#managing-"
+"config-vars) for more information."
+msgstr ""
+
+#: ../../installing.md:51 33ae259eb2884b89832f63790b710bbc
+msgid ""
+"Assuming you [have forked the JOSS GitHub "
+"repository](https://docs.github.com/en/free-pro-team@latest/github"
+"/getting-started-with-github/fork-a-repo) to your account, you can "
+"[configure Heroku as a git "
+"remote](https://devcenter.heroku.com/articles/git#prerequisites-install-"
+"git-and-the-heroku-cli) for your code. This makes it easy to keep your "
+"Heroku deployment in sync with your local development copy."
+msgstr ""
+
+#: ../../installing.md:56 7a74914499304caeb5aeebaf2ad12225
+msgid ""
+"On the JOSS Heroku deployment, you'll need to provision several [add-"
+"ons](https://elements.heroku.com/addons). Specifically, you'll need:"
+msgstr ""
+
+#: ../../installing.md:59 63e1a5bdf03947dbaf70911e67516b7a
+msgid "[Elasticsearch add-on](https://elements.heroku.com/addons/bonsai)"
+msgstr ""
+
+#: ../../installing.md:60 4db8faf5399342ea8bda26e2d590c72d
+msgid "[PostgreSQL add-on](https://elements.heroku.com/addons/heroku-postgresql)"
+msgstr ""
+
+#: ../../installing.md:61 125450c630f04cbdb696309f6cbae800
+msgid "[Scheduler add-on](https://devcenter.heroku.com/articles/scheduler)"
+msgstr ""
+
+#: ../../installing.md:63 f6c31a27438a4e27a8f4650f5a3764d6
+msgid ""
+"For the scheduler add-on, you'll need to designate which tasks it should "
+"run and when. These can be found in the `lib/tasks` folder, and involve "
+"things such as sending out weekly reminder emails to editors. Each task "
+"should be scheduled as a separate job; for example, `rake "
+"send_weekly_emails`."
+msgstr ""
+
+#: ../../installing.md:67 480effe493c745e49a6a46f680482be9
+msgid ""
+"You can also optionally configure the following add-ons (or simply set "
+"their secret keys in your config variables):"
+msgstr ""
+
+#: ../../installing.md:69 18bf6583b4ca4b5aa704859cb3bc8e50
+msgid ""
+"[SendGrid add-on](https://elements.heroku.com/addons/sendgrid) for "
+"sending emails"
+msgstr ""
+
+#: ../../installing.md:70 1ef8f6a531a540d0aae9ba991194e388
+msgid ""
+"[Honeybadger add-on](https://elements.heroku.com/addons/honeybadger) for "
+"error reporting"
+msgstr ""
+
+#: ../../installing.md:72 28a4c573c67b4182903e04d891c3c231
+msgid ""
+"Once you've pushed your application to Heroku and provisioned the "
+"appropriate add-ons, you're ready to update your config with the "
+"appropriate secrets. For a list of the expected secret key names, see the"
+" `app.json` file."
+msgstr ""
+
+#: ../../installing.md:77 6fd5c894e54f4bf185d27a7df1c5d9b5
+msgid ""
+"One \"gotcha\" when provisioning the Bonsai add-on is that it may only "
+"set the `BONSAI_URL` variable. Make sure that there is also an "
+"`ELASTICSEARCH_URL` which is set to the same address."
+msgstr ""
+
+#: ../../installing.md:81 a8d49a25ce6d466fb77c9eab1ac84315
+msgid ""
+"We will not cover Portico, as this requires that your application is a "
+"part of the `openjournals` organization. If you do not already have "
+"access to these keys, you can simply ignore them for now."
+msgstr ""
+
+#: ../../installing.md:85 9b8bd242eaa24872bf8f8a3b562fc579
+msgid ""
+"One secret key we have not covered thus far is `BOT_SECRET`. This is "
+"because it is not one that you obtain from a provide, but a secret key "
+"that you set yourself. We recommend using something like a random SHA1 "
+"string."
+msgstr ""
+
+#: ../../installing.md:90 a07f1080dac54cf69dfa63db432a6e7f
+msgid ""
+"It is important to remember this key, as you will need it when deploying "
+"your Buffy application."
+msgstr ""
+
+#: ../../installing.md:94 be0e73d9129b47a19c2ba229db91cff4
+msgid ""
+"After pushing your application to Heroku, provisioning the appropriate "
+"add-ons, and confirming that your config variables are set correctly, you"
+" should make sure that your username is registered as an admin on the "
+"application."
+msgstr ""
+
+#: ../../installing.md:98 51ac835ee244430d9f362bca2db59b58
+msgid ""
+"You can do this on a local Rails console, by logging in and setting the "
+"boolean field 'admin' on your user ID to True. If you'd prefer to do this"
+" on the Heroku deployment, make sure you've logged into the application. "
+"Then you can directly modify this attribute in the deployments Postgres "
+"database using SQL. For more information on accessing your application's "
+"Postgres database, see [the official "
+"docs](https://devcenter.heroku.com/articles/heroku-postgresql#pg-psql)."
+msgstr ""
+
+#: ../../installing.md:105 17b2ffdb4fc64475811b954d7af4a67a
+msgid "Making modifications to launch your own site"
+msgstr ""
+
+#: ../../installing.md:107 373595fdd5fe46fca658718f3acffad9
+msgid ""
+"Some times you may not want to launch an exact copy of JOSS, but a "
+"modified version. This can be especially useful if you're planning to "
+"spin up your own platform based on the Open Journals framework. "
+"[NeuroLibre](https://neurolibre.org/) is one such example use-case."
+msgstr ""
+
+#: ../../installing.md:112 8fcfc2f6b93e4c2091b2aadd1e8e4fcb
+msgid "Modifying your site configuration"
+msgstr ""
+
+#: ../../installing.md:114 6624ff396d3442e8bcfcf00ce6f7b875
+msgid ""
+"In this case, there are several important variables to be aware of and "
+"modify. Most of these are accessible in the `config` folder."
+msgstr ""
+
+#: ../../installing.md:117 9b4c51ceb34744afa07f805c2870c9f5
+msgid ""
+"First, there are three files which provide settings for your Rails "
+"application in different development contexts:"
+msgstr ""
+
+#: ../../installing.md:119 ../../installing.md:210
+#: 0da0106839214cc2b157be7c6d8feba7 fbdd0ac095944c7ca292eed10fe87092
+msgid "`settings-test.yml`"
+msgstr ""
+
+#: ../../installing.md:120 abd2fc35958a48c6bb958b53fc7a9671
+msgid "`settings-development.yml`"
+msgstr ""
+
+#: ../../installing.md:121 ../../installing.md:211
+#: 3f8bc2da9f75411ba083909f20b54964 ddc8e9cab50b4d1891e2c624589f5742
+msgid "`settings-production.yml`"
+msgstr ""
+
+#: ../../installing.md:123 b9c68715d55148e984be13fa178f4f19
+msgid ""
+"These each contain site-specific variables that should be modified if you"
+" are building off of the Open Journals framework."
+msgstr ""
+
+#: ../../installing.md:125 06b78fe89e454f599cdd523294c88eb8
+msgid ""
+"Next, you'll need to modify the `repository.yml` file. This file lists "
+"the GitHub repository where you expect papers to be published, as well as"
+" the editor team ID. For your GitHub organization, make sure you have "
+"created and populated a team called `editors`. Then, you can check its ID"
+" number as detailed in [this guide](https://fabian-"
+"kostadinov.github.io/2015/01/16/how-to-find-a-github-team-id). In "
+"`config` you should also modify the `orcid.yml` file to list your site as"
+" the production site."
+msgstr ""
+
+#: ../../installing.md:132 f13db8cf9e4644519ad56b82189a306c
+msgid ""
+"Finally, you'll need to set up a [GitHub "
+"webhook](https://docs.github.com/en/free-pro-team@latest/developers"
+"/webhooks-and-events/about-webhooks) for reviews repository. This should "
+"be a repository that you have write access to, where you expect most of "
+"the reviewer-author interaction to occur. For JOSS, this corresponds to "
+"the `openjournals/joss-reviews` GitHub repository."
+msgstr ""
+
+#: ../../installing.md:137 ../../installing.md:221
+#: a64d98ae21c24483915d4efc526de7da b45fc86903bb4d34bfd57621ee5cdcb3
+msgid ""
+"In this GitHub repository's settings, you can add a new webhook with the "
+"following configuration:"
+msgstr ""
+
+#: ../../installing.md:140 686a1bffb5e8446e8fa8ee9309d8824f
+msgid ""
+"Set the `Payload` URL to the `/dispatch` hook for your Heroku application"
+" URL. For example, https://neurolibre.herokuapp.com/dispatch"
+msgstr ""
+
+#: ../../installing.md:142 ../../installing.md:226
+#: 17a6db41035949f990e4d948f27424b7 4ddd63b0f6f643d5bd2b2016f6c7302b
+msgid "Set the `Content type` to `application/json`"
+msgstr ""
+
+#: ../../installing.md:143 ../../installing.md:227
+#: 9052e8d56f124cc78e097c27c7faaf98 ddb732f428924b0f96f1a7d69ba9ace3
+msgid ""
+"Set the secret to a high-entropy, random string as detailed in the "
+"[GitHub docs](https://docs.github.com/en/free-pro-team@latest/developers"
+"/webhooks-and-events/securing-your-webhooks#setting-your-secret-token)"
+msgstr ""
+
+#: ../../installing.md:144 ../../installing.md:228
+#: bd18d6eff9bc4c31bfeec584d7dcc8a1 da172741ab3a4d9997f25854ae69a198
+msgid "Set the webhook to deliver `all events`"
+msgstr ""
+
+#: ../../installing.md:146 bf68263770984fa38c91aa9285ef7a95
+msgid "Updating your application database"
+msgstr ""
+
+#: ../../installing.md:148 c5dc60327d3a414bb3b1f1af4cb4c62d
+msgid ""
+"Optionally, you can edit `seeds.rb`, a file in the `db` folder. \"DB\" is"
+" short for \"database,\" and this file _seeds_ the database with "
+"information about your editorial team. You can edit the file `seeds.rb` "
+"to remove any individuals who are not editors in your organization. This "
+"can be especially useful if you will be creating the database multiple "
+"times during development; for example, if you add in testing information "
+"that you'd later like to remove."
+msgstr ""
+
+#: ../../installing.md:154 23a7defba63e4d8199dce4c3e802a467
+msgid ""
+"You can reinitialize the database from your Heroku CLI using the "
+"following commands:"
+msgstr ""
+
+#: ../../installing.md:163 f2a8d9e5a8dc4ea39b7332bf84f9f6a8
+msgid "Modifying your site contents"
+msgstr ""
+
+#: ../../installing.md:165 67ffa2e9bc1848aa94aedb082bcadc90
+msgid ""
+"You can modify site content by updating files in the `app` and `docs` "
+"folders. For example, in `app/views/notifications` you can change the "
+"text for any emails that will be sent by your application."
+msgstr ""
+
+#: ../../installing.md:168 6a3bc644aed24f6bae19fccc6c80dd3b
+msgid ""
+"Note that files which end in `.html.erb` are treated as HTML files, and "
+"typical HTML formatting applies. You can set the HTML styling by "
+"modifying the Sass files for your application, located in "
+"`app/assets/stylesheets`."
+msgstr ""
+
+#: ../../installing.md:172 e4f19b8d33d545b08a4c919c3c618f28
+msgid ""
+"There are currently a few hard-coded variables in the application which "
+"you will also need to update. Note that these are mostly under "
+"`lib/tasks`. For example, in `stats.rake`, the reviewer sheet ID is hard-"
+"coded on line 37. You should update this to point to your own spreadsheet"
+" where you maintain a list of eligible reviewers."
+msgstr ""
+
+#: ../../installing.md:177 4b836fad75bf48daab9d5c1186b8e1d7
+msgid ""
+"In the same folder, `utils.rake` is currently hard-coded to alternate "
+"assignments of editor-in-chief based on weeks. You should modify this to "
+"either set a single editor-in-chief, or design your own scheme of "
+"alternating between members of your editorial board."
+msgstr ""
+
+#: ../../installing.md:181 b46f9ccf2df2437c91125f29645854df
+msgid "Deploying your Buffy Application"
+msgstr ""
+
+#: ../../installing.md:183 dcf8823d458446aea1fd61c3feb6bd42
+msgid ""
+"Buffy can also be deployed on Heroku. Note that &mdash; for full "
+"functionality &mdash; Buffy must be deployed on [Hobby "
+"dynos](https://devcenter.heroku.com/articles/dyno-types), rather than "
+"free dynos. Hobby dynos allow the Buffy application to run continuously, "
+"without falling asleep after 30 minutes of inactivity; this means that "
+"Buffy can respond to activity on GitHub at any time. Buffy specifically "
+"requires two Hobby dynos: one for the `web` service and one for the "
+"`worker` service."
+msgstr ""
+
+#: ../../installing.md:189 e812a9316c9f4959bd0298c4f43f169e
+msgid ""
+"For a complete step-by-step guide on installing and deploying Buffy, you "
+"can read the [Buffy documentation](https://buffy.readthedocs.io)."
+msgstr ""
+
+#: ../../installing.md:191 5f41ed6042284220a7bece9e43285b4f
+msgid ""
+"As before, once you've pushed your application to Heroku and provisioned "
+"the appropriate add-ons, you're ready to update your config with the "
+"appropriate secrets."
+msgstr ""
+
+#: ../../installing.md:194 622adbea9d8042649356223ef54f3b8c
+msgid ""
+"Specifically, the `JOSS_API_KEY`env var in Heroku should match the "
+"`BOT_SECRET` key that you created in your JOSS deployment."
+msgstr ""
+
+#: ../../installing.md:196 0d0ed34fb17649c3bb25bca81c145fe1
+msgid "Modifying your Buffy deployment"
+msgstr ""
+
+#: ../../installing.md:198 e0cd470cefb04da38734b7e246d48347
+msgid ""
+"Some times you may not want to launch an exact copy of the Buffy, but a "
+"modified version. This can be especially useful if you're planning to "
+"spin up your own platform based on the Open Journals framework. "
+"[rOpenSci-review-bot](https://github.com/ropensci-review-bot) and "
+"[Scoobies](https://github.com/scoobies) are examples of use-cases."
+msgstr ""
+
+#: ../../installing.md:203 54fb2e41380b4eccac2346c55ca57dd5
+msgid "Modifying your Buffy configuration"
+msgstr ""
+
+#: ../../installing.md:205 40dea617bd104bd0af00184cfe6ab720
+msgid ""
+"Similar to the JOSS deployment described above, the Buffy configuration "
+"is controlled through a series of YAML files included in the `config/` "
+"folder. Each of these files provide relevant configuration for a "
+"different development context. Specifically, two files are defined:"
+msgstr ""
+
+#: ../../installing.md:213 305e5b23bc2f4934b642d9605e7c0fcf
+msgid ""
+"which can be used to define testing and production environment variables,"
+" respectively."
+msgstr ""
+
+#: ../../installing.md:215 bee5692828314f52a82ee40bdf8a6250
+msgid ""
+"Finally, you'll need to set up a [GitHub "
+"webhook](https://docs.github.com/en/free-pro-team@latest/developers"
+"/webhooks-and-events/about-webhooks) for your reviews repository. As a "
+"reminder, this should be a repository that you have write access to. For "
+"JOSS, this corresponds to the `openjournals/joss-reviews` GitHub "
+"repository. **This is in addition to the webhook you previously created "
+"for the JOSS deployment, although it points to the same repository.**"
+msgstr ""
+
+#: ../../installing.md:224 e8b69180551748bf8a4a59d38e5d66de
+msgid ""
+"Set the `Payload` URL to the `/dispatch` hook for your Heroku application"
+" URL. For example, https://roboneuro.herokuapp.com/dispatch"
+msgstr ""
+

--- a/docs/locale/es/LC_MESSAGES/paper.po
+++ b/docs/locale/es/LC_MESSAGES/paper.po
@@ -1,0 +1,826 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: es\n"
+"Language-Team: es <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../paper.md:1 fa2014b0271a4a5dbcbdda71c3aea87f
+msgid "JOSS Paper Format"
+msgstr ""
+
+#: ../../paper.md:3 f435876e6c764e9c9a03c779beed7e5b
+msgid ""
+"Submitted articles must use Markdown and must provide a metadata section "
+"at the beginning of the article. Format metadata using YAML, a human-"
+"friendly data serialization language (The Official YAML Web Site, 2022). "
+"The information provided is included in the title and sidebar of the "
+"generated PDF."
+msgstr ""
+
+#: ../../paper.md:7 7f84aa3d14974a3783e82f225be7098a
+msgid "What should my paper contain?"
+msgstr ""
+
+#: ../../paper.md:10 bd929e02502549e9a986519beae8433d
+msgid ""
+"Begin your paper with a summary of the high-level functionality of your "
+"software for a non-specialist reader. Avoid jargon in this section."
+msgstr ""
+
+#: ../../paper.md:13 a86e5255e8de428093396370a3b63b72
+msgid ""
+"JOSS welcomes submissions from broadly diverse research areas. For this "
+"reason, we require that authors include in the paper some sentences that "
+"explain the software functionality and domain of use to a non-specialist "
+"reader. We also require that authors explain the research applications of"
+" the software. The paper should be between 250-1000 words. Authors "
+"submitting papers significantly longer than 1000 words may be asked to "
+"reduce the length of their paper."
+msgstr ""
+
+#: ../../paper.md:15 a2d5b50f11ec4ecaa8eb0a2e8e7184ad
+msgid "Your paper should include:"
+msgstr ""
+
+#: ../../paper.md:17 61fbc3484cd64b4388c3040e5179ede5
+msgid ""
+"A list of the authors of the software and their affiliations, using the "
+"correct format (see the example below)."
+msgstr ""
+
+#: ../../paper.md:18 b1150af4d7104633b3c06f1e13becdfb
+msgid ""
+"A summary describing the high-level functionality and purpose of the "
+"software for a diverse, *non-specialist audience*."
+msgstr ""
+
+#: ../../paper.md:19 ba5c62e4670c4c719b7bd39f28a0b338
+msgid ""
+"A *Statement of need* section that clearly illustrates the research "
+"purpose of the software and places it in the context of related work."
+msgstr ""
+
+#: ../../paper.md:20 9ca2a7e3312f451f86540f3bd34690f7
+msgid ""
+"A list of key references, including to other software addressing related "
+"needs. Note that the references should include full names of venues, "
+"e.g., journals and conferences, not abbreviations only understood in the "
+"context of a specific discipline."
+msgstr ""
+
+#: ../../paper.md:21 e5ebb30afd284a04a47caa540482d06e
+msgid ""
+"Mention (if applicable) a representative set of past or ongoing research "
+"projects using the software and recent scholarly publications enabled by "
+"it."
+msgstr ""
+
+#: ../../paper.md:22 2dec64a1a8a0420392dde5aa4e08f6f3
+msgid "Acknowledgement of any financial support."
+msgstr ""
+
+#: ../../paper.md:24 e876f741ede4426dbb62cf04d87acb5d
+msgid ""
+"As this short list shows, JOSS papers are only expected to contain a "
+"limited set of metadata (see example below), a Statement of need, "
+"Summary, Acknowledgements, and References sections. You can look at an "
+"[example accepted paper](example_paper). Given this format, a \"full "
+"length\" paper is not permitted, and software documentation such as API "
+"(Application Programming Interface) functionality should not be in the "
+"paper and instead should be outlined in the software documentation."
+msgstr ""
+
+#: ../../paper.md:27 ae2e048ffe834cf4b3068e48f886218c
+msgid ""
+"Your paper will be reviewed by two or more reviewers in a public GitHub "
+"issue. Take a look at the [review checklist](review_checklist) and  "
+"[review criteria](review_criteria) to better understand how your "
+"submission will be reviewed."
+msgstr ""
+
+#: ../../paper.md:30 cf85cd7d312145b6aba381d9888ac880
+msgid "Article metadata"
+msgstr ""
+
+#: ../../paper.md:33 7d59faef660b4b528d2b32c5f2574fb9
+msgid "Names"
+msgstr ""
+
+#: ../../paper.md:35 dd8ac44e573f475baa9166905eb83753
+msgid ""
+"Providing an author name is straight-forward: just set the `name` "
+"attribute. However, sometimes more control over the name is required."
+msgstr ""
+
+#: ../../paper.md:37 e5b4e44952cb429b974dbf8832df605b
+msgid "Name parts"
+msgstr ""
+
+#: ../../paper.md:39 67f20378d0c1421e8cb269c7c5c13159
+msgid ""
+"There are many ways to describe the parts of names; we support the "
+"following:"
+msgstr ""
+
+#: ../../paper.md:41 c869635f3e8d4a8e8570dd1806c41c96
+msgid "given names,"
+msgstr ""
+
+#: ../../paper.md:42 eb79984c537545d4be61899db1cfa065
+msgid "surname,"
+msgstr ""
+
+#: ../../paper.md:43 458fa74370974a149dc426d1c52405b1
+msgid "dropping particle,"
+msgstr ""
+
+#: ../../paper.md:44 93fc4ebe42e241ebbc0bd529c139f850
+msgid "non-dropping particle,"
+msgstr ""
+
+#: ../../paper.md:45 cba35b5262cb42bf94509372e0c977d1
+msgid "and suffix."
+msgstr ""
+
+#: ../../paper.md:47 60637395091f49aca67416f5605b5e6a
+msgid ""
+"We use a heuristic to parse names into these components. This parsing may"
+" produce the wrong result, in which case it is necessary to provide the "
+"relevant parts explicitly."
+msgstr ""
+
+#: ../../paper.md:49 f9412ec745274eca9be22b9cfc58390d
+msgid "The respective field names are"
+msgstr ""
+
+#: ../../paper.md:51 8b09eeceb8774b26a7a1accc275559db
+msgid "`given-names` (aliases: `given`, `first`, `firstname`)"
+msgstr ""
+
+#: ../../paper.md:52 047b49c2a7dd445a9c0d6a470c7b6bd3
+msgid "`surname` (aliases: `family`)"
+msgstr ""
+
+#: ../../paper.md:53 1399da8321a54c02ae4a16a764a7d9a6
+msgid "`suffix`"
+msgstr ""
+
+#: ../../paper.md:55 60a965723562460ab4ca4f3f4f26d66e
+msgid ""
+"The full display name will be constructed from these parts, unless the "
+"`name` attribute is given as well."
+msgstr ""
+
+#: ../../paper.md:57 e804dcbbe16d4b9194c8930c8b68fb71
+msgid "Particles"
+msgstr ""
+
+#: ../../paper.md:59 ecb8132848a04bab9788f7afd3cf0042
+msgid ""
+"It's usually enough to place particles like \"van\", \"von\", \"della\", "
+"etc. at the end of the given name or at the beginning of the surname, "
+"depending on the details of how the name is used."
+msgstr ""
+
+#: ../../paper.md:61 d21693e5142848d7a4cfd4058fe70d63
+msgid "`dropping-particle`"
+msgstr ""
+
+#: ../../paper.md:62 aa96722b312a4049bba3cb53b2c630f8
+msgid "`non-dropping-particle`"
+msgstr ""
+
+#: ../../paper.md:64 507def513a2c43a2bece07343c752ab2
+msgid "Literal names"
+msgstr ""
+
+#: ../../paper.md:66 114e5fd3f40a442d95c7282a0245a03d
+msgid ""
+"The automatic construction of the full name from parts is geared towards "
+"common Western names. It may therefore be necessary sometimes to provide "
+"the display name explicitly. This is possible by setting the `literal` "
+"field, e.g., `literal: Tachibana Taki`. This feature should only be used "
+"as a last resort. <!-- e.g., `literal: 宮水 三葉`. -->"
+msgstr ""
+
+#: ../../paper.md:68 2ece940089ea482693daa17ea2e389d0
+msgid "Example"
+msgstr ""
+
+#: ../../paper.md:87 0cdb10d51b2140a99d7d5cb4c2945264
+msgid "The name parts can also be collected under the author's `name`:"
+msgstr ""
+
+#: ../../paper.md:102 95cc4e2a1ef44eaaabb11b0249feb0da
+msgid "Internal references"
+msgstr ""
+
+#: ../../paper.md:104 4c14f1598b3f46f581e2a82e8abed510
+msgid ""
+"The goal of Open Journals is to provide authors with a seamless and "
+"pleasant writing experience. Since Markdown has no default mechanism to "
+"handle document internal references, known as “cross-references”, Open "
+"Journals supports a limited set of LaTex commands. In brief, elements "
+"that were marked with `\\label` and can be referenced with `\\ref` and "
+"`\\autoref`."
+msgstr ""
+
+#: ../../paper.md:112 b44070bda6a54e9c9b1de36173ede776
+msgid "Tables and figures"
+msgstr ""
+
+#: ../../paper.md:114 5880b4e4a8d54c2eaa2da191b4672bc8
+msgid ""
+"Tables and figures can be referenced if they are given a *label* in the "
+"caption. In pure Markdown, this can be done by adding an empty span "
+"`[]{label=\"floatlabel\"}` to the caption. LaTeX syntax is supported as "
+"well: `\\label{floatlabel}`."
+msgstr ""
+
+#: ../../paper.md:116 36b4c9eb2f014c8c8057252d016d38f8
+msgid ""
+"Link to a float element, i.e., a table or figure, with "
+"`\\ref{identifier}` or `\\autoref{identifier}`, where `identifier` must "
+"be defined in the float's caption. The former command results in just the"
+" float's number, while the latter inserts the type and number of the "
+"referenced float. E.g., in this document `\\autoref{proglangs}` yields "
+"\"\\autoref{proglangs}\", while `\\ref{proglangs}` gives "
+"\"\\ref{proglangs}\"."
+msgstr ""
+
+#: ../../paper.md:118 00f1a8c2974e4aa0a3d6de2134ecf323
+msgid ""
+": Comparison of programming languages used in the publishing tool. "
+"[]{label=\"proglangs\"}"
+msgstr ""
+
+#: ../../paper.md:126 6a6b07ce53a8441a8b7ab8ff293711a9
+msgid "Equations"
+msgstr ""
+
+#: ../../paper.md:128 39ad38abe7b2404abd476712b7fe20b5
+msgid ""
+"Cross-references to equations work similarly to those for floating "
+"elements. The difference is that, since captions are not supported for "
+"equations, the label must be included in the equation:"
+msgstr ""
+
+#: ../../paper.md:132 e2b44dcea679454fba346acc19bab564
+msgid ""
+"Referencing, however, is identical, with `\\autoref{eq:fermat}` resulting"
+" in \"\\autoref{eq:fermat}\"."
+msgstr ""
+
+#: ../../paper.md:134 cccf1e00213b47bbb562d831ef502339
+msgid "$$a^n + b^n = c^n \\label{eq:fermat}$$"
+msgstr ""
+
+#: ../../paper.md:136 0611b18dbc83421481f814a7a19e705a
+msgid ""
+"Authors who do not wish to include the label directly in the formula can "
+"use a Markdown span to add the label:"
+msgstr ""
+
+#: ../../paper.md:140 2a3bd0ce271840299c567e14657556b5
+msgid "Markdown"
+msgstr ""
+
+#: ../../paper.md:141 57aff3425b2041198fa569a3efa32452
+msgid ""
+"Markdown is a lightweight markup language used frequently in software "
+"development and online environments. Based on email conventions, it was "
+"developed in 2004 by John Gruber and Aaron Swartz."
+msgstr ""
+
+#: ../../paper.md:143 6297d980245f4f8996aa247167a4fc7c
+msgid "Inline markup"
+msgstr ""
+
+#: ../../paper.md:145 d8f21d85db4d425d8a0f4b1e38da0fda
+msgid ""
+"The markup in Markdown should be semantic, not presentations. The table "
+"below has some basic examples."
+msgstr ""
+
+#: ../../paper.md:26 d3df3328c4b64fc79997a1eb9b5aba15
+msgid "Markup"
+msgstr ""
+
+#: ../../paper.md:26 71e31d5f64224918affd375f45966558
+msgid "Markdown example"
+msgstr ""
+
+#: ../../paper.md:26 2dc916e2562649c7a74cf6c3aeac0874
+msgid "Rendered output"
+msgstr ""
+
+#: ../../paper.md:26 19cc622ca4494b8a9fa55b3a4388c2aa
+msgid "emphasis"
+msgstr ""
+
+#: ../../paper.md:26 a948a0a3802946478e2ff67ec0447655
+msgid "`*this*`"
+msgstr ""
+
+#: ../../paper.md:26 c58033ec56614927859e5e062d0bd345
+msgid "*this*"
+msgstr ""
+
+#: ../../paper.md:26 3e6cf5b487fb4a2689d8ac32c0788ca1
+msgid "strong emphasis"
+msgstr ""
+
+#: ../../paper.md:26 87febb945a3a4114ac4e4d8bbff65234
+msgid "`**that**`"
+msgstr ""
+
+#: ../../paper.md:26 a1765c48f9bb4e5883a902d91aa67278
+msgid "**that**"
+msgstr ""
+
+#: ../../paper.md:26 2ee0f00be1de4d638e605814fa02365f
+msgid "strikeout"
+msgstr ""
+
+#: ../../paper.md:26 885cb945571c4bb19bffa030446ca598
+msgid "`~~not this~~`"
+msgstr ""
+
+#: ../../paper.md:26 6fc0a89828d44669ac25de645a01f13a
+msgid "~~not this~~"
+msgstr ""
+
+#: ../../paper.md:26 385f870923b842eeabdda8c2244b885b
+msgid "subscript"
+msgstr ""
+
+#: ../../paper.md:26 a800ad356de940f8b902cf81915b4bd7
+msgid "`H~2~O`"
+msgstr ""
+
+#: ../../paper.md:26 03cf79ed62ad4410a5620c9515580c52
+msgid "H{sub}`2`O"
+msgstr ""
+
+#: ../../paper.md:26 d72212de80a44aab8408b46657caa9fe
+msgid "superscript"
+msgstr ""
+
+#: ../../paper.md:26 abd55b2a79af49728e32f3cba1d37811
+msgid "`Ca^2+^`"
+msgstr ""
+
+#: ../../paper.md:26 edef998bf9924bb19218abf4b07260e5
+msgid "Ca{sup}`2+`"
+msgstr ""
+
+#: ../../paper.md:26 2d13cc92c79d4f96afb59bd17f76a9f2
+msgid "underline"
+msgstr ""
+
+#: ../../paper.md:26 c6f3cde067ba4082906c6c064f7074f4
+msgid "`[underline]{.ul}`"
+msgstr ""
+
+#: ../../paper.md:26 7b4509b5bd7345888756987c4a8be939
+msgid "[underline]{.ul}"
+msgstr ""
+
+#: ../../paper.md:26 65162614eaac4acc96a0a3071cb8a3db
+msgid "small caps"
+msgstr ""
+
+#: ../../paper.md:26 91530edf3cb845caacc1e535364ca03e
+msgid "`[Small Caps]{.sc}`"
+msgstr ""
+
+#: ../../paper.md:26 45ab80e8677a43899fd1b35f6e7a8203
+msgid "[Small Caps]{.sc}"
+msgstr ""
+
+#: ../../paper.md:26 be91f863a4e8472cbf1e661551378429
+msgid "inline code"
+msgstr ""
+
+#: ../../paper.md:26 35992e1d02f746c1a80deaed97a40045
+msgid "`` `return 23` ``"
+msgstr ""
+
+#: ../../paper.md:26 50a8e17eb7444ab6b6a9d3a3386d3acd
+msgid "`return 23`"
+msgstr ""
+
+#: ../../paper.md:159 0d3c74f2e23a46929da8ff4443dc3f24
+msgid "Links"
+msgstr ""
+
+#: ../../paper.md:161 dc93319bdbfe4c8fbda1e72409ac8e1d
+msgid ""
+"Link syntax is `[link description](targetURL)`. E.g., this link to the "
+"[Journal of Open Source Software](https://joss.theoj.org/) is written as "
+"\\ `[Journal of Open Source Software](https://joss.theoj.org/)`."
+msgstr ""
+
+#: ../../paper.md:164 a46e19b9f7424c4ebc18a97071b16854
+msgid ""
+"Open Journal publications are not limited by the constraints of print "
+"publications. We encourage authors to use hyperlinks for websites and "
+"other external resources. However, the standard scientific practice of "
+"citing the relevant publications should be followed regardless."
+msgstr ""
+
+#: ../../paper.md:166 e7673ea4de8c41e5b647187597cf4438
+msgid "Grid Tables"
+msgstr ""
+
+#: ../../paper.md:168 a6f5f6ad8afb4076aef3a6a26e42bf3f
+msgid ""
+"Grid tables are made up of special characters which form the rows and "
+"columns, and also change table and style variables."
+msgstr ""
+
+#: ../../paper.md:170 d5ce43c9effb4504928b003a114ed47b
+msgid ""
+"Complex information can be conveyed by using the following features not "
+"found in other table styles:"
+msgstr ""
+
+#: ../../paper.md:172 18e1a75a972749a888862eb73b6182e5
+msgid "spanning columns"
+msgstr ""
+
+#: ../../paper.md:173 885f47fb518a4f8db6004b4680b63532
+msgid "adding footers"
+msgstr ""
+
+#: ../../paper.md:174 b3b4738e305047ca8c576bda1044e5d8
+msgid "using intra-cellular body elements"
+msgstr ""
+
+#: ../../paper.md:175 765a10f0d6ea48449a45f8bb917bc042
+msgid "creating multi-row headers"
+msgstr ""
+
+#: ../../paper.md:177 637517af24604afca5f59c7db1b5f470
+msgid ""
+"Grid table syntax uses the characters \"-\", \"=\", \"|\", and \"+\" to "
+"represent the table outline:"
+msgstr ""
+
+#: ../../paper.md:179 86751efbcd76472aa01f232810e33bea
+msgid "Hyphens (-) separate horizontal rows."
+msgstr ""
+
+#: ../../paper.md:180 caccc6e900e440ddac1d5e0ed3bd6593
+msgid ""
+"Equals signs (=) produce a header when used to create the row under the "
+"header text."
+msgstr ""
+
+#: ../../paper.md:181 c453086fc1754cfbb07b7e8fe800df08
+msgid ""
+"Equals signs (=) create a footer when used to enclose the last row of the"
+" table."
+msgstr ""
+
+#: ../../paper.md:182 97201779586f43f78b6083f89aabf9c3
+msgid "Vertical bars (|) separate columns and also adjusts the depth of a row."
+msgstr ""
+
+#: ../../paper.md:183 eda6f86cd1864a5885c9133f4df32357
+msgid "Plus signs (+) indicates a juncture between horizontal and parallel lines."
+msgstr ""
+
+#: ../../paper.md:185 cfbc0c2781684349b6b42e3e77b9f394
+msgid ""
+"Note: Inserting a colon (:) at the boundaries of the separator line after"
+" the header will change text alignment. If there is no header, insert "
+"colons into the top line."
+msgstr ""
+
+#: ../../paper.md:187 e7d4ac076a6e4b24bf520f1e30ea99b2
+msgid "Sample grid table:"
+msgstr ""
+
+#: ../../paper.md:204 68e153d4ff5b43538ab81db30e236a5b
+msgid "Figures and Images"
+msgstr ""
+
+#: ../../paper.md:206 d3dd4a2dc0064607b123dbed87a838df
+msgid ""
+"To create a figure, a captioned image must appear by itself in a "
+"paragraph. The Markdown syntax for a figure is a link, preceded by an "
+"exclamation point (!) and a description.   Example:   `![This description"
+" will be the figure caption](path/to/image.png)`"
+msgstr ""
+
+#: ../../paper.md:210 25374bd786624c4c8dd131cbd7ba12c9
+msgid ""
+"In order to create a figure rather than an image, there must be a "
+"description included and the figure syntax must be the only element in "
+"the paragraph, i.e., it must be surrounded by blank lines."
+msgstr ""
+
+#: ../../paper.md:212 afe902d108f54b1b8c09d40f691776eb
+msgid ""
+"Images that are larger than the text area are scaled to fit the page. You"
+" can give images an explicit height and/or width, e.g. when adding an "
+"image as part of a paragraph. The Markdown `![Nyan cat](nyan-"
+"cat.png){height=\"9pt\"}` includes the image saved as `nyan-cat.png` "
+"while scaling it to a height of 9 pt."
+msgstr ""
+
+#: ../../paper.md:214 d781dc3c1e0e4ec88d36b614f55f1d4a
+msgid "Citations"
+msgstr ""
+
+#: ../../paper.md:216 a308b28c59314248bcad2d66a5f81828
+msgid ""
+"Bibliographic data should be collected in a file `paper.bib`; it should "
+"be formatted in the BibLaTeX format, although plain BibTeX is acceptable "
+"as well. All major citation managers offer to export these formats."
+msgstr ""
+
+#: ../../paper.md:218 68879f46c083445189cd2ec5f2e24677
+msgid ""
+"Cite a bibliography entry by referencing its identifier: `[@upper1974]` "
+"will create the reference \"(Upper 1974)\". Omit the brackets when "
+"referring to the author as part of a sentence: \"For a case study on "
+"writers block, see Upper (1974).\" Please refer to the [pandoc "
+"manual](https://pandoc.org/MANUAL#extension-citations) for additional "
+"features, including page locators, prefixes, suffixes, and suppression of"
+" author names in citations."
+msgstr ""
+
+#: ../../paper.md:226 9ced5108486944279bbadf6acd752d6d
+msgid "The full citation will display as"
+msgstr ""
+
+#: ../../paper.md:228 b58d3000ebc14f6ea205d83d02d97ffe
+msgid ""
+"Upper, D. 1974. \"The Unsuccessful Self-Treatment of a Case of "
+"\\\"Writer's Block\\\".\" *Journal of Applied Behavior Analysis* 7 (3): "
+"497. <https://doi.org/10.1901/jaba.1974.7-497a>."
+msgstr ""
+
+#: ../../paper.md:232 83bffdb66e8c469e891be7c79776e24c
+msgid "Mathematical Formulæ"
+msgstr ""
+
+#: ../../paper.md:234 88f755b42e5f4f70ad0886fb02178d06
+msgid ""
+"Mark equations and other math content with dollar signs ($). Use a single"
+" dollar sign ($) for math that will appear directly within the text. Use "
+"two dollar signs ($$) when the formula is to be presented centered and on"
+" a separate line, in \"display\" style. The formula itself must be given "
+"using TeX syntax."
+msgstr ""
+
+#: ../../paper.md:236 c57d9b2d35344152b639f4665a30e1c0
+msgid ""
+"To give some examples: When discussing a variable *x* or a short formula "
+"like"
+msgstr ""
+
+#: ../../paper.md:238 84a73b2d6e43464498f0945bc8cb6d9f
+msgid "\\sin \\frac{\\pi}{2}"
+msgstr ""
+
+#: ../../paper.md:242 dea1c388f0544db69339d9736ec000b5
+msgid "we would write $x$ and"
+msgstr ""
+
+#: ../../paper.md:246 a97b8654f0da4367a248b0aebf7dbd58
+msgid ""
+"respectively. However, for more complex formulæ, display style is more "
+"appropriate. Writing"
+msgstr ""
+
+#: ../../paper.md:250 0f0329c771f44cb6a6efaafd1ad78646
+msgid "will give us"
+msgstr ""
+
+#: ../../paper.md:252 918f159918e6425cba03454fee55c46e
+msgid "$$\\int_{-\\infty}^{+\\infty} e^{-x^2} \\, dx = \\sqrt{\\pi}$$"
+msgstr ""
+
+#: ../../paper.md:254 ../../paper.md:272 200c575fa9724d6191d0ac3601ce1657
+#: 654239a09caa439db25316f6f862e3ed
+msgid "Footnotes"
+msgstr ""
+
+#: ../../paper.md:256 50bee0b418a74fd0b1553da10571d333
+msgid ""
+"Syntax for footnotes centers around the \"caret\" character `^`. The "
+"symbol is also used as a delimiter for superscript text and thereby "
+"mirrors the superscript numbers used to mark a footnote in the final "
+"text."
+msgstr ""
+
+#: ../../paper.md:265 b78a90e3ad884ad89029584ca691d168
+msgid "The above example results in the following output:"
+msgstr ""
+
+#: ../../paper.md:269 adf6b36b98e74cde95d2ae621d9d8cb4
+msgid ""
+"Articles are published under a Creative Commons license [#f1]_. Software "
+"should use an OSI-approved license."
+msgstr ""
+
+#: ../../paper.md:273 c2d72dc731f9452cb4eba7528bf9f3b3
+msgid "An open license that allows reuse."
+msgstr ""
+
+#: ../../paper.md:277 d8cecaaf776f437f8a3d75f4c3c4fe8f
+msgid ""
+"Note: numbers do not have to be sequential, they will be reordered "
+"automatically in the publishing step. In fact, the identifier of a note "
+"can be any sequence of characters, like `[^marker]`, but may not contain "
+"whitespace characters."
+msgstr ""
+
+#: ../../paper.md:280 b0b34a44b50f43c0b4f2dc2f7fb0da1f
+msgid "Blocks"
+msgstr ""
+
+#: ../../paper.md:282 b056c0cf16644fe7ab3c59aa8b23cd76
+msgid "The larger components of a document are called \"blocks\"."
+msgstr ""
+
+#: ../../paper.md:284 205d779737564263b3301c258d94a892
+msgid "Headings"
+msgstr ""
+
+#: ../../paper.md:286 7d07abf30db64a60a587faeaeb53ffff
+msgid ""
+"Headings are added with `#` followed by a space, where each additional "
+"`#` demotes the heading to a level lower in the hierarchy:"
+msgstr ""
+
+#: ../../paper.md:296 03bca033beee433d96a81737d3adcbf9
+msgid ""
+"Please start headings on the first level. The maximum supported level is "
+"5, but paper authors are encouraged to limit themselves to headings of "
+"the first two or three levels."
+msgstr ""
+
+#: ../../paper.md:298 545dbaf2d690400bb80f400e9a5db1d1
+msgid "Deeper nesting"
+msgstr ""
+
+#: ../../paper.md:300 6fc28f3a87ad460ab3c89394b150fad9
+msgid ""
+"Fourth- and fifth-level subsections – like this one and the following "
+"heading – are supported by the system; however, their use is discouraged."
+" Use lists instead of fourth- and fifth-level headings."
+msgstr ""
+
+#: ../../paper.md:303 907b61bed238496d8d774a7c4933d893
+msgid "Lists"
+msgstr ""
+
+#: ../../paper.md:305 34fbfc819c714c67a5e7e83e95af6289
+msgid ""
+"Bullet lists and numbered lists, a.k.a. enumerations, offer an additional"
+" method to present sequential and hierarchical information."
+msgstr ""
+
+#: ../../paper.md:314 e117581200c145db9836ca8670bafa45
+msgid "apples"
+msgstr ""
+
+#: ../../paper.md:315 df8b5cb323ee435cb354c118514ab0d5
+msgid "citrus fruits"
+msgstr ""
+
+#: ../../paper.md:316 b1e18a0e189646efb99c1048c7ca2ffb
+msgid "lemons"
+msgstr ""
+
+#: ../../paper.md:317 f63fd2fea04d4b2fa4cfc6d0e0e2bb4a
+msgid "oranges"
+msgstr ""
+
+#: ../../paper.md:319 d3c61a750d9c4f33b662bc3e6f39b2b6
+msgid ""
+"Enumerations start with the number of the first item. Using the the first"
+" two [laws of "
+"thermodynamics](https://en.wikipedia.org/wiki/Laws_of_thermodynamics) as "
+"example,"
+msgstr ""
+
+#: ../../paper.md:330 06cb1a1c2ed24fa8b6a14b4772b3c397
+msgid "Rendered:"
+msgstr ""
+
+#: ../../paper.md:332 2cf710ad67ae4c2ba56d655cc91662ed
+msgid ""
+"If two systems are each in thermal equilibrium with a third, they are "
+"also in thermal equilibrium with each other."
+msgstr ""
+
+#: ../../paper.md:333 af3e0769ebf54102be5e436699193ced
+msgid ""
+"In a process without transfer of matter, the change in internal energy, "
+"$\\Delta U$, of a thermodynamic system is equal to the energy gained as "
+"heat, $Q$, less the thermodynamic work, $W$, done by the system on its "
+"surroundings. $$\\Delta U = Q - W$$"
+msgstr ""
+
+#: ../../paper.md:336 e7942e2a2aed45a083f4736213905b84
+msgid "Checking that your paper compiles"
+msgstr ""
+
+#: ../../paper.md:338 87276e2613d946699125e8ff7e56341d
+msgid ""
+"JOSS uses Pandoc to compile papers from their Markdown form into a PDF. "
+"There are a few different ways you can test that your paper is going to "
+"compile properly for JOSS:"
+msgstr ""
+
+#: ../../paper.md:340 278486451bea43619f324ad6bab10fde
+msgid "GitHub Action"
+msgstr ""
+
+#: ../../paper.md:342 b6d499cea66f4dd7b73a26b06d2d13ee
+msgid ""
+"If you're using GitHub for your repository, you can use the [Open "
+"Journals GitHub Action](https://github.com/marketplace/actions/open-"
+"journals-pdf-generator) to automatically compile your paper each time you"
+" update your repository."
+msgstr ""
+
+#: ../../paper.md:344 e75e90a3f7794e239a964024a9b46db3
+msgid ""
+"The PDF is available via the Actions tab in your project and click on the"
+" latest workflow run. The zip archive file (including the `paper.pdf`) is"
+" listed in the run's Artifacts section."
+msgstr ""
+
+#: ../../paper.md:346 2ad09cdbb09f44bd93356b2a61bbbb80
+msgid "Docker"
+msgstr ""
+
+#: ../../paper.md:348 dffc31688cae44f08b93b3b9bc3b6b68
+msgid ""
+"If you have Docker installed on your local machine, you can use the same "
+"Docker Image to compile a draft of your paper locally. In the example "
+"below, the `paper.md` file is in the `paper` directory. Upon successful "
+"execution of the command, the `paper.pdf` file will be created in the "
+"same location as the `paper.md` file:"
+msgstr ""
+
+#: ../../paper.md:358 033a33ebf2ba4473907162b56a9c9f4a
+msgid "Locally"
+msgstr ""
+
+#: ../../paper.md:360 10a19a9058f842bba680a0cab71b851e
+msgid ""
+"The materials for the `inara` container image above are themselves open "
+"source and available in [its own "
+"repository](https://github.com/openjournals/inara). You can clone that "
+"repository and run the `inara` script locally with `make` after "
+"installing the necessary dependencies, which can be inferred from the "
+"[`Dockerfile`](https://github.com/openjournals/inara/blob/main/Dockerfile)."
+msgstr ""
+
+#: ../../paper.md:362 61413520e58d44b3b72760315e5aa7c5
+msgid "Behind the scenes"
+msgstr ""
+
+#: ../../paper.md:364 b0935bca284342188f389d7ab25691a2
+msgid ""
+"Readers may wonder about the reasons behind some of the choices made for "
+"paper writing. Most often, the decisions were driven by radical "
+"pragmatism. For example, Markdown is not only nearly ubiquitous in the "
+"realms of software, but it can also be converted into many different "
+"output formats. The archiving standard for scientific articles is JATS, "
+"and the most popular publishing format is PDF. Open Journals has built "
+"its pipeline based on [pandoc](https://pandoc.org), a universal document "
+"converter that can produce both of these publishing formats as well as "
+"many more."
+msgstr ""
+
+#: ../../paper.md:366 c49bc21e23344cb59e03d9194ac0e11d
+msgid ""
+"A common method for PDF generation is to go via LaTeX. However, support "
+"for tagging -- a requirement for accessible PDFs -- is not readily "
+"available for LaTeX. The current method used ConTeXt, to produce tagged "
+"PDF/A-3."
+msgstr ""
+

--- a/docs/locale/es/LC_MESSAGES/policies.po
+++ b/docs/locale/es/LC_MESSAGES/policies.po
@@ -1,0 +1,85 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: es\n"
+"Language-Team: es <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../policies.md:1 05bd176d1b3d4a84b95c1e98561974a7
+msgid "JOSS Policies"
+msgstr ""
+
+#: ../../policies.md:3 1a24f03bf77c44e5bc89d17ecd904804
+msgid "Animal research policy"
+msgstr ""
+
+#: ../../policies.md:5 a29e58a0a21447f1a28925c36a80f353
+msgid ""
+"In the exceptional case a JOSS submission contains original data on "
+"animal research, the corresponding author must confirm that the data was "
+"collected in accordance with the latest guidelines and applicable "
+"regulations. The manuscript must include complete reporting of the data, "
+"including the ways that the study was approved and relevant details of "
+"the sample. Authors are required to report either the "
+"[ARRIVE](https://arriveguidelines.org/) or "
+"[PREPARE](https://doi.org/10.1177/0023677217724823) guidelines for animal"
+" research in the submission."
+msgstr ""
+
+#: ../../policies.md:7 41e6fe0485154930a4a4630831b36898
+msgid ""
+"We recommend that authors replace, reduce, and refine animal research as "
+"promoted by the [N3RS](https://www.nc3rs.org.uk/)."
+msgstr ""
+
+#: ../../policies.md:9 0a44ed6a60e84552b1810e6aad1aa183
+msgid "Data sharing policy"
+msgstr ""
+
+#: ../../policies.md:11 6f14b42a55d34bb783de81296f134597
+msgid ""
+"If any original data analysis results are provided within the submitted "
+"work, such results have to be entirely reproducible by reviewers, "
+"including accessing the data."
+msgstr ""
+
+#: ../../policies.md:13 bfde40c520e74ffc9264824de2104fe9
+msgid ""
+"Submissions are, by definition, contained within one or multiple "
+"repositories, which we require authors to archive before we accept the "
+"submission. Any data contained within the software is made available "
+"accordingly."
+msgstr ""
+
+#: ../../policies.md:16 32119166412c467e927ba9c349404d68
+msgid "Human participants research policy"
+msgstr ""
+
+#: ../../policies.md:18 527c91102a9f44639f5edc8632fc3b59
+msgid ""
+"In the exceptional case a JOSS submission contains original data on human"
+" participants, the study must have been performed in accordance with the "
+"[Declaration of Helsinki](https://www.wma.net/policies-post/wma-"
+"declaration-of-helsinki-ethical-principles-for-medical-research-"
+"involving-human-subjects/). The manuscript must contain all relevant "
+"information regarding ethics approval, including but not limited to the "
+"responsible ethics committee and reference number. This also applies to "
+"ethics exemptions. Informed consent must be collected from all human "
+"research participants, and authors are required to state whether this "
+"occurred in the manuscript."
+msgstr ""
+

--- a/docs/locale/es/LC_MESSAGES/review_checklist.po
+++ b/docs/locale/es/LC_MESSAGES/review_checklist.po
@@ -1,0 +1,199 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: es\n"
+"Language-Team: es <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../review_checklist.md:1 66a6c65f275d44cbb2bf2b7d90818c3a
+msgid "Review checklist"
+msgstr ""
+
+#: ../../review_checklist.md:3 ab33d256eec14d68a92c5df919eb7ea3
+msgid ""
+"JOSS reviews are checklist-driven. That is, there is a checklist for each"
+" JOSS reviewer to work through when completing their review. A JOSS "
+"review is generally considered incomplete until the reviewer has checked "
+"off all of their checkboxes."
+msgstr ""
+
+#: ../../review_checklist.md:5 bdb4fdb8aa7d4521b7d8fb3ed024ad92
+msgid ""
+"Below is an example of the review checklist for the [Yellowbrick JOSS "
+"submission](https://github.com/openjournals/joss-reviews/issues/1075)."
+msgstr ""
+
+#: ../../review_checklist.md:9 ac29b31942e64e75a81f234148534d4e
+msgid ""
+"Note this section of our documentation only describes the JOSS review "
+"checklist. Authors and reviewers should consult the [review "
+"criteria](review_criteria) to better understand how these checklist items"
+" should be interpreted."
+msgstr ""
+
+#: ../../review_checklist.md:11 a5b9ebdb2c224bccb418db97543955fd
+msgid "Conflict of interest"
+msgstr ""
+
+#: ../../review_checklist.md:13 d9e6d5eef2514de981668ed987f0fa41
+msgid ""
+"I confirm that I have read the [JOSS conflict of interest "
+"policy](reviewer_guidelines.md#joss-conflict-of-interest-policy) and "
+"that: I have no COIs with reviewing this work or that any perceived COIs "
+"have been waived by JOSS for the purpose of this review."
+msgstr ""
+
+#: ../../review_checklist.md:15 b756fc2a709942baac7158306b73e675
+msgid "Code of Conduct"
+msgstr ""
+
+#: ../../review_checklist.md:17 f565cf05471743518d47a4dcde002be2
+msgid ""
+"I confirm that I read and will adhere to the [JOSS code of "
+"conduct](https://joss.theoj.org/about#code_of_conduct)."
+msgstr ""
+
+#: ../../review_checklist.md:19 a8b74cd44e3545d4964f0d2d28ee4928
+msgid "General checks"
+msgstr ""
+
+#: ../../review_checklist.md:21 47a2f9a832c14548be1b915bfa9aa4d1
+msgid ""
+"**Repository:** Is the source code for this software available at the <a "
+"target=\"_blank\" "
+"href=\"https://github.com/DistrictDataLabs/yellowbrick\">repository "
+"url</a>?"
+msgstr ""
+
+#: ../../review_checklist.md:22 0c35535cc6fe469188caf674344b3ba5
+msgid ""
+"**License:** Does the repository contain a plain-text LICENSE file with "
+"the contents of an [OSI "
+"approved](https://opensource.org/licenses/alphabetical) software license?"
+msgstr ""
+
+#: ../../review_checklist.md:23 62ebe9bb575643c29322218589461dbe
+msgid ""
+"**Contribution and authorship:** Has the submitting author made major "
+"contributions to the software? Does the full list of paper authors seem "
+"appropriate and complete?"
+msgstr ""
+
+#: ../../review_checklist.md:25 d697e71dad8a472c8821084c9a69704a
+msgid "Functionality"
+msgstr ""
+
+#: ../../review_checklist.md:27 043f354cc3634e31a57f6c02c4f98df4
+msgid ""
+"**Installation:** Does installation proceed as outlined in the "
+"documentation?"
+msgstr ""
+
+#: ../../review_checklist.md:28 40f63352e5fd4566abfab33af3e21c3f
+msgid ""
+"**Functionality:** Have the functional claims of the software been "
+"confirmed?"
+msgstr ""
+
+#: ../../review_checklist.md:29 4887147c31084be681cadd1d7c031f0a
+msgid ""
+"**Performance:** If there are any performance claims of the software, "
+"have they been confirmed? (If there are no claims, please check off this "
+"item.)"
+msgstr ""
+
+#: ../../review_checklist.md:31 040ce75ed5d34bfe84921ed499be6aa5
+msgid "Documentation"
+msgstr ""
+
+#: ../../review_checklist.md:33 ce980eb02c1a4bb6ba7c51f7ce7c2b03
+msgid ""
+"**A statement of need:** Do the authors clearly state what problems the "
+"software is designed to solve and who the target audience is?"
+msgstr ""
+
+#: ../../review_checklist.md:34 4b0a6f9b8a4d4f98b32efd462a30cb38
+msgid ""
+"**Installation instructions:** Is there a clearly-stated list of "
+"dependencies? Ideally these should be handled with an automated package "
+"management solution."
+msgstr ""
+
+#: ../../review_checklist.md:35 804ce952933a4ea2be9a7333cc78e95b
+msgid ""
+"**Example usage:** Do the authors include examples of how to use the "
+"software (ideally to solve real-world analysis problems)."
+msgstr ""
+
+#: ../../review_checklist.md:36 d7652d9182a848fbaff430778b15723a
+msgid ""
+"**Functionality documentation:** Is the core functionality of the "
+"software documented to a satisfactory level (e.g., API method "
+"documentation)?"
+msgstr ""
+
+#: ../../review_checklist.md:37 1690d7664c00418c9c66f3f5127fc584
+msgid ""
+"**Automated tests:** Are there automated tests or manual steps described "
+"so that the functionality of the software can be verified?"
+msgstr ""
+
+#: ../../review_checklist.md:38 be6c547613474995be785253c9ebbcfd
+msgid ""
+"**Community guidelines:** Are there clear guidelines for third parties "
+"wishing to 1) Contribute to the software 2) Report issues or problems "
+"with the software 3) Seek support"
+msgstr ""
+
+#: ../../review_checklist.md:40 ab745636d12945438b7d66d2deb64534
+msgid "Software paper"
+msgstr ""
+
+#: ../../review_checklist.md:42 61634e5a367b4123a26fd3005e19af68
+msgid ""
+"**Summary:** Has a clear description of the high-level functionality and "
+"purpose of the software for a diverse, non-specialist audience been "
+"provided?"
+msgstr ""
+
+#: ../../review_checklist.md:43 6b1c201f0b624ac5815b79eb1c119945
+msgid ""
+"**A statement of need:** Does the paper have a section titled 'Statement "
+"of need' that clearly states what problems the software is designed to "
+"solve, who the target audience is, and its relation to other work?"
+msgstr ""
+
+#: ../../review_checklist.md:44 918b339399514b9da9e93fdfa1ec098a
+msgid ""
+"**State of the field:** Do the authors describe how this software "
+"compares to other commonly-used packages?"
+msgstr ""
+
+#: ../../review_checklist.md:45 c767f227017641bb92d17fa4aadba03a
+msgid ""
+"**Quality of writing:** Is the paper well written (i.e., it does not "
+"require editing for structure, language, or writing quality)?"
+msgstr ""
+
+#: ../../review_checklist.md:46 281e3f89b1e24882a2f4a38d01c89fa7
+msgid ""
+"**References:** Is the list of references complete, and is everything "
+"cited appropriately that should be cited (e.g., papers, datasets, "
+"software)? Do references in the text use the proper [citation syntax]( "
+"https://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html#citation_syntax)?"
+msgstr ""
+

--- a/docs/locale/es/LC_MESSAGES/review_criteria.po
+++ b/docs/locale/es/LC_MESSAGES/review_criteria.po
@@ -1,0 +1,388 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: es\n"
+"Language-Team: es <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../review_criteria.md:1 a3ae2504cdaa47aeaa3da0fb14ab5a56
+msgid "Review criteria"
+msgstr ""
+
+#: ../../review_criteria.md:3 c49b5ecb47a84a32b6f5b3ee3715d525
+msgid "The JOSS paper"
+msgstr ""
+
+#: ../../review_criteria.md:5 93a2222f76c943dd84499681ef06115a
+msgid ""
+"As outlined in the [submission guidelines provided to authors](paper.md"
+"#what-should-my-paper-contain), the JOSS paper (the compiled PDF "
+"associated with this submission) should only include:"
+msgstr ""
+
+#: ../../review_criteria.md:7 1f4d9cc91cd84aaa9bb019fe4dba0dc8
+msgid "A list of the authors of the software and their affiliations."
+msgstr ""
+
+#: ../../review_criteria.md:8 c1fc8ff600484d3dab42a4daa19a5536
+msgid ""
+"A summary describing the high-level functionality and purpose of the "
+"software for a diverse, non-specialist audience."
+msgstr ""
+
+#: ../../review_criteria.md:9 aba52248ddba49299ca26939f4a55724
+msgid "A clear statement of need that illustrates the purpose of the software."
+msgstr ""
+
+#: ../../review_criteria.md:10 5432e875314441b08dadb882791eb795
+msgid ""
+"A description of how this software compares to other commonly-used "
+"packages in this research area."
+msgstr ""
+
+#: ../../review_criteria.md:11 290b1f2a97d344c491ef92b86b97498c
+msgid ""
+"Mentions (if applicable) of any ongoing research projects using the "
+"software or recent scholarly publications enabled by it."
+msgstr ""
+
+#: ../../review_criteria.md:12 862c8f7394104c96ac6b7900f1014999
+msgid "A list of key references including a link to the software archive."
+msgstr ""
+
+#: ../../review_criteria.md:15 d387e6729d58447da57400ea805b9ddc
+msgid ""
+"Note the paper *should not* include software documentation such as API "
+"(Application Programming Interface) functionality, as this should be "
+"outlined in the software documentation."
+msgstr ""
+
+#: ../../review_criteria.md:18 c3c635e88b274a3086ddda3ad4b1e176
+msgid "Review items"
+msgstr ""
+
+#: ../../review_criteria.md:21 c677627ec8a34ec7a23f7c58e5c70b10
+msgid ""
+"Note, if you've not yet been involved in a JOSS review, you can see an "
+"example JOSS review checklist [here](review_checklist)."
+msgstr ""
+
+#: ../../review_criteria.md:24 066ba8aa557d4a598cea9d5f302fe406
+msgid "Software license"
+msgstr ""
+
+#: ../../review_criteria.md:26 29bfcd0a730a42a6b230d4ab11897725
+msgid ""
+"There should be an [OSI "
+"approved](https://opensource.org/licenses/alphabetical) license included "
+"in the repository. Common licenses such as those listed on "
+"[choosealicense.com](https://choosealicense.com) are preferred. Note "
+"there should be an actual license file present in the repository not just"
+" a reference to the license."
+msgstr ""
+
+#: ../../review_criteria.md:28 c6803cd60a494344846c83ad030e05e9
+msgid ""
+"**Acceptable:** A plain-text LICENSE or COPYING file with the contents of"
+" an OSI approved license<br />             **Not acceptable:** A phrase "
+"such as 'MIT license' in a README file"
+msgstr ""
+
+#: ../../review_criteria.md:31 04833d2d9e924b539b619745a7a9cd0d
+msgid "Substantial scholarly effort"
+msgstr ""
+
+#: ../../review_criteria.md:33 30bac5e4746e4f448ac0115fb7e272a1
+msgid ""
+"Reviewers should verify that the software represents substantial "
+"scholarly effort. As a rule of thumb, JOSS' minimum allowable "
+"contribution should represent **not less than** three months of work for "
+"an individual. Signals of effort may include:"
+msgstr ""
+
+#: ../../review_criteria.md:35 7477cde373f0429480d60affc9bd8f25
+msgid ""
+"Age of software (is this a well-established software project) / length of"
+" commit history."
+msgstr ""
+
+#: ../../review_criteria.md:36 0cf8268b8f464abf9c8c17f76fadc30a
+msgid "Number of commits."
+msgstr ""
+
+#: ../../review_criteria.md:37 c674174db0f24c299a27e7def881586a
+msgid "Number of authors."
+msgstr ""
+
+#: ../../review_criteria.md:38 a40a69e54f2347069f5f48bce39d053a
+msgid ""
+"Lines of code (LOC): These statistics are usually reported by "
+"EditorialBot in the `pre-review` issue thread."
+msgstr ""
+
+#: ../../review_criteria.md:39 824bad6c28e34daf8cc2af69e6834cc0
+msgid "Whether the software has already been cited in academic papers."
+msgstr ""
+
+#: ../../review_criteria.md:40 9cac14af8bd34ff9b14aca3dadb45d9c
+msgid ""
+"Whether the software is sufficiently useful that it is _likely to be "
+"cited_ by other researchers working in this domain."
+msgstr ""
+
+#: ../../review_criteria.md:42 c7e64a5ebbe54d2f8df4184127bbefc8
+msgid ""
+"These guidelines are not meant to be strictly prescriptive. Recently "
+"released software may not have been around long enough to gather "
+"citations in academic literature. While some authors contribute openly "
+"and accrue a long and rich commit history before submitting, others may "
+"upload their software to GitHub shortly before submitting their JOSS "
+"paper.  Reviewers should rely on their expert understanding of their "
+"domain to judge whether the software is of broad interest (_likely to be "
+"cited by other researchers_) or more narrowly focused around the needs of"
+" an individual researcher or lab."
+msgstr ""
+
+#: ../../review_criteria.md:45 14e061e917a34d84bd1b45fbd683c521
+msgid ""
+"The decision on scholarly effort is ultimately one made by JOSS editors. "
+"Reviewers are asked to flag submissions of questionable scope during the "
+"review process so that the editor can bring this to the attention of the "
+"JOSS editorial team."
+msgstr ""
+
+#: ../../review_criteria.md:48 bc63b89e20f54816b2c6fa2bd7631a72
+msgid "Documentation"
+msgstr ""
+
+#: ../../review_criteria.md:50 762d838e2b6342e2aa20e552cff0281c
+msgid ""
+"There should be sufficient documentation for you, the reviewer to "
+"understand the core functionality of the software under review. A high-"
+"level overview of this documentation should be included in a `README` "
+"file (or equivalent). There should be:"
+msgstr ""
+
+#: ../../review_criteria.md:52 cdbfad5d318f495ca77ff18e66a48c26
+msgid "A statement of need"
+msgstr ""
+
+#: ../../review_criteria.md:54 b64bdb4ac55d45f281f55d3a240ce249
+msgid ""
+"The authors should clearly state what problems the software is designed "
+"to solve, who the target audience is, and its relation to other work."
+msgstr ""
+
+#: ../../review_criteria.md:56 b94ecbcfa45a42c7a68caca936983ff2
+msgid "Installation instructions"
+msgstr ""
+
+#: ../../review_criteria.md:58 04c1fd41940943a0b240a2426431c51d
+msgid ""
+"Software dependencies should be clearly documented and their installation"
+" handled by an automated procedure. Where possible, software installation"
+" should be managed with a package manager. However, this criterion "
+"depends upon the maturity and availability of software packaging and "
+"distribution in the programming language being used. For example, Python "
+"packages should be `pip install`able, and have adopted [packaging "
+"conventions](https://packaging.python.org), while Fortran submissions "
+"with a Makefile may be sufficient."
+msgstr ""
+
+#: ../../review_criteria.md:60 423ec8bc924d45e3a8a68f1a52ba46ad
+msgid ""
+"**Good:** The software is simple to install, and follows established "
+"distribution and dependency management approaches for the language being "
+"used<br /> **OK:** A list of dependencies to install, together with some "
+"kind of script to handle their installation (e.g., a Makefile)<br /> "
+"**Bad (not acceptable):** Dependencies are unclear, and/or installation "
+"process lacks automation"
+msgstr ""
+
+#: ../../review_criteria.md:64 99c4a218ff0b475d8fb1519284276fd9
+msgid "Example usage"
+msgstr ""
+
+#: ../../review_criteria.md:66 93205fb027ac4d7ab35b410f0128cb4a
+msgid ""
+"The authors should include examples of how to use the software (ideally "
+"to solve real-world analysis problems)."
+msgstr ""
+
+#: ../../review_criteria.md:68 cf0cd14d290d47439729b5d22edfd9e2
+msgid "API documentation"
+msgstr ""
+
+#: ../../review_criteria.md:70 742f31db489740669c3b2daeeef92d17
+msgid ""
+"Reviewers should check that the software API is documented to a suitable "
+"level."
+msgstr ""
+
+#: ../../review_criteria.md:72 bb9dd3804e264b9888e5628d92711333
+msgid ""
+"**Good:** All functions/methods are documented including example inputs "
+"and outputs<br /> **OK:** Core API functionality is documented<br /> "
+"**Bad (not acceptable):** API is undocumented"
+msgstr ""
+
+#: ../../review_criteria.md:77 7ca53aa3538c4b46a4332b7cfe5c2195
+msgid ""
+"The decision on API documentation is left largely to the discretion of "
+"the reviewer and their experience of evaluating the software."
+msgstr ""
+
+#: ../../review_criteria.md:80 4f72d30f771d4d7f8a552288047c7258
+msgid "Community guidelines"
+msgstr ""
+
+#: ../../review_criteria.md:82 366133c9c36a4406a00140fdff344f46
+msgid "There should be clear guidelines for third-parties wishing to:"
+msgstr ""
+
+#: ../../review_criteria.md:84 3cfd6451af164fd8acc6792d2319d05a
+msgid "Contribute to the software"
+msgstr ""
+
+#: ../../review_criteria.md:85 387acec0c9134ec99118b0a4a0b7de4e
+msgid "Report issues or problems with the software"
+msgstr ""
+
+#: ../../review_criteria.md:86 e862f9edf72a4cd6869dab2578a0ddf4
+msgid "Seek support"
+msgstr ""
+
+#: ../../review_criteria.md:88 ac41672935d7481fb21fcd597a34fb5d
+msgid "Functionality"
+msgstr ""
+
+#: ../../review_criteria.md:90 ec0fd30c7a7e4f36bfc8b38410305be9
+msgid ""
+"Reviewers are expected to install the software they are reviewing and to "
+"verify the core functionality of the software."
+msgstr ""
+
+#: ../../review_criteria.md:92 f090de964a8c43e0a8c990ee6d4800da
+msgid "Tests"
+msgstr ""
+
+#: ../../review_criteria.md:94 e65f9d63fb1a48d08d5ce15aa49f9735
+msgid ""
+"Authors are strongly encouraged to include an automated test suite "
+"covering the core functionality of their software."
+msgstr ""
+
+#: ../../review_criteria.md:96 089c873fc04040bfb2ee1834edf23802
+msgid ""
+"**Good:** An automated test suite hooked up to continuous integration "
+"(GitHub Actions, Circle CI, or similar)<br /> **OK:** Documented manual "
+"steps that can be followed to objectively check the expected "
+"functionality of the software (e.g., a sample input file to assert "
+"behavior)<br /> **Bad (not acceptable):** No way for you, the reviewer, "
+"to objectively assess whether the software works"
+msgstr ""
+
+#: ../../review_criteria.md:100 ebb1b4031d094c5594972efd0a2a835b
+msgid "Other considerations"
+msgstr ""
+
+#: ../../review_criteria.md:102 86cfff0974ac429bb5f3b5a0ffcc5761
+msgid "Authorship"
+msgstr ""
+
+#: ../../review_criteria.md:104 fb9888066a4044ffbf7d1021d1ab3fa4
+msgid ""
+"As part of the review process, you are asked to check whether the "
+"submitting author has made a 'substantial contribution' to the submitted "
+"software (as determined by the commit history) and to check that 'the "
+"full list of paper authors seems appropriate and complete?'"
+msgstr ""
+
+#: ../../review_criteria.md:106 a1199fe7c5144a11a60643dd829bfe6d
+msgid ""
+"As discussed in the [submission guidelines for "
+"authors](submitting.md#authorship), authorship is a complex topic with "
+"different practices in different communities.  Ultimately, the authors "
+"themselves are responsible for deciding which contributions are "
+"sufficient for co-authorship, although JOSS policy is that purely "
+"financial contributions are not considered sufficient. Your job as a "
+"reviewer is to check that the list of authors appears reasonable, and if "
+"it's not obviously complete/correct, to raise this as a question during "
+"the review."
+msgstr ""
+
+#: ../../review_criteria.md:108 2a98da4cffce4906ab6de24f09322c25
+msgid "An important note about 'novel' software and citations of relevant work"
+msgstr ""
+
+#: ../../review_criteria.md:110 525c4a7e843147fe99eddcd11fff5fbe
+msgid ""
+"Submissions that implement solutions already solved in other software "
+"packages are accepted into JOSS provided that they meet the criteria "
+"listed above and cite prior similar work. Reviewers should point out "
+"relevant published work which is not yet cited."
+msgstr ""
+
+#: ../../review_criteria.md:112 3f8680b3074b45cd8c9d73cb69ffb1cb
+msgid "What happens if the software I'm reviewing doesn't meet the JOSS criteria?"
+msgstr ""
+
+#: ../../review_criteria.md:114 0f4ae26b8fa2418393f9280bfde27152
+msgid ""
+"We ask that reviewers grade submissions in one of three categories: 1) "
+"Accept 2) Minor Revisions 3) Major Revisions. Unlike some journals we do "
+"not reject outright submissions requiring major revisions - we're more "
+"than happy to give the author as long as they need to make these "
+"modifications/improvements."
+msgstr ""
+
+#: ../../review_criteria.md:116 2d3fb95950504a8f9805e879737a7f0d
+msgid ""
+"What about submissions that rely upon proprietary languages/development "
+"environments?"
+msgstr ""
+
+#: ../../review_criteria.md:118 28a5400b4e234c6f8656ae98057b751f
+msgid ""
+"As outlined in our author guidelines, submissions that rely upon a "
+"proprietary/closed source language or development environment are "
+"acceptable provided that they meet the other submission requirements and "
+"that you, the reviewer, are able to install the software & verify the "
+"functionality of the submission as required by our reviewer guidelines."
+msgstr ""
+
+#: ../../review_criteria.md:120 9d2bcdbbff5a40e68ed6cfb4a3f30852
+msgid ""
+"If an open source or free variant of the programming language exists, "
+"feel free to encourage the submitting author to consider making their "
+"software compatible with the open source/free variant."
+msgstr ""
+
+#: ../../review_criteria.md:122 b48c8ad73ef84644ab7f489a5335dd18
+msgid "Where can the repository be hosted?"
+msgstr ""
+
+#: ../../review_criteria.md:124 239c57cd8c514639a01b029768e59a6e
+msgid ""
+"Repositories must be hosted at a location that allows outside users to "
+"freely open issues and propose code changes, such as GitHub, GitLab, "
+"Bitbucket, etc. Submissions will not be accepted if the repository is "
+"hosted at a location where accounts must be manually approved (or paid "
+"for), regardless of if this approval is done by the owners of the "
+"repository or some other entity."
+msgstr ""
+

--- a/docs/locale/es/LC_MESSAGES/reviewer_guidelines.po
+++ b/docs/locale/es/LC_MESSAGES/reviewer_guidelines.po
@@ -1,0 +1,129 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: es\n"
+"Language-Team: es <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../reviewer_guidelines.md:1 a419474b5d484081ac03bf756dc47be2
+msgid "Reviewing for JOSS"
+msgstr ""
+
+#: ../../reviewer_guidelines.md:3 6f0fdd54d4174b4595d47c2b51ca3d61
+msgid ""
+"Firstly, thank you so much for agreeing to review for the Journal of Open"
+" Source Software (JOSS), we're delighted to have your help. This document"
+" is designed to outline our editorial guidelines and help you understand "
+"our requirements for accepting a submission into the JOSS. Our review "
+"process is based on a tried-and-tested approach of the [rOpenSci "
+"collaboration](http://ropensci.org/blog/2016/03/28/software-review)."
+msgstr ""
+
+#: ../../reviewer_guidelines.md:5 d5e8babfd2064983aa963d6a55fe50fa
+msgid "Guiding principles"
+msgstr ""
+
+#: ../../reviewer_guidelines.md:7 e9542046504d4ac8a187bd3008f57960
+msgid ""
+"We like to think of JOSS as a 'developer friendly' journal. That is, if "
+"the submitting authors have followed best practices (have documentation, "
+"tests, continuous integration, and a license) then their review should be"
+" rapid."
+msgstr ""
+
+#: ../../reviewer_guidelines.md:9 c4a4f8320cda4a24885dcce346f51047
+msgid ""
+"For those submissions that don't quite meet the bar, please try to give "
+"clear feedback on how authors could improve their submission. A key goal "
+"of JOSS is to raise the quality of research software generally and you "
+"(the experienced reviewer) are well placed to give this feedback."
+msgstr ""
+
+#: ../../reviewer_guidelines.md:11 c0da10831e7e434abf4b8a055a939ea5
+msgid ""
+"A JOSS review involves checking submissions against a checklist of "
+"essential software features and details in the submitted paper. This "
+"should be objective, not subjective; it should be based on the materials "
+"in the submission as perceived without distortion by personal feelings, "
+"prejudices, or interpretations."
+msgstr ""
+
+#: ../../reviewer_guidelines.md:13 f8fcae6e6d2149468bfe9f42b965a85d
+msgid ""
+"We encourage reviewers to file issues against the submitted repository's "
+"issue tracker. **When you have completed your review, please leave a "
+"comment in the review issue saying so.**"
+msgstr ""
+
+#: ../../reviewer_guidelines.md:15 1e6f2e4fec2d44178087bb2565ae4b21
+msgid ""
+"You can include in your review links to any new issues that you the "
+"reviewer believe to be impeding the acceptance of the repository. "
+"(Similarly, if the submitted repository is a GitHub repository, "
+"mentioning the review issue URL in the submitted repository's issue "
+"tracker will create a mention in the review issue's history.)"
+msgstr ""
+
+#: ../../reviewer_guidelines.md:17 efc7dd0cb2b94f26bc26af6c2c612cb5
+msgid "JOSS Conflict of Interest Policy"
+msgstr ""
+
+#: ../../reviewer_guidelines.md:19 579958bd5d754abea42dacc3dfbb13be
+msgid ""
+"The definition of a conflict of Interest in peer review is a circumstance"
+" that makes you \"unable to make an impartial scientific judgment or "
+"evaluation.\" ([PNAS Conflict of Interest "
+"Policy](http://www.pnas.org/site/authors/coi.xhtml)). JOSS is concerned "
+"with avoiding any actual conflicts of interest, and being sufficiently "
+"transparent that we avoid the appearance of conflicts of interest as "
+"well."
+msgstr ""
+
+#: ../../reviewer_guidelines.md:21 2bcd98fbb8054a0493f210435d102957
+msgid ""
+"As a reviewer (or editor), COIs are your present or previous association "
+"with any authors of a submission: recent (past four years) collaborators "
+"in funded research or work that is published; and lifetime for the family"
+" members, business partners, and thesis student/advisor or mentor. In "
+"addition, your recent (past year) association with the same organization "
+"of a submitter is a COI, for example, being employed at the same "
+"institution."
+msgstr ""
+
+#: ../../reviewer_guidelines.md:23 3e219416fb1b41f6be1daed87f710feb
+msgid ""
+"If you have a conflict of interest with a submission, you should disclose"
+" the specific reason to the submissions' editor (or to an EiC if you are "
+"an editor, or to the other EiCs if you are an EiC). This may lead to you "
+"not being able to review or edit the submission, but some conflicts may "
+"be recorded and then waived, and if you think you are able to make an "
+"impartial assessment of the work, you should request that the conflict be"
+" waived. For example, if you and a submitter were two of 2000 authors of "
+"a high energy physics paper but did not actually collaborate. Or if you "
+"and a submitter worked together 6 years ago, but due to delays in the "
+"publishing industry, a paper from that collaboration with both of you as "
+"authors was published 2 years ago. Or if you and a submitter are both "
+"employed by the same very large organization but in different units "
+"without any knowledge of each other."
+msgstr ""
+
+#: ../../reviewer_guidelines.md:25 20b6775665854597b7c9a1e07e37d175
+msgid ""
+"Declaring actual, perceived, and potential conflicts of interest is "
+"required under professional ethics. If in doubt: ask the editors."
+msgstr ""
+

--- a/docs/locale/es/LC_MESSAGES/sample_messages.po
+++ b/docs/locale/es/LC_MESSAGES/sample_messages.po
@@ -1,0 +1,53 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: es\n"
+"Language-Team: es <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../sample_messages.md:1 cef95ca5eb52466087ac6592b8313bc2
+msgid "Sample messages for authors and reviewers"
+msgstr ""
+
+#: ../../sample_messages.md:3 4cc65d85532a4849b89d03bd9f2df182
+msgid "Sample email to potential reviewers"
+msgstr ""
+
+#: ../../sample_messages.md:38 75d2d7121efb4d739fc9ccee78cd9590
+msgid "Query scope of submission"
+msgstr ""
+
+#: ../../sample_messages.md:50 b1bf7b7a0f1a4a308ace2cc4ae649d71
+msgid "GitHub invite to potential reviewers"
+msgstr ""
+
+#: ../../sample_messages.md:56 88bea41bab0f4aa68bd78b43f506f193
+msgid "Message to reviewers at the start of a review"
+msgstr ""
+
+#: ../../sample_messages.md:76 2fed1a4176bd444f8e00e87dd5bb5521
+msgid "Message to authors at the end of a review"
+msgstr ""
+
+#: ../../sample_messages.md:88 c726398e48664dbc97293c9d76bd2ed6
+msgid "Rejection due to out of scope/failing substantial scholarly effort test"
+msgstr ""
+
+#: ../../sample_messages.md:90 1813d0630c2b491e816e004cf1e16d04
+msgid "(Note that rejections are handled by EiCs and not individual editors)."
+msgstr ""
+

--- a/docs/locale/es/LC_MESSAGES/submitting.po
+++ b/docs/locale/es/LC_MESSAGES/submitting.po
@@ -1,0 +1,527 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: es\n"
+"Language-Team: es <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../submitting.md:1 71cbc32ad5bf43439a801a3bd72ab616
+msgid "Submitting a paper to JOSS"
+msgstr ""
+
+#: ../../submitting.md:3 ce6cc30f0f5742389088b8ca91bf4cea
+msgid ""
+"If you've already developed a fully featured research code, released it "
+"under an [OSI-approved license](https://opensource.org/licenses), and "
+"written good documentation and tests, then we expect that it should take "
+"perhaps an hour or two to prepare and submit your paper to JOSS. But "
+"please read these instructions carefully for a streamlined submission."
+msgstr ""
+
+#: ../../submitting.md:6 be732c65a672404fb848550294f9dd33
+msgid "Submission requirements"
+msgstr ""
+
+#: ../../submitting.md:8 fd0c74f034f8459bbc39cd47a2179404
+msgid ""
+"The software must be open source as per the [OSI "
+"definition](https://opensource.org/osd)."
+msgstr ""
+
+#: ../../submitting.md:9 177b6f6b577848b081b1b3a885a0fc34
+msgid ""
+"The software must be hosted at a location where users can open issues and"
+" propose code changes without manual approval of (or payment for) "
+"accounts."
+msgstr ""
+
+#: ../../submitting.md:10 81033d1871ec4a14a360bd8427c4061e
+msgid "The software must have an **obvious** research application."
+msgstr ""
+
+#: ../../submitting.md:11 e2fa627d3e534e168ccd394e8e1aa99b
+msgid ""
+"You must be a major contributor to the software you are submitting, and "
+"have a GitHub account to participate in the review process."
+msgstr ""
+
+#: ../../submitting.md:12 9eb67b83630b41558fdab6b507408a07
+msgid ""
+"Your paper must not focus on new research results accomplished with the "
+"software."
+msgstr ""
+
+#: ../../submitting.md:13 7a7b9c123a364cec93888316cee67854
+msgid ""
+"Your paper (`paper.md` and BibTeX files, plus any figures) must be hosted"
+" in a Git-based repository together with your software."
+msgstr ""
+
+#: ../../submitting.md:14 1966b52d0e7942228fe11f836d43911e
+msgid ""
+"The paper may be in a short-lived branch which is never merged with the "
+"default, although if you do this, make sure this branch is _created_ from"
+" the default so that it also includes the source code of your submission."
+msgstr ""
+
+#: ../../submitting.md:16 4522f942cd214907949aae02b4c51bb0
+msgid "In addition, the software associated with your submission must:"
+msgstr ""
+
+#: ../../submitting.md:18 7f9d57e5b3f941b496a57903370962f1
+msgid "Be stored in a repository that can be cloned without registration."
+msgstr ""
+
+#: ../../submitting.md:19 195c2e675de44629a06315c28b1c3942
+msgid "Be stored in a repository that is browsable online without registration."
+msgstr ""
+
+#: ../../submitting.md:20 92aafa33002e4bab93d1636798edac83
+msgid "Have an issue tracker that is readable without registration."
+msgstr ""
+
+#: ../../submitting.md:21 481c9906fc414102850fd47d4387a1d5
+msgid "Permit individuals to create issues/file tickets against your repository."
+msgstr ""
+
+#: ../../submitting.md:23 30106fab445b4df49a92acc026401e20
+msgid "What we mean by research software"
+msgstr ""
+
+#: ../../submitting.md:25 c90e60057d834a2494df62e9d7687a23
+msgid ""
+"JOSS publishes articles about research software. This definition includes"
+" software that: solves complex modeling problems in a scientific context "
+"(physics, mathematics, biology, medicine, social science, neuroscience, "
+"engineering); supports the functioning of research instruments or the "
+"execution of research experiments; extracts knowledge from large data "
+"sets; offers a mathematical library, or similar. While useful for many "
+"areas of research, pre-trained machine learning models and notebooks are "
+"not in-scope for JOSS."
+msgstr ""
+
+#: ../../submitting.md:27 ae9ca5bd94884dd8bd0327ed4cbfcee9
+msgid "Substantial scholarly effort"
+msgstr ""
+
+#: ../../submitting.md:29 4df6f96e766b4979b64a65dd02ee1d04
+msgid ""
+"JOSS publishes articles about software that represent substantial "
+"scholarly effort on the part of the authors. Your software should be a "
+"significant contribution to the available open source software that "
+"either enables some new research challenges to be addressed or makes "
+"addressing research challenges significantly better (e.g., faster, "
+"easier, simpler)."
+msgstr ""
+
+#: ../../submitting.md:31 6e18cc918f19432faf5ccbedff57edfb
+msgid ""
+"As a rule of thumb, JOSS' minimum allowable contribution should represent"
+" **not less than** three months of work for an individual. Some factors "
+"that may be considered by editors and reviewers when judging effort "
+"include:"
+msgstr ""
+
+#: ../../submitting.md:33 9b107a1e586d4d9bb3435aa25c7b078a
+msgid ""
+"Age of software (is this a well-established software project) / length of"
+" commit history."
+msgstr ""
+
+#: ../../submitting.md:34 7ec26d3e19fa408a813b80a864297808
+msgid "Number of commits."
+msgstr ""
+
+#: ../../submitting.md:35 44355accc3ff464d88a9b0993cf9fad2
+msgid "Number of authors."
+msgstr ""
+
+#: ../../submitting.md:36 5a295caed8b0403ca4c94f914ab90722
+msgid ""
+"Total lines of code (LOC). Submissions under 1000 LOC will usually be "
+"flagged, those under 300 LOC will be desk rejected."
+msgstr ""
+
+#: ../../submitting.md:37 8da115eebe0147d1810885380da53882
+msgid "Whether the software has already been cited in academic papers."
+msgstr ""
+
+#: ../../submitting.md:38 3c7ffb04490d4e70b2deede95f59a3ea
+msgid ""
+"Whether the software is sufficiently useful that it is _likely to be "
+"cited_ by your peer group."
+msgstr ""
+
+#: ../../submitting.md:40 ca3f0849aa9c49a7827756a6b0279698
+msgid ""
+"In addition, JOSS requires that software should be feature-complete "
+"(i.e., no half-baked solutions), packaged appropriately according to "
+"common community standards for the programming language being used (e.g.,"
+" [Python](https://packaging.python.org), "
+"[R](https://r-pkgs.org/index.html)), and designed for maintainable "
+"extension (not one-off modifications of existing tools). \"Minor "
+"utility\" packages, including \"thin\" API clients, and single-function "
+"packages are not acceptable."
+msgstr ""
+
+#: ../../submitting.md:42 05900ce680f74068b3d2b2234e835913
+msgid "A note on web-based software"
+msgstr ""
+
+#: ../../submitting.md:44 0fa3a80b5753418eb40586ad94d41213
+#, python-format
+msgid ""
+"Many web-based research tools are out of scope for JOSS due to a lack of "
+"modularity and challenges testing and maintaining the code. Web-based "
+"tools may be considered 'in scope' for JOSS, provided that they meet one "
+"or both of the following criteria: 1) they are are built around and "
+"expose a 'core library' through a web-based experience (e.g., "
+"R/[Shiny](https://www.rstudio.com/products/shiny/) applications) or 2) "
+"the web application demonstrates a high-level of rigor with respect to "
+"domain modeling and testing (e.g., adopts and implements a design pattern"
+" such as "
+"[MVC](https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93controller)"
+" using a framework such as [Django](https://www.djangoproject.com/))."
+msgstr ""
+
+#: ../../submitting.md:46 a7a177222c5a4338af4683c9e830e978
+msgid ""
+"Similar to other categories of submission to JOSS, it's essential that "
+"any web-based tool can be tested easily by reviewers locally (i.e., on "
+"their local machine)."
+msgstr ""
+
+#: ../../submitting.md:48 e062985b56ee4940a02dafc8d0110f03
+msgid "Co-publication of science, methods, and software"
+msgstr ""
+
+#: ../../submitting.md:50 7463266f25d24104b732b5cc847b5739
+msgid ""
+"Sometimes authors prepare a JOSS publication alongside a contribution "
+"describing a science application, details of algorithm development, "
+"and/or methods assessment. In this circumstance, JOSS considers "
+"submissions for which the implementation of the software itself reflects "
+"a substantial scientific effort. This may be represented by the design of"
+" the software, the implementation of the algorithms, creation of "
+"tutorials, or any other aspect of the software. We ask that authors "
+"indicate whether related publications (published, in review, or nearing "
+"submission) exist as part of submitting to JOSS."
+msgstr ""
+
+#: ../../submitting.md:52 980ec3e752254675a5fcbba6fe1d427f
+msgid "Other venues for reviewing and publishing software packages"
+msgstr ""
+
+#: ../../submitting.md:54 885a143d4e9e4b068ccc4368d41e1fc0
+msgid ""
+"Authors wishing to publish software deemed out of scope for JOSS have a "
+"few options available to them:"
+msgstr ""
+
+#: ../../submitting.md:56 43ba4588359841f0933b8f80396d0a3d
+msgid ""
+"Follow [GitHub's guide](https://guides.github.com/activities/citable-"
+"code/) on how to create a permanent archive and DOI for your software. "
+"This DOI can then be used by others to cite your work."
+msgstr ""
+
+#: ../../submitting.md:57 0c1921b7858540afbed5f145221c4e4c
+msgid ""
+"Enquire whether your software might be considered by communities such as "
+"[rOpenSci](https://ropensci.org) and [pyOpenSci](https://pyopensci.org)."
+msgstr ""
+
+#: ../../submitting.md:59 4201ae50bb354bcabc952a4933fbaffd
+msgid "Should I write my own software or contribute to an existing package?"
+msgstr ""
+
+#: ../../submitting.md:61 c295535022b642cfb470639de383178a
+msgid ""
+"While we are happy to review submissions in standalone repositories, we "
+"also review submissions that are significant contributions made to "
+"existing packages. It is often better to have an integrated library or "
+"package of methods than a large number of single-method packages."
+msgstr ""
+
+#: ../../submitting.md:63 0201c8f9c91d490ab4e4f5574774e250
+msgid "Policies"
+msgstr ""
+
+#: ../../submitting.md:65 aa37ca3febd7418cb10d12b2b82ea741
+msgid ""
+"**Disclosure:** All authors must disclose any potential conflicts of "
+"interest related to the research in their manuscript, including "
+"financial, personal, or professional relationships that may affect their "
+"objectivity. This includes any financial relationships, such as "
+"employment, consultancies, honoraria, stock ownership, or other financial"
+" interests that may be relevant to the research."
+msgstr ""
+
+#: ../../submitting.md:67 7da66e89310a4a368f5e5d13db4598c4
+msgid ""
+"**Acknowledgement:** Authors should acknowledge all sources of financial "
+"support for the work and include a statement indicating whether or not "
+"the sponsor had any involvement in it."
+msgstr ""
+
+#: ../../submitting.md:69 676858145ce44bd88f2d1acc8e00303e
+msgid ""
+"**Review process:** Editors and reviewers must be informed of any "
+"potential conflicts of interest before reviewing the manuscript to ensure"
+" unbiased evaluation of the research."
+msgstr ""
+
+#: ../../submitting.md:71 e17ce766ddf54a99a34152e02f590de6
+msgid ""
+"**Compliance:** Authors who fail to comply with the COI policy may have "
+"their manuscript rejected or retracted if a conflict is discovered after "
+"publication."
+msgstr ""
+
+#: ../../submitting.md:73 f082af420013469ea87e5e47602ede5b
+msgid ""
+"**Review and Update:** This COI policy will be reviewed and updated "
+"regularly to ensure it remains relevant and effective."
+msgstr ""
+
+#: ../../submitting.md:75 1b6123be3aa9458ca1abe472bfc6a73a
+msgid "Conflict of Interest policy for authors"
+msgstr ""
+
+#: ../../submitting.md:77 dfe5a74b60e840fab111d4a239be2092
+msgid ""
+"An author conflict of interest (COI) arises when an author has financial,"
+" personal, or other interests that may influence their research or the "
+"interpretation of its results. In order to maintain the integrity of the "
+"work published in JOSS, we require that authors disclose any potential "
+"conflicts of interest at submission time."
+msgstr ""
+
+#: ../../submitting.md:79 eae21d8642ae4e06893e671d7e50b8a8
+msgid "Preprint Policy"
+msgstr ""
+
+#: ../../submitting.md:81 d34627f972a0467195f060a48e97035f
+msgid ""
+"Authors are welcome to submit their papers to a preprint server "
+"([arXiv](https://arxiv.org/), [bioRxiv](https://www.biorxiv.org/), "
+"[SocArXiv](https://socopen.org/), [PsyArXiv](https://psyarxiv.com/) etc.)"
+" at any point before, during, or after the submission and review process."
+msgstr ""
+
+#: ../../submitting.md:83 d7139daf4aee486cb97d6ce667ee7f03
+msgid ""
+"Submission to a preprint server is _not_ considered a previous "
+"publication."
+msgstr ""
+
+#: ../../submitting.md:85 dd31368d70844c2ba70ddf4e0fc3aa1b
+msgid "Authorship"
+msgstr ""
+
+#: ../../submitting.md:87 080b12bc710e4465b136748026764e6b
+msgid ""
+"Purely financial (such as being named on an award) and organizational "
+"(such as general supervision of a research group) contributions are not "
+"considered sufficient for co-authorship of JOSS submissions, but active "
+"project direction and other forms of non-code contributions are. The "
+"authors themselves assume responsibility for deciding who should be "
+"credited with co-authorship, and co-authors must always agree to be "
+"listed. In addition, co-authors agree to be accountable for all aspects "
+"of the work, and to notify JOSS if any retraction or correction of "
+"mistakes are needed after publication."
+msgstr ""
+
+#: ../../submitting.md:89 155e841452dc4a03a996f9cad264c0fe
+msgid "Submissions using proprietary languages/development environments"
+msgstr ""
+
+#: ../../submitting.md:91 2da8c3a5108b445886c4fd0fa14f1706
+msgid ""
+"We strongly prefer software that doesn't rely upon proprietary (paid for)"
+" development environments/programming languages. However, provided _your "
+"submission meets our requirements_ (including having a valid open source "
+"license) then we will consider your submission for review. Should your "
+"submission be accepted for review, we may ask you, the submitting author,"
+" to help us find reviewers who already have the required development "
+"environment installed."
+msgstr ""
+
+#: ../../submitting.md:93 3a154b0142da47ef977734c5cae46c2f
+msgid "Submission Process"
+msgstr ""
+
+#: ../../submitting.md:95 aedcc91a3841485683a22414ecccae2f
+msgid "Before you submit, you should:"
+msgstr ""
+
+#: ../../submitting.md:97 5ec969a179bb454c8c059c7ba7e35f1b
+msgid ""
+"Make your software available in an open repository (GitHub, Bitbucket, "
+"etc.) and include an [OSI approved open source "
+"license](https://opensource.org/licenses)."
+msgstr ""
+
+#: ../../submitting.md:98 9f5479a2846e4f2dada98e900de5d858
+msgid ""
+"Make sure that the software complies with the [JOSS review "
+"criteria](review_criteria). In particular, your software should be full-"
+"featured, well-documented, and contain procedures (such as automated "
+"tests) for checking correctness."
+msgstr ""
+
+#: ../../submitting.md:99 b18084fdb5764ba38ab6bfb4f7829dd9
+msgid ""
+"Write a short paper in Markdown format using `paper.md` as file name, "
+"including a title, summary, author names, affiliations, and key "
+"references. See our [example paper](example_paper) to follow the correct "
+"format."
+msgstr ""
+
+#: ../../submitting.md:100 f91d9e13cd814e0e9aceb3888e5ee21d
+msgid ""
+"(Optional) create a metadata file describing your software and include it"
+" in your repository. We provide [a "
+"script](https://gist.github.com/arfon/478b2ed49e11f984d6fb) that "
+"automates the generation of this metadata."
+msgstr ""
+
+#: ../../submitting.md:102 a075ecd3fbca4896b053977cb2c441fa
+msgid "Submitting your paper"
+msgstr ""
+
+#: ../../submitting.md:104 7129a25f2dfb445da6465a68a9d5cb73
+msgid "Submission is as simple as:"
+msgstr ""
+
+#: ../../submitting.md:106 7616900c2ae54bf1aa3d7266b05129ff
+msgid "Filling in the [short submission form](http://joss.theoj.org/papers/new)"
+msgstr ""
+
+#: ../../submitting.md:107 a99c4e5802ea4f85bc8826256000daf1
+msgid ""
+"Waiting for the managing editor to start a pre-review issue over in the "
+"JOSS reviews repository: https://github.com/openjournals/joss-reviews"
+msgstr ""
+
+#: ../../submitting.md:109 3586343bfb9d4d36b0500ffbe6476716
+msgid "No submission fees"
+msgstr ""
+
+#: ../../submitting.md:111 fa914426586e4013a9774d2a273fa493
+msgid ""
+"There are no fees for submitting or publishing in JOSS. You can read more"
+" about our [cost and sustainability "
+"model](http://joss.theoj.org/about#costs)."
+msgstr ""
+
+#: ../../submitting.md:113 1890cf9ebb07463d855f2321ef97a341
+msgid "Review Process"
+msgstr ""
+
+#: ../../submitting.md:115 fad65e22fa3d4763a8364dc654735ed6
+msgid "After submission:"
+msgstr ""
+
+#: ../../submitting.md:117 7ef0f9d383394a039c02d02bccb37d7e
+msgid ""
+"An Associate Editor-in-Chief will carry out an initial check of your "
+"submission, and proceed to assign a handling editor."
+msgstr ""
+
+#: ../../submitting.md:118 b69093aef0544b7d986ab71eed8ecaf9
+msgid ""
+"The handling editor will assign two or more JOSS reviewers, and the "
+"review will be carried out in the [JOSS reviews "
+"repository](https://github.com/openjournals/joss-reviews)."
+msgstr ""
+
+#: ../../submitting.md:119 a124181eeaf14a21b56ee720011fcd6d
+msgid ""
+"Authors will respond to reviewer-raised issues (if any are raised) on the"
+" submission repository's issue tracker. Reviewer and editor "
+"contributions, like any other contributions, should be acknowledged in "
+"the repository."
+msgstr ""
+
+#: ../../submitting.md:120 42ce72f09737477f9734c8b21f653b97
+msgid ""
+"**JOSS reviews are iterative and conversational in nature.** Reviewers "
+"are encouraged to post comments/questions/suggestions in the review "
+"thread as they arise, and authors are expected to respond in a timely "
+"fashion."
+msgstr ""
+
+#: ../../submitting.md:121 ee84f73437f44e5b84c8d81a97a6fd18
+msgid ""
+"Authors and reviewers are asked to be patient when waiting for a response"
+" from an editor. Please allow a week for an editor to respond to a "
+"question before prompting them for further action."
+msgstr ""
+
+#: ../../submitting.md:122 5c004698eab4486798f76d010ab7555d
+msgid ""
+"Upon successful completion of the review, authors will make a tagged "
+"release of the software, and deposit a copy of the repository with a "
+"data-archiving service such as [Zenodo](https://zenodo.org/) or "
+"[figshare](https://figshare.com/), get a DOI for the archive, and update "
+"the review issue thread with the version number and DOI."
+msgstr ""
+
+#: ../../submitting.md:123 e9a1850c91664d9d82885b19f94c08c5
+msgid ""
+"After we assign a DOI for your accepted JOSS paper, its metadata is "
+"deposited with CrossRef and listed on the JOSS website."
+msgstr ""
+
+#: ../../submitting.md:124 f4726f1773f44fd5beed4c2e8d04a5ca
+msgid ""
+"The review issue will be closed, and automatic posts from [@JOSS_TheOJ at"
+" Twitter](https://twitter.com/JOSS_TheOJ) and [@JOSS at "
+"Mastodon](https://fosstodon.org/@joss) will announce it!"
+msgstr ""
+
+#: ../../submitting.md:126 ac2cccc96054481e9da17a5f7ab487a5
+msgid ""
+"If you want to learn more details about the review process, take a look "
+"at the [reviewer guidelines](reviewer_guidelines)."
+msgstr ""
+
+#: ../../submitting.md:128 918c5067728d42d0a81dbe095682832a
+msgid "Confidential requests"
+msgstr ""
+
+#: ../../submitting.md:130 04fed9904c5d40b4a5cf50ab9f708a60
+msgid ""
+"Please write admin@theoj.org with confidential matters such as retraction"
+" requests, report of misconduct, and retroactive author name changes."
+msgstr ""
+
+#: ../../submitting.md:132 c57a3a1aee824bd98b028fa7d25c43e9
+msgid ""
+"In the event of a name change request, the DOI will remain unchanged, and"
+" the paper will be updated without the publication of a correction "
+"notice. Please note that because JOSS submissions are managed publicly, "
+"updates to papers are visible in the public record (e.g., in the [JOSS "
+"papers repository](https://github.com/openjournals/joss-papers) commit "
+"history)."
+msgstr ""
+
+#: ../../submitting.md:134 d4ed5f2a5fe842b191c5708f33bf7e89
+msgid "JOSS will also update Crossref metadata."
+msgstr ""
+

--- a/docs/locale/es/LC_MESSAGES/translating.po
+++ b/docs/locale/es/LC_MESSAGES/translating.po
@@ -1,0 +1,124 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 13:00-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: es\n"
+"Language-Team: es <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../translating.md:1 dc0404984ec141be90f2c0ab0b08952e
+msgid "Contributing to Translation"
+msgstr ""
+
+#: ../../translating.md:3 436d651294454374ad5e679c4d227a60
+msgid ""
+"These docs and the main journal website welcome corrections or "
+"translations into additional languages."
+msgstr ""
+
+#: ../../translating.md:6 61edeeb8b3d4438a88d83dcbbf9a28f6
+msgid ""
+"Both are available in the same repository "
+"[openjournals/joss](https://github.com/openjournals/joss) with slightly "
+"different contributor workflows:"
+msgstr ""
+
+#: ../../translating.md:9 646240381af84c869dd9dcfd5910e4d3
+msgid "Python Docs"
+msgstr ""
+
+#: ../../translating.md:11 1bc1a234c2da449a90e5f6d7d1da7bfa
+msgid ""
+"The documents in the `docs` directory (this site) are built with `sphinx`"
+" and internationalized with `sphinx-intl`. These translations use "
+"standard `gettext`-style `.pot` and `.po` files."
+msgstr ""
+
+#: ../../translating.md:15 67377f2b156543c193d7089c35864d73
+msgid ""
+"The `.pot` files are generated from the source pages on each update and "
+"not versioned, and the translations are contained within `.po` files in "
+"the `locale` directory. A CI action ensures that any change to the "
+"english source text is reflected in the generated `.po` files."
+msgstr ""
+
+#: ../../translating.md:20 a71c1369388a4a9fa5f4359e8bcd71c9
+msgid "Adding a new language"
+msgstr ""
+
+#: ../../translating.md:22 b2f7d9c4ff87411a98ce8c5ea6aba22d
+msgid ""
+"Install the requirements, ideally in a virtual environment:  `python -m "
+"pip install -r requirements.txt`"
+msgstr ""
+
+#: ../../translating.md:24 6ec9f8d4512648af8911082fab6e2d3e
+msgid ""
+"Add a new "
+"[ISO-639](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes) "
+"code to the `languages` list in `conf.py`"
+msgstr ""
+
+#: ../../translating.md:26 1e4917f5f5df46ca84277ea8969c87d5
+msgid ""
+"Run `make i18n` (which just calls `update_i18n.py`) to generate the `.po`"
+" files"
+msgstr ""
+
+#: ../../translating.md:27 609caf2c695e4f9599080559bb527f57
+msgid ""
+"Open a PR with the empty `.po` files - the maintainers of the site will "
+"have to add the new language as a [readthedocs "
+"project](https://docs.readthedocs.io/en/stable/localization.html"
+"#projects-with-multiple-translations), so this early PR gives them time "
+"to get that ready by the time the translation is relatively complete"
+msgstr ""
+
+#: ../../translating.md:30 17bcfc9e6a5d467484b9bf6298ae6cb1
+msgid "Work on the translations in the `.po` files!"
+msgstr ""
+
+#: ../../translating.md:32 48c06b282fec40638c03fa2746b75734
+msgid "Translating"
+msgstr ""
+
+#: ../../translating.md:34 a1b5330df5c4410f851a8f295c0b8034
+msgid ""
+"You can run the `sphinx-intl stat` command to get a sense of what files "
+"need the most work:"
+msgstr ""
+
+#: ../../translating.md:37 77325337d66047aa995749393e3bbae9
+msgid "From `docs`:"
+msgstr ""
+
+#: ../../translating.md:59 7cd4308945884faea16c3fa9d1dd6d56
+msgid ""
+"See the [pyopensci `TRANSLATING.md` guide in the `python-package-"
+"guide`](https://github.com/pyOpenSci/python-package-"
+"guide/blob/main/TRANSLATING.md) for further instructions!"
+msgstr ""
+
+#: ../../translating.md:62 fac172f90d63435cbf1dd8ff06adecb0
+msgid ""
+"After you are finished, run `make i18n` again to reformat your strings to"
+" fit the standard style that the CI will check for."
+msgstr ""
+
+#: ../../translating.md:65 1ad35b647a5845208e9d30cbe5168562
+msgid "JOSS Website"
+msgstr ""
+

--- a/docs/locale/es/LC_MESSAGES/venv.po
+++ b/docs/locale/es/LC_MESSAGES/venv.po
@@ -1,0 +1,903 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: es\n"
+"Language-Team: es <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../venv/lib/python3.11/site-packages/MarkupSafe-2.1.5.dist-info/LICENSE.rst:1
+#: 4b04f57e9705450b9306605acd594245
+msgid "Copyright 2010 Pallets"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/MarkupSafe-2.1.5.dist-info/LICENSE.rst:3
+#: ../../venv/lib/python3.11/site-packages/click-8.1.7.dist-info/LICENSE.rst:3
+#: ../../venv/lib/python3.11/site-packages/idna-3.8.dist-info/LICENSE.md:6
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:10
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:44
+#: 1c4ecad3a0424d278d60922719a1bd17 52fbaf4189b2418891a406cc66dfea0b
+#: bfb06a8d236443628369f31abfe6c5a5 c44159ded9ac490fbf34569fb4b5e505
+#: dc0fa4a1b4994b5990003a4f8be3018e
+msgid ""
+"Redistribution and use in source and binary forms, with or without "
+"modification, are permitted provided that the following conditions are "
+"met:"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/MarkupSafe-2.1.5.dist-info/LICENSE.rst:7
+#: ../../venv/lib/python3.11/site-packages/alabaster-0.7.16.dist-info/LICENSE.rst:12
+#: ../../venv/lib/python3.11/site-packages/click-8.1.7.dist-info/LICENSE.rst:7
+#: ../../venv/lib/python3.11/site-packages/idna-3.8.dist-info/LICENSE.md:10
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:14
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:48
+#: 0a8e3445bb9045aaa841f636280c29e9 50113402d53346e8b923c2791161f01e
+#: 6d0e378e76a44454a0b8e54e701b4696 99979e2633bb42d6a30709742d964325
+#: f0f15fee79ed4b40ae793c9a39b91bf0 fa525a2654e74ef38a3627c05034bffe
+msgid ""
+"Redistributions of source code must retain the above copyright notice, "
+"this list of conditions and the following disclaimer."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/MarkupSafe-2.1.5.dist-info/LICENSE.rst:10
+#: ../../venv/lib/python3.11/site-packages/alabaster-0.7.16.dist-info/LICENSE.rst:15
+#: ../../venv/lib/python3.11/site-packages/click-8.1.7.dist-info/LICENSE.rst:10
+#: ../../venv/lib/python3.11/site-packages/idna-3.8.dist-info/LICENSE.md:13
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:17
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:50
+#: 0031803d4c2d4c2ca18f449baefa0288 02124d671c794341906e400a07da7441
+#: 09b72535bd7a4abca7204af33a35ec0d 224b40621fba4ad5b474748d7844882b
+#: 9dc8f8e5362441f29805a535a6c346be c62e1ce755f84d55aa0895f42813eceb
+msgid ""
+"Redistributions in binary form must reproduce the above copyright notice,"
+" this list of conditions and the following disclaimer in the "
+"documentation and/or other materials provided with the distribution."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/MarkupSafe-2.1.5.dist-info/LICENSE.rst:14
+#: ../../venv/lib/python3.11/site-packages/click-8.1.7.dist-info/LICENSE.rst:14
+#: ../../venv/lib/python3.11/site-packages/idna-3.8.dist-info/LICENSE.md:17
+#: 4de8e3ea9944403e868dfe5117f95570 a7e7f1a47d64472998a37ca0df813f2c
+#: ba2cd4afb9e140dc90a0fed6a5642677
+msgid ""
+"Neither the name of the copyright holder nor the names of its "
+"contributors may be used to endorse or promote products derived from this"
+" software without specific prior written permission."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/MarkupSafe-2.1.5.dist-info/LICENSE.rst:18
+#: ../../venv/lib/python3.11/site-packages/click-8.1.7.dist-info/LICENSE.rst:18
+#: ../../venv/lib/python3.11/site-packages/idna-3.8.dist-info/LICENSE.md:21
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:21
+#: 714609d72fe247c8ad7729ac1f599b1f b8eacd94e15b4a6199fe0065a84e1cc7
+#: c3270b0b2f504737aef0391ae710c590 f0f3f4fb89af44b08e1db0d4d9e3c2e8
+msgid ""
+"THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS "
+"IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED "
+"TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A "
+"PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER"
+" OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,"
+" EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, "
+"PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR "
+"PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF "
+"LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING "
+"NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS "
+"SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/alabaster-0.7.16.dist-info/LICENSE.rst:1
+#: dfcb151fc3914bdd8ec2a51b56633fbf
+msgid "Copyright (c) 2020 Jeff Forcier."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/alabaster-0.7.16.dist-info/LICENSE.rst:3
+#: bef43b50d4ac4d0d8a49beddecaad047
+msgid ""
+"Based on original work copyright (c) 2011 Kenneth Reitz and copyright (c)"
+" 2010 Armin Ronacher."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/alabaster-0.7.16.dist-info/LICENSE.rst:6
+#: 565f5758f467498abf005b476600b18a
+msgid "Some rights reserved."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/alabaster-0.7.16.dist-info/LICENSE.rst:8
+#: 5c13cb064db14e03b7874927cb3567a2
+msgid ""
+"Redistribution and use in source and binary forms of the theme, with or "
+"without modification, are permitted provided that the following "
+"conditions are met:"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/alabaster-0.7.16.dist-info/LICENSE.rst:20
+#: a0cc506593fb41bdb6af104b963f3a1a
+msgid ""
+"The names of the contributors may not be used to endorse or promote "
+"products derived from this software without specific prior written "
+"permission."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/alabaster-0.7.16.dist-info/LICENSE.rst:24
+#: c75de0dede354a8ba06bcf63b2049444
+msgid ""
+"THIS THEME IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS "
+"IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED "
+"TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A "
+"PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER "
+"OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, "
+"EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, "
+"PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR "
+"PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF "
+"LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING "
+"NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS THEME,"
+" EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/click-8.1.7.dist-info/LICENSE.rst:1
+#: 77270f4e7f2a4a4da5fe29bfaa4a3688
+msgid "Copyright 2014 Pallets"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/idna-3.8.dist-info/LICENSE.md:1
+#: 12a5eef7249e48d5a9d9ad59ccf233af
+msgid "BSD 3-Clause License"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/idna-3.8.dist-info/LICENSE.md:3
+#: de0055e0f911416fa5f584514d6240ba
+msgid "Copyright (c) 2013-2024, Kim Davies and contributors. All rights reserved."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/imagesize-1.4.1.dist-info/LICENSE.rst:2
+#: 6dd5458610ed4e9cba29810165da96ce
+msgid "The MIT License (MIT)"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/imagesize-1.4.1.dist-info/LICENSE.rst:4
+#: 9f00b96eb75f4a049843504e6bd8eb4a
+msgid "Copyright © 2016 Yoshiki Shibukawa"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/imagesize-1.4.1.dist-info/LICENSE.rst:6
+#: 1852768a207148e8a640eb1acc076ab7
+msgid ""
+"Permission is hereby granted, free of charge, to any person obtaining a "
+"copy of this software and associated documentation files (the "
+"“Software”), to deal in the Software without restriction, including "
+"without limitation the rights to use, copy, modify, merge, publish, "
+"distribute, sublicense, and/or sell copies of the Software, and to permit"
+" persons to whom the Software is furnished to do so, subject to the "
+"following conditions:"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/imagesize-1.4.1.dist-info/LICENSE.rst:12
+#: c58be8ee3c8f473f813bde5daeafa536
+msgid ""
+"The above copyright notice and this permission notice shall be included "
+"in all copies or substantial portions of the Software."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/imagesize-1.4.1.dist-info/LICENSE.rst:15
+#: bcc0103fc9e548e89f1d6b5bc7c98b31
+msgid ""
+"THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS "
+"OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF "
+"MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN"
+" NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,"
+" DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR "
+"OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE"
+" USE OR OTHER DEALINGS IN THE SOFTWARE."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:1
+#: e49e03c1886844259db71a8b0da9789b
+msgid "markdown-it-container"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:3
+#: a88b013cb1a14120b1d5a9ecea4ce9e8
+msgid ""
+"[![Build Status](https://img.shields.io/travis/markdown-it/markdown-it-"
+"container/master.svg?style=flat)](https://travis-ci.org/markdown-it"
+"/markdown-it-container) [![NPM version](https://img.shields.io/npm/v"
+"/markdown-it-container.svg?style=flat)](https://www.npmjs.org/package"
+"/markdown-it-container) [![Coverage "
+"Status](https://img.shields.io/coveralls/markdown-it/markdown-it-"
+"container/master.svg?style=flat)](https://coveralls.io/r/markdown-it"
+"/markdown-it-container?branch=master)"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:3
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:3
+#: 643fb1c2331c444d9eebcd59b0d84541 cbb138ffd079476e9fe9d321fc8140c3
+msgid "Build Status"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:3
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:3
+#: 445043497ac446d5b5d8faaae13e055c fb3a1e66cb544d44a6830d3373fee4b1
+msgid "NPM version"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:3
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:3
+#: 675a06e31cd54cb4af1320b991125f4a 72f10afff03e4b4794fd68d69afcd9d2
+msgid "Coverage Status"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:7
+#: 8be808a359e54b2492064927350fba55
+msgid ""
+"Plugin for creating block-level custom containers for [markdown-"
+"it](https://github.com/markdown-it/markdown-it) markdown parser."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:9
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:9
+#: 631b149484d24e069016c7c1532d2d2a b767f0ca917a44de82f46da9e24e96e0
+msgid "__v2.+ requires `markdown-it` v5.+, see changelog.__"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:11
+#: 223eb6d266f64663862ff0cdef64a2d6
+msgid "With this plugin you can create block containers like:"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:19
+#: 140f37968c6544cab5bdbfb02d68faaf
+msgid ""
+".... and specify how they should be rendered. If no renderer defined, "
+"`<div>` with container name class will be created:"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:28
+#: 60fd44e6161d42c597c5cc42d2eed050
+msgid ""
+"Markup is the same as for [fenced code "
+"blocks](http://spec.commonmark.org/0.18/#fenced-code-blocks). Difference "
+"is, that marker use another character and content is rendered as markdown"
+" markup."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:32
+#: 1ceac555acc142ee8eeacaefafaa3f59
+msgid "Installation"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:34
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:16
+#: 86896043684e479dbd1adef4bcac2d7d b8e71f9c76714680aeb2932862327ceb
+msgid "node.js, browser:"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:42
+#: 7b65b1f4c2724172bb8c7b295b2e4020
+msgid "API"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:49
+#: e5471c7e42184b81b02e665a8a581796
+msgid "Params:"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:51
+#: 4e3326221502434b86c72ef95b41eb1c
+msgid "__name__ - container name (mandatory)"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:52
+#: 8ed63f922bec4da6b4f8bf2c4f25744f
+msgid "__options:__"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:53
+#: 8ae43dd5876a4aa6b280d2c4a1136da5
+msgid ""
+"__validate__ - optional, function to validate tail after opening marker, "
+"should return `true` on success."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:55
+#: 92c1d59d17d54ababefbb54659ad6e55
+msgid "__render__ - optional, renderer function for opening/closing tokens."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:56
+#: dc129b03265c4b358f333b46c657e072
+msgid "__marker__ - optional (`:`), character to use in delimiter."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:59
+#: bdf4b7ccb1674f76b933dec24378a70b
+msgid "Example"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:93
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:36
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:1
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:133
+#: 267559600a324daf8006b181564ce566 a79d787bc551494d9ca6a05f14b8e305
+#: df86e1c582764592b97e877a242c6754 e734876cb52e46e7b6a3bac331c58bda
+msgid "License"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:95
+#: 0869b2da52404f49aa98f1bd9f537651
+msgid ""
+"[MIT](https://github.com/markdown-it/markdown-it-"
+"container/blob/master/LICENSE)"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:1
+#: cc74ddf7f726442a85770d6a72aeb251
+msgid "markdown-it-deflist"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:3
+#: 31b33cfff4184aaf9f43a3e90efe371d
+msgid ""
+"[![Build Status](https://img.shields.io/travis/markdown-it/markdown-it-"
+"deflist/master.svg?style=flat)](https://travis-ci.org/markdown-it"
+"/markdown-it-deflist) [![NPM version](https://img.shields.io/npm/v"
+"/markdown-it-deflist.svg?style=flat)](https://www.npmjs.org/package"
+"/markdown-it-deflist) [![Coverage "
+"Status](https://img.shields.io/coveralls/markdown-it/markdown-it-"
+"deflist/master.svg?style=flat)](https://coveralls.io/r/markdown-it"
+"/markdown-it-deflist?branch=master)"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:7
+#: 7d21759f971b4214afcfa828d381248f
+msgid ""
+"Definition list (`<dl>`) tag plugin for [markdown-it](https://github.com"
+"/markdown-it/markdown-it) markdown parser."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:11
+#: 987f97e09dc54604953d756f606dcb80
+msgid ""
+"Syntax is based on [pandoc definition "
+"lists](http://johnmacfarlane.net/pandoc/README.html#definition-lists)."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:14
+#: ed30c3a0e7ac4ac8bb5bc6b3ef717acc
+msgid "Install"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:23
+#: 5b56c9e9862040c4a3021651b5d92687
+msgid "Use"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:32
+#: 32291d893f79454e80caa070b39edd1d
+msgid ""
+"_Differences in browser._ If you load script directly into the page, "
+"without package system, module will add itself globally as "
+"`window.markdownitDeflist`."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:38
+#: 41fce509e63049ac8424e184b06b5109
+msgid ""
+"[MIT](https://github.com/markdown-it/markdown-it-"
+"deflist/blob/master/LICENSE)"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:1
+#: e057db94d78a4d14ad08b3011dfbc477
+msgid ""
+"[![License](https://img.shields.io/github/license/goessner/markdown-it-"
+"texmath.svg)](https://github.com/goessner/markdown-it-"
+"texmath/blob/master/licence.txt) [![npm](https://img.shields.io/npm/v"
+"/markdown-it-texmath.svg)](https://www.npmjs.com/package/markdown-it-"
+"texmath) [![npm](https://img.shields.io/npm/dt/markdown-it-"
+"texmath.svg)](https://www.npmjs.com/package/markdown-it-texmath)"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:1
+#: 74576af3ad9a4ee39bfe44e316de5fb1 c4872ca8b32c4a4790ab0597faf8a8a6
+msgid "npm"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:5
+#: 157e5a3dd0264571916e500b8de44002
+msgid "markdown-it-texmath"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:7
+#: 309e16f425964b159a4ba307590e184f
+msgid ""
+"Add TeX math equations to your Markdown documents rendered by [markdown-"
+"it](https://github.com/markdown-it/markdown-it) parser. "
+"[KaTeX](https://github.com/Khan/KaTeX) is used as a fast math renderer."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:9
+#: f8a4e94757f2422187c6435994cf7371
+msgid "Features"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:10
+#: 4f9f5dd8bf7f4854b4e5638e412ee282
+msgid ""
+"Simplify the process of authoring markdown documents containing math "
+"formulas. This extension is a comfortable tool for scientists, engineers "
+"and students with markdown as their first choice document format."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:13
+#: b0aa32493be546e58e566fc4747d46dd
+msgid "Macro support"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:14
+#: c00e2c3e083f4388bc7037ba1498dd18
+msgid "Simple formula numbering"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:15
+#: 695beb0db9c34573b5938bca9ee90e4f
+msgid "Inline math with tables, lists and blockquote."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:16
+#: be57ab220b7540888023ab3059f71bc7
+msgid "User setting delimiters:"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:17
+#: a30604d94dce451daafcdb5bc890d3ac
+msgid "`'dollars'` (default)"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:18
+#: 6f0461a9f63345c09a4d0178947dbb68
+msgid "inline: `$...$`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:19
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:35
+#: 12142a76d44d4ce5a16c4d5a158a9637 dc1b9cbd2f82487891503c0bafeda846
+msgid "display: `$$...$$`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:20
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:36
+#: 7e3c7d4b5bd54953bbdbd63bc6d7d2b5 f877016f55b7445ba30eabbe42b70592
+msgid "display + equation number: `$$...$$ (1)`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:21
+#: b8672b73a3354b7da686ae497556ff0e
+msgid "`'brackets'`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:22
+#: 75b30e1f2b0b4e3d986b1cd299422178
+msgid "inline: `\\(...\\)`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:23
+#: 1fb03d476a78432fb6df765247a9756d
+msgid "display: `\\[...\\]`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:24
+#: 83ef05ce21aa4e2d85d4d6e6ae9792d0
+msgid "display + equation number: `\\[...\\] (1)`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:25
+#: fe4d88fc08214241881129b5809e626d
+msgid "`'gitlab'`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:26
+#: d3abb6d66da44a79922e6d4e6c591cfe
+msgid "inline: ``$`...`$``"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:27
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:31
+#: 27a059ce708a4188a0bb041a725a3a20 cb0b71fa64334a71ad45ae199735edf8
+msgid "display: `` ```math ... ``` ``"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:28
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:32
+#: 3fde380aaa3945098eb8c7d3f1ca0fee eb7c543e030d4bc8ae1363703dc98995
+msgid "display + equation number: `` ```math ... ``` (1)``"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:29
+#: 17b547696b3a49ffb84ca24d282958c9
+msgid "`'julia'`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:30
+#: a537a5dc24534cb890e59dd3b1812a7e
+msgid "inline: `$...$`  or ``` ``...`` ```"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:33
+#: d36e5471714647f9ab6d1fbb7fa35cae
+msgid "`'kramdown'`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:34
+#: 15f31bf2467f42298aa5f8c26c6e586e
+msgid "inline: ``$$...$$``"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:38
+#: 94fed257197541c0bf7e9f8fb6d18733
+msgid "Show me"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:40
+#: e874f0a1930b4a5b8113d67bbca00bfd
+msgid ""
+"View a [test table](https://goessner.github.io/markdown-it-"
+"texmath/index.html)."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:42
+#: aa9577bc494a4effadf83ecc4027026b
+msgid ""
+"[try it out ...](https://goessner.github.io/markdown-it-texmath/markdown-"
+"it-texmath-demo.html)"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:44
+#: aee8284928ba4f8eb1632e3a2c551fa6
+msgid "Use with `node.js`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:46
+#: bb77829871ba4620b31bed6d2e78816b
+msgid ""
+"Install the extension. Verify having `markdown-it` and `katex` already "
+"installed ."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:50
+#: 23a36619cd544731943d0b39c03abbbf
+msgid "Use it with JavaScript."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:59
+#: 7cc8519d35664f64aecb71811907b28e
+msgid "Use in Browser"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:83
+#: b92a92ced9ef40d8b39e21ad0e8e2c27
+msgid "CDN"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:85
+#: bf5f80a2ccca4fb2930d7aac38f18edc
+msgid "Use following links for `texmath.js` and `texmath.css`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:86
+#: d4a48801bb9f4a3994af4674142e785b
+msgid "`https://gitcdn.xyz/cdn/goessner/markdown-it-texmath/master/texmath.js`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:87
+#: f80a34376a374cca938d70c30c25fb51
+msgid "`https://gitcdn.xyz/cdn/goessner/markdown-it-texmath/master/texmath.css`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:89
+#: 31a28aa4a3e94a5996ebc74e4193808f
+msgid "Dependencies"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:91
+#: 9848d2d73f914656b6c171d05b7d8bb3
+msgid ""
+"[`markdown-it`](https://github.com/markdown-it/markdown-it): Markdown "
+"parser done right. Fast and easy to extend."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:92
+#: fa7ced3164cb48e49bdd4932a9a4f39d
+msgid ""
+"[`katex`](https://github.com/Khan/KaTeX): This is where credits for fast "
+"rendering TeX math in HTML go to."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:94
+#: 9efc2dd198d6436f94d82e29f6a01ddd
+msgid "ToDo"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:96
+#: 496b6811181140d1b87b046e281ee0c9
+msgid "nothing yet"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:98
+#: 5d717d64ba734c43a58128212dd36e0a
+msgid "FAQ"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:100
+#: 061ba8572ca048d190a69f157744524a
+msgid "__`markdown-it-texmath` with React Native does not work, why ?__"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:101
+#: 77e5944397a7463e9a73036487698715
+msgid ""
+"`markdown-it-texmath` is using regular expressions with `y` [(sticky) "
+"property](https://developer.mozilla.org/en-"
+"US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/sticky) and cannot"
+" avoid this. The use of the `y` flag in regular expressions means the "
+"plugin is not compatible with React Native (which as of now doesn't "
+"support it and throws an error `Invalid flags supplied to RegExp "
+"constructor`)."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:103
+#: cbe91ac47621429e94e3d2b7dd2835e0
+msgid "CHANGELOG"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:105
+#: cf019dffbb1a4b0e86c9d6f3bf053cec
+msgid "[0.6.0] on October 04, 2019"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:106
+#: 05490a0fff214b72ba3e1924fe73ec4f
+msgid ""
+"Add support for [Julia "
+"Markdown](https://docs.julialang.org/en/v1/stdlib/Markdown/) on "
+"[request](https://github.com/goessner/markdown-it-texmath/issues/15)."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:108
+#: 2093987c7b3b411bb5f6247aa287c147
+msgid "[0.5.5] on February 07, 2019"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:109
+#: 5269b5c18ce241d1a255e3ab2c68baef
+msgid ""
+"Remove [rendering bug with brackets "
+"delimiters](https://github.com/goessner/markdown-it-texmath/issues/9)."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:111
+#: 6aaf8d7a4e064bb3b98a5edae720fe8c
+msgid "[0.5.4] on January 20, 2019"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:112
+#: 75fabae3db7343879034b56ae4299a77
+msgid ""
+"Remove pathological [bug within "
+"blockquotes](https://github.com/goessner/mdmath/issues/50)."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:114
+#: 7f4b1fc7dc8045f8988333ff58e8f07c
+msgid "[0.5.3] on November 11, 2018"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:115
+#: b39e4ea4dad641178b78ff31ce51b458
+msgid ""
+"Add support for Tex macros (https://katex.org/docs/supported.html#macros)"
+" ."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:116
+#: 3c4d1c6e691e405a8410a3bf5d567a62
+msgid ""
+"Bug with [brackets delimiters](https://github.com/goessner/markdown-it-"
+"texmath/issues/9) ."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:118
+#: 715aaf957c2f45f68aa18fb6adcecae1
+msgid "[0.5.2] on September 07, 2018"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:119
+#: 1c21dcd8158e4b7380335032f8488823
+msgid "Add support for [Kramdown](https://kramdown.gettalong.org/) ."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:121
+#: 8c40cb3b696d400581aafbffe01a2863
+msgid "[0.5.0] on August 15, 2018"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:122
+#: b0703ac4821f4ec6ab431d8b4ff0c713
+msgid ""
+"Fatal blockquote bug investigated. Implemented workaround to vscode bug, "
+"which has finally gone with vscode 1.26.0 ."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:124
+#: 07f70dde3d0b49d7bf4b46e7b43fc60c
+msgid "[0.4.6] on January 05, 2018"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:125
+#: 2ccc50aeca474fd3ab8fd4414e678598
+msgid "Escaped underscore bug removed."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:127
+#: 59f4f020ddb7424fa3fa5d217b9457b9
+msgid "[0.4.5] on November 06, 2017"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:128
+#: 681997521a854dc4bdc39d2eaa888c34
+msgid "Backslash bug removed."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:130
+#: 531fd1ab52274de3801dc5911ee09ad2
+msgid "[0.4.4] on September 27, 2017"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:131
+#: 31968e82ca544532bec7bc26ef8ed9f9
+msgid ""
+"Modifying the `block` mode regular expression with `gitlab` delimiters, "
+"so removing the `newline` bug."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:135
+#: 52c2b744570047b3b3a075714536978d
+msgid "`markdown-it-texmath` is licensed under the [MIT License](./license.txt)"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:137
+#: 89bc025154c44499bf25fd4a6621ba0d
+msgid "© [Stefan Gössner](https://github.com/goessner)"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:2
+#: e2034c149edf4233ba2d239de2bc5a37
+msgid "License for Sphinx"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:4
+#: 0724495e2bf4464d912bb8b932511a88
+msgid ""
+"Unless otherwise indicated, all code in the Sphinx project is licenced "
+"under the two clause BSD licence below."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:7
+#: a54d7f8a1705480d94cc3228b74332d2
+msgid ""
+"Copyright (c) 2007-2024 by the Sphinx team (see AUTHORS file). All rights"
+" reserved."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:35
+#: ff1b2ef9d7374205ba6c12fddff922ab
+msgid "Licenses for incorporated software"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:37
+#: 1323d5c2d81442e7bf615b20ad8c4d3c
+msgid ""
+"The included implementation of "
+"NumpyDocstring._parse_numpydoc_see_also_section was derived from code "
+"under the following license:"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:42
+#: 4e59393bef704f569239fae16276714f
+msgid ""
+"Copyright (C) 2008 Stefan van der Walt <stefan@mentat.za.net>, Pauli "
+"Virtanen <pav@iki.fi>"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:55
+#: 2608a2347fc24391a73c6841ab66828d
+msgid ""
+"THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR "
+"IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES"
+" OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. "
+"IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, "
+"INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT "
+"NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,"
+" DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY "
+"THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT "
+"(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF "
+"THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx/ext/autosummary/templates/autosummary/base.rst:1
+#: ../../venv/lib/python3.11/site-packages/sphinx/ext/autosummary/templates/autosummary/class.rst:1
+#: ../../venv/lib/python3.11/site-packages/sphinx/ext/autosummary/templates/autosummary/module.rst:1
+#: 0451370ee9314f7c906ab2836764c47a 34eae62f4d5740edb136c49059b2f68a
+#: 9fa2c23ace9742ef857c70bd4efa6475
+msgid "{{ fullname | escape | underline}}"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx/ext/autosummary/templates/autosummary/module.rst:49
+#: 2a32ebb5750d4a979e7eb61b0b2a43d1
+msgid "{%- block modules %} {%- if modules %} .. rubric:: Modules"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx/ext/autosummary/templates/autosummary/module.rst:56
+#: d57cb8ab9dca45e4aea575779c41d097
+#, python-format
+msgid "{% for item in modules %}"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx/ext/autosummary/templates/autosummary/module.rst:57
+#: 7cceed397e184649b97d1c43c3bdf7cc
+msgid "{{ item }}"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx/ext/autosummary/templates/autosummary/module.rst:58
+#: 92d7e04737254ad29257454aef84d60e
+#, python-format
+msgid "{%- endfor %} {% endif %} {%- endblock %}"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx_intl-2.2.0.dist-info/AUTHORS.rst:3
+#: bcacc45f6d95492d8bad5f48f0118261
+msgid "AUTHORS"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx_intl-2.2.0.dist-info/AUTHORS.rst:5
+#: 593ea41c5a514301b5452416e55ede81
+msgid "Takayuki Shimizukawa <https://github.com/shimizukawa>"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx_intl-2.2.0.dist-info/AUTHORS.rst:6
+#: e742c33eb1364000ba767acc24bfa569
+msgid "Takeshi Komiya <https://github.com/tk0miya>"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx_intl-2.2.0.dist-info/AUTHORS.rst:9
+#: 44931f9b8feb4787ab34eb833e84679d
+msgid "Original"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx_intl-2.2.0.dist-info/AUTHORS.rst:11
+#: 9f8934708c8843d08acf1b7ee6f45a3b
+msgid "This utility derived from these projects."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx_intl-2.2.0.dist-info/AUTHORS.rst:13
+#: 967f61e50bfc436b8f5d6b4bf16d2534
+msgid "https://bitbucket.org/tk0miya/sphinx-gettext-helper"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx_intl-2.2.0.dist-info/AUTHORS.rst:14
+#: cdbc970fd030448782c80d668fa88cf6
+msgid "https://bitbucket.org/shimizukawa/sphinx-transifex"
+msgstr ""
+

--- a/docs/locale/nb/LC_MESSAGES/editing.po
+++ b/docs/locale/nb/LC_MESSAGES/editing.po
@@ -1,0 +1,799 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: nb\n"
+"Language-Team: nb <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../editing.md:1 ba75e061942846b39d6400279abb3237
+msgid "Editorial Guide"
+msgstr ""
+
+#: ../../editing.md:3 4425ba5e1b67491e91d218933ae1bedc
+msgid ""
+"The Journal of Open Source Software (JOSS) conducts all peer review and "
+"editorial processes in the open, on the GitHub issue tracker."
+msgstr ""
+
+#: ../../editing.md:5 588c730a7e6140ea92d7ef96a144ba34
+msgid ""
+"JOSS editors manage the review workflow with the help of our bot, "
+"`@editorialbot`. The bot is summoned with commands typed directly on the "
+"GitHub review issues. For a list of commands, type: `@editorialbot "
+"commands`."
+msgstr ""
+
+#: ../../editing.md:8 ea507efa5e7c4203af483f907285e322
+msgid ""
+"To learn more about `@editorialbot`'s functionalities, take a look at our"
+" [dedicated guide](editorial_bot)."
+msgstr ""
+
+#: ../../editing.md:11 01a2380aa2e84215bf133d231a693ea1
+msgid "Overview of editorial process"
+msgstr ""
+
+#: ../../editing.md:13 1d0e9c7d61634731889074477da77a8e
+msgid "**Step 1: An author submits a paper.**"
+msgstr ""
+
+#: ../../editing.md:15 be3c1216b0ef4b4eb0ce620c0486ce3a
+msgid ""
+"The author can choose to select an preferred editor based on the "
+"information available in our biographies. This can be changed later."
+msgstr ""
+
+#: ../../editing.md:17 e89317316a414f3997d43046e0ebca4f
+msgid ""
+"**Step 2: If you are selected as an editor you get @-mentioned in the "
+"pre-review issue.**"
+msgstr ""
+
+#: ../../editing.md:19 7dfb3122440545e2abf13fbce2590990
+msgid ""
+"This doesn’t mean that you’re the editor, just that you’ve been suggested"
+" by the author."
+msgstr ""
+
+#: ../../editing.md:21 3bd75b6544eb40f4a8632660039bfe66
+msgid ""
+"**Step 3: Once you are the editor, find the link to the code repository "
+"in the `pre-review` issue**"
+msgstr ""
+
+#: ../../editing.md:23 5d43095e44a14c4793ad6f4495a55247
+msgid ""
+"If the paper is not in the default branch, add it to the issue with the "
+"command: `@editorialbot set branch-where-paper-is as branch`."
+msgstr ""
+
+#: ../../editing.md:25 dc2a2117853f4cf98427079ca7959f87
+msgid ""
+"**Step 4: The editor looks at the software submitted and checks to see "
+"if:**"
+msgstr ""
+
+#: ../../editing.md:27 c2fa085a985240b5a09962904479e0b5
+msgid "There’s a general description of the software"
+msgstr ""
+
+#: ../../editing.md:28 d08990aef10944a29ce0c0ff47222780
+msgid "The software is within scope as research software"
+msgstr ""
+
+#: ../../editing.md:29 aa784fe1458146bcbf4a6357a20aa4dd
+msgid "It has an OSI-approved license"
+msgstr ""
+
+#: ../../editing.md:31 1616e7978406420985cb59579086bdc9
+msgid ""
+"**Step 5: The editor responds to the author saying that things look in "
+"line (or not) and will search for reviewer**"
+msgstr ""
+
+#: ../../editing.md:33 8d341ffd2d5748a7a2873fe78c1f54f3
+msgid "**Step 6: The editor finds >= 2 reviewers**"
+msgstr ""
+
+#: ../../editing.md:35 f6e3b8184f6448b7987dc9d1856febae
+msgid ""
+"Use the list of reviewers: type the command `@editorialbot list "
+"reviewers` or look at use the [Reviewers Management "
+"System](https://reviewers.joss.theoj.org)"
+msgstr ""
+
+#: ../../editing.md:37 9d1e2e91340549c5a7115b4781afd5ae
+msgid ""
+"If people are in the review list, the editor can @-mention them on the "
+"issue to see if they will review: e.g. `@person1 @person2 can you review "
+"this submission for JOSS?`"
+msgstr ""
+
+#: ../../editing.md:38 bc55566434724ed9bca98d34b52fdead
+msgid ""
+"Or solicit reviewers outside the list. Send an email to people describing"
+" what JOSS is and asking if they would be interested in reviewing."
+msgstr ""
+
+#: ../../editing.md:39 80c9c8dfcae14f43bfc7ff51dfe90c78
+msgid ""
+"If you ask the author to suggest potential reviewers, please be sure to "
+"tell the author not to @-tag their suggestions."
+msgstr ""
+
+#: ../../editing.md:41 50d524d4d91242d89e3d8b53172027c0
+msgid "**Step 7: Editor tells EditorialBot to assign the reviewers to the paper**"
+msgstr ""
+
+#: ../../editing.md:43 ee6ceff15aec4326a765b27464e4e151
+msgid "Use `@editorialbot add @reviewer as reviewer`"
+msgstr ""
+
+#: ../../editing.md:44 faacbbf290f04780b04687fc697eb7a7
+msgid "To add a second reviewer use `@editorialbot add @reviewer2 as reviewer`"
+msgstr ""
+
+#: ../../editing.md:46 2247f7a372ad4610860360322b89a8b9
+msgid "**Step 8: Create the actual review issue**"
+msgstr ""
+
+#: ../../editing.md:48 9f059ce78963480fb5630d0619c405fc
+msgid "Use `@editorialbot start review`"
+msgstr ""
+
+#: ../../editing.md:49 5cce03e372f348b2bbd2bc8bb7ea4255
+msgid ""
+"An issue is created with the review checklist, one per reviewer, e.g. "
+"https://github.com/openjournals/joss-reviews/issues/717"
+msgstr ""
+
+#: ../../editing.md:51 8fec36d962204eb08ac273f7d87f4a91
+msgid "**Step 9: Close the pre-review issue**"
+msgstr ""
+
+#: ../../editing.md:53 8dfb216bd6594395a11a5a73a0ab0665
+msgid "**Step 10: The actual JOSS review**"
+msgstr ""
+
+#: ../../editing.md:55 afd01c95bf5e465d80168253137007ae
+msgid ""
+"The reviewer reviews the paper and has a conversation with the author. "
+"The editor lurks on this conversation and comes in if needed for "
+"questions (or CoC issues)."
+msgstr ""
+
+#: ../../editing.md:56 298bde930f5540d794bb912008afea98
+msgid ""
+"The reviewer potentially asks for changes and the author makes changes. "
+"Everyone agrees it’s ready."
+msgstr ""
+
+#: ../../editing.md:58 e82ce62ae4434ce8a860d7e380585acd
+msgid "**Step 11: The editor pings the EiC team to get the paper published**"
+msgstr ""
+
+#: ../../editing.md:60 3c0819139b644e1090266a2c3f8dfb09
+msgid ""
+"Make a final check of the paper with `@editorialbot generate pdf` and "
+"that all references have DOIs (where appropriate) with `@editorialbot "
+"check references`."
+msgstr ""
+
+#: ../../editing.md:61 8e1bcc08da4f45a3ad2cd0cc88eccb53
+msgid ""
+"If everything looks good, ask the author to make a new release (if "
+"possible) of the software being reviewed and deposit a new archive the "
+"software with Zenodo/figshare. Update the review thread with this archive"
+" DOI: `@editorialbot set 10.5281/zenodo.xxxxxx as archive`."
+msgstr ""
+
+#: ../../editing.md:62 3bdfdd0fffbe4486b9d3eaa0fcc285e5
+msgid ""
+"Editors can get a checklist of the final steps using the `@editorialbot "
+"create post-review checklist` command"
+msgstr ""
+
+#: ../../editing.md:63 dc8a53ae589b4714b782d44e169c6eb4
+msgid ""
+"Finally, use `@editorialbot recommend-accept` on the review thread to "
+"ping the `@openjournals/joss-eics` team letting them know the paper is "
+"ready to be accepted."
+msgstr ""
+
+#: ../../editing.md:65 4ef13c64642d4dddb985e7d7443b615c
+msgid ""
+"**Step 12: Celebrate publication! Tweet! Thank reviewers! Say thank you "
+"on issue.**"
+msgstr ""
+
+#: ../../editing.md:67 abc94aab3bb847aaabd9b314068f769e
+msgid "Visualization of editorial flow"
+msgstr ""
+
+#: ../../editing.md:69 780171765db2498cbffedd0d64336c5f
+msgid "![Editorial flow](images/JOSS-flowchart.png)"
+msgstr ""
+
+#: ../../editing.md:69 49ebbf2f618b4e4aa1d887ee92d811c1
+msgid "Editorial flow"
+msgstr ""
+
+#: ../../editing.md:72 da842b437107499d9f5f02d98142d0ca
+msgid "Pre-review"
+msgstr ""
+
+#: ../../editing.md:74 0dea21b9176141998658732613afcbae
+msgid ""
+"Once a submission comes in, it will be in the queue for a quick check by "
+"the Track Editor-in-chief (TEiC). From there, it moves to a `PRE-REVIEW` "
+"issue, where the TEiC will assign a handling editor, and the author can "
+"suggest reviewers. Initial direction to the authors for improving the "
+"paper can already happen here, especially if the paper lacks some "
+"requested sections."
+msgstr ""
+
+#: ../../editing.md:77 804139f147a14d7a8494d05a58fbda97
+msgid ""
+"If the paper is out-of-scope for JOSS, editors assess this and notify the"
+" author in the ``PRE-REVIEW`` issue."
+msgstr ""
+
+#: ../../editing.md:80 98e964c5547b4becbcdaf2f51775354e
+msgid ""
+"Editors can flag submissions of questionable scope using the command "
+"`@editorialbot query scope`."
+msgstr ""
+
+#: ../../editing.md:82 44c33ad2bbfa430ba1d2ec0031f3d8ed
+msgid ""
+"The TEiC assigns an editor (or a volunteering editor self-assigns) with "
+"the command `@editorialbot assign @username as editor` in a comment."
+msgstr ""
+
+#: ../../editing.md:85 92e566f78ff84e148a7e62170b2b8b6e
+msgid ""
+"Please check in on the "
+"[dashboard](https://joss.theoj.org/dashboard/incoming) semi-regularly to "
+"see which papers are currently without an editor, and if possible, "
+"volunteer to edit papers that look to be in your domain. If you choose to"
+" be an editor in the issue thread type the command `@editorialbot assign "
+"@yourhandle as editor` or simply `@editorialbot assign me as editor`"
+msgstr ""
+
+#: ../../editing.md:88 96324eec2dff4339a9097d19f4f88dbe
+msgid "How papers are assigned to editors"
+msgstr ""
+
+#: ../../editing.md:90 014c09095aeb4cf1b5bc42650b1d168e
+msgid ""
+"By default, unless an editor volunteers, the Track Editor-in-chief (TEiC)"
+" on duty will attempt to assign an incoming paper to the most suitable "
+"handling editor. While TEiC will make every effort to match a submission "
+"with the most appropriate editor, there are a number of situations where "
+"an TEiC may assign a paper to an editor that doesn't fit entirely within "
+"the editor's research domains:"
+msgstr ""
+
+#: ../../editing.md:92 fac8f2d244fd41759d31f0b68f21272f
+msgid "If there's no obvious fit to _any_ of the JOSS editors"
+msgstr ""
+
+#: ../../editing.md:93 87f3e1b98650471fac5779492f60f6c2
+msgid "If the most suitable editor is already handling a large number of papers"
+msgstr ""
+
+#: ../../editing.md:94 6af7d1f654964f4a81937920c4f81453
+msgid "If the chosen editor has a lighter editorial load than other editors"
+msgstr ""
+
+#: ../../editing.md:96 fcee040231ea469a98208739ff188df8
+msgid ""
+"In most cases, the TEiC will ask one or more editors to edit a submission"
+" (e.g. `@editor1, @editor 2 - would one of you be willing to edit this "
+"submission for JOSS`). If the editor doesn't respond within ~3 working "
+"days, the TEiC may assign the paper to the editor regardless."
+msgstr ""
+
+#: ../../editing.md:98 7ead8edc335b4f539c9b9f2b2e18fc0c
+msgid ""
+"Editors may also be invited to edit over email when an TEiC runs the "
+"command `@editorialbot invite @editor1 as editor`."
+msgstr ""
+
+#: ../../editing.md:100 3bf16fb790074ada87a3d4aeb9f427ea
+msgid "Finding reviewers"
+msgstr ""
+
+#: ../../editing.md:102 8dc3490e7abd4a8186526a8eb64fb943
+msgid ""
+"At this point, the handling editor's job is to identify reviewers who "
+"have sufficient expertise in the field of software and in the field of "
+"the submission. JOSS papers have to have a minimum of two reviewers per "
+"submission, except for papers that have previously been peer-reviewed via"
+" rOpenSci. In some cases, the editor also might want to formally add "
+"themselves as one of the reviewers. If the editor feels particularly "
+"unsure of the submission, a third (or fourth) reviewer can be recruited."
+msgstr ""
+
+#: ../../editing.md:104 4bad7fcd46c7403aa7758ed50bd77e66
+msgid ""
+"To recruit reviewers, the handling editor can mention them in the `PRE-"
+"REVIEW` issue with their GitHub handle, ping them on Twitter, or email "
+"them. After expressing initial interest, candidate reviewers may need a "
+"longer explanation via email. See sample reviewer invitation email, "
+"below."
+msgstr ""
+
+#: ../../editing.md:106 682e99ffe4e241eaaf9e3993356ab10a
+msgid "**Reviewer Considerations**"
+msgstr ""
+
+#: ../../editing.md:108 edf7d8efffb045e0965b6b9293648a03
+msgid ""
+"It is rare that all reviewers have the expertise to cover all aspects of "
+"a submission (e.g., knows the language really well and knows the "
+"scientific discipline well). As such, a good practice is to try and make "
+"sure that between the two or three reviewers, all aspects of the "
+"submission are covered."
+msgstr ""
+
+#: ../../editing.md:109 4f10a84abdd14117a2a3152e849c5be5
+msgid ""
+"Selection and assignment of reviewers should adhere to the [JOSS COI "
+"policy](https://joss.theoj.org/about#ethics)."
+msgstr ""
+
+#: ../../editing.md:111 2104a69a5a9042bead939ae983b3c7a0
+msgid "**Potential ways to find reviewers**"
+msgstr ""
+
+#: ../../editing.md:113 136014fdf9e547db8f7b3be69cbd5f00
+msgid ""
+"Finding reviewers can be challenging, especially if a submission is "
+"outside of your immediate area of expertise. Some strategies you can use "
+"to identify potential candidates:"
+msgstr ""
+
+#: ../../editing.md:115 1d3468cc8f104c929ec80034bec03e35
+msgid ""
+"Search the [reviewer application](https://reviewers.joss.theoj.org) of "
+"volunteer reviewers."
+msgstr ""
+
+#: ../../editing.md:116 24b24f22566b400e9d984588466bb29a
+msgid ""
+"When using this spreadsheet, pay attention to the number of reviews this "
+"individual is already doing to avoid overloading them."
+msgstr ""
+
+#: ../../editing.md:117 5ecccfbb623042939b0e2825f92f9b3c
+msgid ""
+"It can be helpful to use the \"Data > Filter Views\" capability to "
+"temporarily filter the table view to include only people with language or"
+" domain expertise matching the paper."
+msgstr ""
+
+#: ../../editing.md:118 89e4d0c5f2c54f5bab1af508c97869c2
+msgid ""
+"Ask the author(s): You are free to ask the submitting author to suggest "
+"possible reviewers by using the [reviewer "
+"application](https://reviewers.joss.theoj.org) and also people from their"
+" professional network. In this situation, the editor still needs to "
+"verify that their suggestions are appropriate."
+msgstr ""
+
+#: ../../editing.md:119 c1f2ce44cb154c3682ace1d6796a6aaa
+msgid ""
+"Use your professional network: You're welcome to invite people you know "
+"of who might be able to give a good review."
+msgstr ""
+
+#: ../../editing.md:120 e49dc26b10b943eea7f86075231528c2
+msgid ""
+"Search Google and GitHub for related work, and write to the authors of "
+"that related work."
+msgstr ""
+
+#: ../../editing.md:121 c8c6d4f9aec24548be6f2a2d26ad284f
+msgid ""
+"Ask on social networks: Sometimes asking on Twitter for reviewers can "
+"identify good candidates."
+msgstr ""
+
+#: ../../editing.md:122 29ba76f084644361b591486d0c4661ab
+msgid "Check the work being referenced in the submission:"
+msgstr ""
+
+#: ../../editing.md:123 8f788d2e5ed34216a7e0434cd7931844
+msgid ""
+"Authors of software that is being built on might be interested in "
+"reviewing the submission."
+msgstr ""
+
+#: ../../editing.md:124 aecd3f6132b548138055f4b72f5ed1ff
+msgid ""
+"Users of the software that is being submission be interested in reviewing"
+" the submission"
+msgstr ""
+
+#: ../../editing.md:125 294125b1c6654509a55a4a87e71bd443
+msgid ""
+"Avoid asking JOSS editors to review: If at all possible, avoid asking "
+"JOSS editors to review as they are generally very busy editing their own "
+"papers."
+msgstr ""
+
+#: ../../editing.md:127 79d5e0b0ef3b486fb67f3fe0511645b2
+msgid ""
+"Once a reviewer accepts, the handling editor runs the command "
+"`@editorialbot add @username as reviewer` in the `PRE-REVIEW` issue. Add "
+"more reviewers with the same command. Under the uncommon circumstance "
+"that a review must be started before all reviewers have been identified "
+"(e.g., if finding a second reviewer is taking a long time and the first "
+"reviewer wants to get started), an editor may elect to start the review "
+"and add the remaining reviewers later. To accomplish this, the editor "
+"will need to hand-edit the review checklist to create space for the "
+"reviewers added after the review issues is created."
+msgstr ""
+
+#: ../../editing.md:130 16ba9cbed3c94a629a7aff1bd90c6291
+msgid "Starting the review"
+msgstr ""
+
+#: ../../editing.md:132 ccd53f6c37f242b1b911877fa7e9c1b9
+msgid ""
+"Next, run the command `@editorialbot start review`. If you haven't "
+"assigned an editor and reviewer, this command will fail and "
+"`@editorialbot` will tell you this. This will open the `REVIEW` issue, "
+"with prepared review checklists for each reviewer, and instructions. The "
+"editor should move the conversation to the separate `REVIEW` issue."
+msgstr ""
+
+#: ../../editing.md:134 3cbe8574ab8f4792ae7f8fe839e05c89
+msgid "Review"
+msgstr ""
+
+#: ../../editing.md:136 bf31464bd63349f3ba503187408dac67
+msgid ""
+"The `REVIEW` issue contains some instructions for the reviewers to get a "
+"checklist using the command `@editorialbot generate my checklist`. The "
+"reviewer(s) should check off items of the checklist one-by-one, until "
+"done. In the meantime, reviewers can engage the authors freely in a "
+"conversation aimed at improving the paper."
+msgstr ""
+
+#: ../../editing.md:138 dcd070b1d78e440099f479ff0a2a7e9e
+msgid ""
+"If a reviewer recants their commitment or is unresponsive, editors can "
+"remove them with the command `@editorialbot remove @username from "
+"reviewers`. You can also add new reviewers in the `REVIEW` issue."
+msgstr ""
+
+#: ../../editing.md:140 e3e6abaa736c4364b7a380072fbdefe9
+msgid ""
+"Comments in the `REVIEW` issue should be kept brief, as much as possible,"
+" with more lengthy suggestions or requests posted as separate issues, "
+"directly in the submission repository. A link-back to those issues in the"
+" `REVIEW` is helpful."
+msgstr ""
+
+#: ../../editing.md:142 6dc3f0fe1e9c4c8bae2c397282f35570
+msgid ""
+"When the reviewers are satisfied with the improvements, we ask that they "
+"confirm their recommendation to accept the submission."
+msgstr ""
+
+#: ../../editing.md:144 3d33796171b4423b9498b2019870a5bb
+msgid "Adding a new reviewer once the review has started"
+msgstr ""
+
+#: ../../editing.md:146 223e9320e2f241fbad473c96d116ec25
+msgid ""
+"Sometimes you'll need to add a new reviewer once the main review (i.e. "
+"post pre-review) is already underway. In this situation you should do the"
+" following:"
+msgstr ""
+
+#: ../../editing.md:148 2c32f175245f49e4bbfb7b9cbba3f175
+msgid "In the review thread, do `@editorialbot add @newreviewer as reviewer`."
+msgstr ""
+
+#: ../../editing.md:149 ee79dc393c664659a4630aae28ac15cf
+msgid ""
+"The new reviewer must use the command `@editorialbot generate my "
+"checklist` to get a checklist."
+msgstr ""
+
+#: ../../editing.md:152 98b3a290d25d4f2b81fe1a2c529f8aaa
+msgid "Post-review"
+msgstr ""
+
+#: ../../editing.md:154 b0385263d4914f7f95ad0ba80654bda3
+msgid ""
+"When a submission is ready to be accepted, we ask that the authors issue "
+"a new tagged release of the software (if changed), and archive it (on "
+"[Zenodo](https://zenodo.org/), [fig**share**](https://figshare.com/), or "
+"other). The authors then post the version number and archive DOI in the "
+"`REVIEW` issue. The handling editor executes the pre-publication steps, "
+"and pings the Track Editor-in-Chief for final processing."
+msgstr ""
+
+#: ../../editing.md:156 dd52392784634b948e15a964b80cc429
+msgid ""
+"Optionally you can ask EditorialBot to generate a checklist with all the "
+"post-review steps running the command: `@editorialbot create post-review "
+"checklist`"
+msgstr ""
+
+#: ../../editing.md:158 ee9fcf7e3bce4bf68049aa27061cfa26
+msgid "Pre-publication steps:"
+msgstr ""
+
+#: ../../editing.md:159 c1789b1a6ebd45de969fdd00d51e3384
+msgid "(Optional) Run `@editorialbot create post-review checklist`"
+msgstr ""
+
+#: ../../editing.md:160 ab121be0a95345ea93212c99be108c04
+msgid "Get a new proof with the `@editorialbot generate pdf` command."
+msgstr ""
+
+#: ../../editing.md:161 fe48b1e1bb3b4016a571de52fcb8acdb
+msgid ""
+"Download the proof, check all references have DOIs, follow the links and "
+"check the references."
+msgstr ""
+
+#: ../../editing.md:162 96ff3f242de14c91b1b16b870cf57190
+msgid ""
+"EditorialBot can help check references with the command `@editorialbot "
+"check references`"
+msgstr ""
+
+#: ../../editing.md:163 d101dc7a7cf44f42b1435e34cd9945a8
+msgid ""
+"Proof-read the paper and ask authors to fix any remaining typos, badly "
+"formed citations, awkward wording, etc.."
+msgstr ""
+
+#: ../../editing.md:164 2ffdfd41c5d34a12b80a07a8be7255ab
+msgid ""
+"Ask the author to make a tagged release and archive, and report the "
+"version number and archive DOI in the review thread."
+msgstr ""
+
+#: ../../editing.md:165 3051b32771ed4fa6beb9efa4f8bc99da
+msgid "Check the archive deposit has the correct metadata (title and author list)"
+msgstr ""
+
+#: ../../editing.md:166 ccf9d0666940483f8d57c5642b830627
+msgid ""
+"In most situations, the two author lists should match. Authors and "
+"editors should review the two, and any differences need to be explained."
+msgstr ""
+
+#: ../../editing.md:167 ac196a6ce5104305ad119ebce0706214
+msgid ""
+"Other contributors can be present (and they should be marked as such, if "
+"possible)"
+msgstr ""
+
+#: ../../editing.md:168 7c48124d7b1f42a1a82476eb5fc66d14
+msgid "Check that the all authors of the paper are in the archive metadata"
+msgstr ""
+
+#: ../../editing.md:169 40166d1d39d24148a9100d4360f6ca19
+msgid "Eventually, ask for the reason why the two lists differ"
+msgstr ""
+
+#: ../../editing.md:170 cd935c631a74446bbfc43553b9bb07e6
+msgid "Run `@editorialbot set <doi> as archive`."
+msgstr ""
+
+#: ../../editing.md:171 368d9095453b4bd18c092dc6e21e04c1
+msgid "Run `@editorialbot set <v1.x.x> as version` if the version was updated."
+msgstr ""
+
+#: ../../editing.md:172 9ac44e6c0edb46868744955ea9c0150d
+msgid ""
+"Run `@editorialbot recommend-accept` to generate the final proofs, which "
+"has EditorialBot notify the `@openjournals/joss-eics` team that the paper"
+" is ready for final processing."
+msgstr ""
+
+#: ../../editing.md:174 badc1c00d346425281eade6905e889fd
+msgid ""
+"At this point, the EiC/AEiC will take over to make final checks and "
+"publish the paper."
+msgstr ""
+
+#: ../../editing.md:176 77f1a1c6606547e3ab5ea9ca88f7d7dd
+msgid ""
+"It’s also a good idea to ask the authors to check the proof. We’ve had a "
+"few papers request a post-publication change of author list, for "
+"example—this requires a manual download/compile/deposit cycle and should "
+"be a rare event."
+msgstr ""
+
+#: ../../editing.md:179 c5a921af2ecc436eb220853ae603677a
+msgid "Rejecting a paper"
+msgstr ""
+
+#: ../../editing.md:181 8efdd60bb1cb44bdb5051d9d1a7566aa
+msgid ""
+"If you believe a submission should be rejected, for example, because it "
+"is out of scope for JOSS, then you should:"
+msgstr ""
+
+#: ../../editing.md:183 cf41a6d5b66d4a5987759324687f6bcc
+msgid ""
+"Ask EditorialBot to flag the submission as potentially out of scope with "
+"the command `@editorialbot query scope`. This command adds the `query-"
+"scope` label to the issue."
+msgstr ""
+
+#: ../../editing.md:184 fae66735afaa4048a0dbf3c52e71361a
+msgid ""
+"Mention to the author your reasons for flagging the submission as "
+"possibly out of scope, and _optionally_ give them an opportunity to "
+"defend their submission."
+msgstr ""
+
+#: ../../editing.md:185 f8412a3f08914dbd85c5da0f52ebe973
+msgid ""
+"During the scope review process, the editorial team may ask the authors "
+"to provide additional information about their submission to assist the "
+"editorial board with their decision."
+msgstr ""
+
+#: ../../editing.md:186 968111ab343f41ce81c9d602c9b5278f
+msgid ""
+"The TEiC will make a final determination of whether a submission is in "
+"scope, taking into account the feedback of other editors."
+msgstr ""
+
+#: ../../editing.md:188 6ec183d943404235a37ba3d47089981f
+msgid "**Scope reviews for resubmissions**"
+msgstr ""
+
+#: ../../editing.md:190 68327f04c16a46fbb0d61cb884365a69
+msgid ""
+"In the event that an author re-submits a paper to JOSS that was "
+"previously rejected, the TEiC will use their discretion to determine: 1) "
+"whether a full scope review by the entire editorial team is necessary, 2)"
+" if the previous reasons for rejection remain valid, or 3) if there have "
+"been enough updates to warrant sending the submission out for review."
+msgstr ""
+
+#: ../../editing.md:192 d326cebcc2c645e78ff94af22dd9cedd
+msgid "JOSS Collaborations"
+msgstr ""
+
+#: ../../editing.md:194 f99912839e0344578a143c27763823ae
+msgid "AAS publishing"
+msgstr ""
+
+#: ../../editing.md:196 e3b861edaece45999cf91c771506c552
+msgid ""
+"JOSS is collaborating with [AAS publishing](https://journals.aas.org/) to"
+" offer software review for some of the papers submitted to their "
+"journals. A detailed overview of the motivations/background is available "
+"in the [announcement blog post](https://blog.joss.theoj.org/2018/12/a"
+"-new-collaboration-with-aas-publishing), here we document the additional "
+"editorial steps that are necessary for JOSS to follow:"
+msgstr ""
+
+#: ../../editing.md:198 430ed54db1b84ce3b8fc3454c026de24
+msgid "**Before/during review**"
+msgstr ""
+
+#: ../../editing.md:200 2824e9d988df40d39bd555ab5021a72b
+#, python-format
+msgid ""
+"If the paper is a joint publication, make sure you apply the "
+"[`AAS`](https://github.com/openjournals/joss-"
+"reviews/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3AAAS+) label to both "
+"the `pre-review` and the `review` issues."
+msgstr ""
+
+#: ../../editing.md:201 fbab9c2ddbf24bc3be059c5caff98168
+msgid ""
+"Before moving the JOSS paper from `pre-review` to `review`, ensure that "
+"you (the JOSS editor) make the reviewers aware that JOSS will be "
+"receiving a small financial donation from AAS publishing for this review "
+"(e.g. [like this](https://github.com/openjournals/joss-"
+"reviews/issues/1852#issuecomment-553203738))."
+msgstr ""
+
+#: ../../editing.md:203 bd6a4d0ce06b4ef992111f0b0fab8ec9
+msgid "**After the paper has been accepted by JOSS**"
+msgstr ""
+
+#: ../../editing.md:205 15fc7b6817dd4a34a3738b6ddf38803f
+msgid ""
+"Once the JOSS review is complete, ask the author for the status of their "
+"AAS publication, specifically if they have the AAS paper DOI yet."
+msgstr ""
+
+#: ../../editing.md:206 1f05887484b3458c919fb4e94c3d54a7
+msgid ""
+"Once this is available, ask the author to add this information to their "
+"`paper.md` YAML header as documented in the [submission "
+"guidelines](paper.md#what-should-my-paper-contain)."
+msgstr ""
+
+#: ../../editing.md:215 451308dd5cd24ada9f6722ba8c1a0af9
+msgid ""
+"Pause the review (by applying the `paused` label) to await notification "
+"that the AAS paper is published."
+msgstr ""
+
+#: ../../editing.md:217 4ff28cbd250c4fceb96de378b856ac9b
+msgid "**Once the AAS paper is published**"
+msgstr ""
+
+#: ../../editing.md:219 bf3b62f96e854102825cd412df62de48
+msgid ""
+"Ask the EiC on rotation to publish the paper as normal (by tagging "
+"`@openjournals/joss-eics`)."
+msgstr ""
+
+#: ../../editing.md:221 a93e797d3cf34ede894cb4b3b3c8b0b4
+msgid "rOpenSci-reviewed or pyOpenSci-reviewed and accepted submissions"
+msgstr ""
+
+#: ../../editing.md:223 d405d6dec9e14b038b65cfc2b48521be
+msgid ""
+"If a paper has already been reviewed and accepted by rOpenSci or "
+"pyOpenSci, the streamlined JOSS review process is:"
+msgstr ""
+
+#: ../../editing.md:225 428f938147824290aaaed1b3fc54a753
+msgid "Assign yourself as editor and reviewer"
+msgstr ""
+
+#: ../../editing.md:226 564417ceb9e649d2bd8c9a9bfb405a6b
+msgid ""
+"Add a comment in the pre-review issue pointing to the rOpenSci or "
+"pyOpenSci review"
+msgstr ""
+
+#: ../../editing.md:227 8b7f7c94e76441c6ae25d3737691114d
+msgid "Add the rOpenSci/pyOpenSci label to the pre-review issue"
+msgstr ""
+
+#: ../../editing.md:228 cfd6fcb87a664d24993490dbb413a97f
+msgid "Start the review issue"
+msgstr ""
+
+#: ../../editing.md:229 cf1a6126e15a4f00acbde92f4ecda2f6
+msgid ""
+"Add a comment in the review issue pointing to the rOpenSci or pyOpenSci "
+"review"
+msgstr ""
+
+#: ../../editing.md:230 e6326b05c5ce4cce8be342399b12699a
+msgid "Compile the paper and check it looks OK"
+msgstr ""
+
+#: ../../editing.md:231 4054dfb927f34f0ebb7728cb76dcf2c2
+msgid "Go to to the source code repo and grab the Zenodo DOI"
+msgstr ""
+
+#: ../../editing.md:232 4be4829b0bc740f293b518b74c728de1
+msgid "Accept and publish the paper"
+msgstr ""
+

--- a/docs/locale/nb/LC_MESSAGES/editor_onboarding.po
+++ b/docs/locale/nb/LC_MESSAGES/editor_onboarding.po
@@ -1,0 +1,501 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: nb\n"
+"Language-Team: nb <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../editor_onboarding.md:1 ddb34aa291fa467782c10edc4e35d8ec
+msgid "Editor Onboarding"
+msgstr ""
+
+#: ../../editor_onboarding.md:3 4470f6e71d994a41bc3b0be762b41e49
+msgid "Onboarding a new JOSS editor"
+msgstr ""
+
+#: ../../editor_onboarding.md:5 7a2a0c328d17494296e4f01b7422db62
+msgid ""
+"All new editors at JOSS have an onboarding call with an Editor-in-Chief. "
+"You can use the structure below to make sure you highlight the most "
+"important aspects of being an editor."
+msgstr ""
+
+#: ../../editor_onboarding.md:7 f980df4541fe4b068ece12e9398edac7
+msgid "**Thing to check before the call**"
+msgstr ""
+
+#: ../../editor_onboarding.md:9 af4253ba4430455bb650d2f4cb581162
+msgid ""
+"Have they reviewed or published in JOSS before? If not, you'll need to "
+"spend significantly more time explaining how the review process works."
+msgstr ""
+
+#: ../../editor_onboarding.md:10 367afd43cfd54e6c86cde5bae5877cdd
+msgid ""
+"Check on their research background (e.g., what tracks they might edit "
+"most actively in)."
+msgstr ""
+
+#: ../../editor_onboarding.md:11 dcfc47c7f9804d4f8b882ab744958e48
+msgid ""
+"Make sure to send them the [editorial "
+"guide](https://joss.readthedocs.io/en/latest/editing.html) to read before"
+" the call."
+msgstr ""
+
+#: ../../editor_onboarding.md:13 e284abf557264473b259da6e015f2cea
+msgid "The onboarding call"
+msgstr ""
+
+#: ../../editor_onboarding.md:15 26bc3820950d4500bc9e20f4c4414eb1
+msgid "**Preamble/introductions**"
+msgstr ""
+
+#: ../../editor_onboarding.md:17 0288d672dd644d869574fe8651ef8880
+msgid "Welcome! Thank them for their application to join the team."
+msgstr ""
+
+#: ../../editor_onboarding.md:18 fc4b238db8ee4f83be7ba4ca0bc59fb9
+msgid ""
+"Point out that this isn't an interview. Rather, this is an informational "
+"call designed to give the candidate the information they need to make an "
+"informed decision about editing at JOSS."
+msgstr ""
+
+#: ../../editor_onboarding.md:19 da6f67fa611c48c6bad424c28d3951a9
+msgid ""
+"90-day trial period/try out. Editor or JOSS editorial board can decide to"
+" part ways after that period."
+msgstr ""
+
+#: ../../editor_onboarding.md:20 0e10b197ceca4bfc86456fb0c1192d23
+msgid ""
+"No strict term limits. Some editors have been with us for 7+ years, "
+"others do 1-2 years. Most important thing is to be proactive with your "
+"editing responsibilities and communicating any issues with the EiCs."
+msgstr ""
+
+#: ../../editor_onboarding.md:21 d154b8c176bf47159aaddb9e58e4452c
+msgid "Confirm with them their level of familiarity with JOSS/our review process."
+msgstr ""
+
+#: ../../editor_onboarding.md:22 660c4e8cc8d042e08cedb31cff5d0dcb
+msgid ""
+"Point out that they *do not* need to make a decision on the call today. "
+"They are welcome to have a think about joining and get back to us."
+msgstr ""
+
+#: ../../editor_onboarding.md:24 ff266d9d359d4404b1f7d46e7bfa3f6e
+msgid "**Share your screen**"
+msgstr ""
+
+#: ../../editor_onboarding.md:26 90c995e80f744e3f85b69f1af85caae6
+msgid "Visit JOSS (https://joss.theoj.org)"
+msgstr ""
+
+#: ../../editor_onboarding.md:27 df997b30aea14f7bae260fb0f87e5a2b
+msgid ""
+"Pick a recently-published paper (you might want to identify this before "
+"the call one that shows off the review process well)."
+msgstr ""
+
+#: ../../editor_onboarding.md:28 e0bf12eb96994b469b6478049c9d70b0
+msgid "Show the paper on the JOSS site, and then go to the linked review issue."
+msgstr ""
+
+#: ../../editor_onboarding.md:29 c04aa708d2ba4de787763ba25b8460a8
+msgid ""
+"Explain that there are *two* issues per submission – the pre-review issue"
+" and the main review issue."
+msgstr ""
+
+#: ../../editor_onboarding.md:31 ebedb7d569f143b7901d1e5920d334ab
+msgid "**The pre-review issue**"
+msgstr ""
+
+#: ../../editor_onboarding.md:33 6c3464eb92a14c1ea6d4b264b68baaa7
+msgid ""
+"The 'meeting room for the paper'. Where author meets editor, and "
+"reviewers are identified."
+msgstr ""
+
+#: ../../editor_onboarding.md:34 43f5cee5fd4040fbb79f098fe9809d54
+msgid ""
+"Note that the EiC may have initiated a scope review. The editor should "
+"not start editing until this has completed. Also, editors are able to "
+"query the scope (as are reviewers) if they think the EiC should have (but"
+" didn't)."
+msgstr ""
+
+#: ../../editor_onboarding.md:35 411abf04587a4cbf8f75697715c489a9
+msgid "Walk them through what is happening in the pre-review issue..."
+msgstr ""
+
+#: ../../editor_onboarding.md:36 b737b32ada224c4bb1f3257819a037cf
+msgid ""
+"Editor is invited (likely with GitHub mention but also via email invite "
+"(`@editorialbot invite @editor as editor`))"
+msgstr ""
+
+#: ../../editor_onboarding.md:37 e7cb4bb86a9344e6b3c83a57b8295014
+msgid "Once editor accepts they start looking for reviewers."
+msgstr ""
+
+#: ../../editor_onboarding.md:39 2241d7556d9344b0bf3d888fbd589f75
+msgid "**Finding reviewers**"
+msgstr ""
+
+#: ../../editor_onboarding.md:41 bc39c6a124ce4ab9bb5966d25e08574f
+msgid "Explain that this is one of the more time-intensive aspects of editing."
+msgstr ""
+
+#: ../../editor_onboarding.md:42 4d11d78ab4224553b74d70cf8c81b1c9
+msgid ""
+"Explain where you can look for editors (your own professional network, "
+"asking the authors for recommendations, the [reviewers "
+"application](https://reviewers.joss.theoj.org/), similar papers "
+"identified by Editorialbot, )"
+msgstr ""
+
+#: ../../editor_onboarding.md:43 257f9d1b6ede475da45d8dfd2b8cd0e4
+msgid ""
+"Point out that we have a minimum of two reviewers, but if more than that "
+"accept (e.g., 3/4 then take them all – this gives you redundancy if one "
+"drops out)."
+msgstr ""
+
+#: ../../editor_onboarding.md:44 b9b7f5b236234980b8338708625b6c99
+msgid ""
+"Don't invite only one reviewer at a time! If you do this, it may take "
+"many weeks to find two reviewers who accept. Try 3/4/5 invites "
+"simultaneously."
+msgstr ""
+
+#: ../../editor_onboarding.md:45 958063b5e00d409986233f3c63a01288
+msgid ""
+"The [sample messages](sample_messages) section of the documentation has "
+"some example language you can use."
+msgstr ""
+
+#: ../../editor_onboarding.md:47 32dd245a660d4f8f9f9a6f0dd237a14b
+msgid "**The review**"
+msgstr ""
+
+#: ../../editor_onboarding.md:49 6e2a3f7b1656412dbb572f635fcf461c
+msgid "Once at least two reviewers are assigned, time to get going!"
+msgstr ""
+
+#: ../../editor_onboarding.md:50 5fba2497e6b1466a85ae9172fce563e0
+msgid "Encourage reviewers to complete their review in 4-6 weeks."
+msgstr ""
+
+#: ../../editor_onboarding.md:51 81a249a1d7ea458d86906e025a10c1ca
+msgid ""
+"Make sure to check in on the review – if reviewers haven't started after "
+"~1-2 weeks, time to remind them."
+msgstr ""
+
+#: ../../editor_onboarding.md:52 08f9e20221544c80be398b68741ca9f2
+msgid ""
+"Your role as editor is not to do the review yourself, rather, your job is"
+" to ensure that both reviewers give a good review and to facilitate "
+"discussion and consensus on what the author needs to do."
+msgstr ""
+
+#: ../../editor_onboarding.md:53 4a7a2460acb24ceeb3ffabd0f91b46fe
+msgid ""
+"Walk the editor through the various review artifacts: The checklist, "
+"comments/questions/discussion between reviewers and author, issues opened"
+" on the upstream repository (and cross-linked into the review thread)."
+msgstr ""
+
+#: ../../editor_onboarding.md:54 37291112d1d24315a1986185a1889f9b
+msgid ""
+"Point editors to the ['top tips'](editor_tips) section of our docs. Much "
+"of what makes an editor successful is regular check-ins on the review, "
+"and nudging people if nothing is happening."
+msgstr ""
+
+#: ../../editor_onboarding.md:55 81b8bcab7a7c4866a1ce5d80f36f21a0
+msgid "Do *not* let a review go multiple weeks without checking in."
+msgstr ""
+
+#: ../../editor_onboarding.md:57 55f437eb8c484edc8358b4b68812fe8b
+msgid "**Wrapping up the review**"
+msgstr ""
+
+#: ../../editor_onboarding.md:59 e24ad8981bcd4ea7a3ed82eabeb35cdf
+msgid ""
+"Once the review is wrapping up, show the candidate the checks that an "
+"editor should be doing (reading the paper, suggested edits, asking for an"
+" archive etc.)"
+msgstr ""
+
+#: ../../editor_onboarding.md:60 a7dc51a9e76d46dbbaf8382844910310
+msgid ""
+"Show the `recommend-accept` step which is the formal hand-off between "
+"editor and editor-in-chief."
+msgstr ""
+
+#: ../../editor_onboarding.md:61 cc1e0eb549fc462088805e50b4310680
+msgid ""
+"The [sample messages](sample_messages) section of the documentation has a"
+" checklist for the last steps of the review (for both authors and "
+"editors)."
+msgstr ""
+
+#: ../../editor_onboarding.md:64 de4909e22b204f90b674d316ada8efab
+msgid "**Show them the dashboard on the JOSS site**"
+msgstr ""
+
+#: ../../editor_onboarding.md:66 1646494e0e7f438fb5ae2ae411724336
+msgid ""
+"Point out that this means you *do not* need to stay on top of all of your"
+" notifications (the dashboard has the latest information)."
+msgstr ""
+
+#: ../../editor_onboarding.md:67 fd5cb0e8de564c4cb29ebd8f1c8af3df
+msgid ""
+"Highlight here that we ask editors to handle 8-12 submissions per year on"
+" average."
+msgstr ""
+
+#: ../../editor_onboarding.md:68 3583962d5d484e40a914d1e7686d4f6e
+msgid ""
+"...and that means 3-4 submissions on their desk at any one time (once "
+"they have completed their initial probationary period)."
+msgstr ""
+
+#: ../../editor_onboarding.md:69 4cf41efd823e4bbfa2379b5ea90ce9d9
+msgid ""
+"Show them the backlog for a track, and how they are welcome to pick "
+"papers from it (ideally oldest first)."
+msgstr ""
+
+#: ../../editor_onboarding.md:70 cc536af2918645c290f873f07dbfd5b7
+msgid ""
+"Show them their profile page, and how they can list their tracks there, "
+"and also what their availability is."
+msgstr ""
+
+#: ../../editor_onboarding.md:72 532406aae528432c8e6b8da2538281cf
+msgid "**Other important things to highlight**"
+msgstr ""
+
+#: ../../editor_onboarding.md:74 0d82dd40846f4a688a25ef91c634db8d
+msgid ""
+"Don't invite other editors as reviewers. We're all busy editing our own "
+"papers..."
+msgstr ""
+
+#: ../../editor_onboarding.md:75 2b19e938b20648679ccb8b70188f7c45
+msgid ""
+"Please be willing to edit outside of your specialisms. This helps JOSS "
+"run smoothly – often we don't have the 'ideal' editor for a submission "
+"and someone has to take it."
+msgstr ""
+
+#: ../../editor_onboarding.md:76 311d1b82d8e845f790edd906dc77e098
+msgid ""
+"Highlight that editors will have a buddy to work with for the first few "
+"months, and that it's very common for editors to ask questions in Slack "
+"(and people generally respond quickly)."
+msgstr ""
+
+#: ../../editor_onboarding.md:77 f8d7387c02164ea5b55945c48a7a6e25
+msgid ""
+"Scope reviews only work if editors vote! Please respond and vote on the "
+"weekly scope review email if you can. The process is private (authors "
+"don't know what editors are saying). Detailed comments are really helpful"
+" for the EiCs."
+msgstr ""
+
+#: ../../editor_onboarding.md:79 76170cd543ae4bc988d3e904381a1a35
+msgid "**Wrapping up**"
+msgstr ""
+
+#: ../../editor_onboarding.md:81 ec717aaa4f5c413a94e6b5246b09f47c
+msgid ""
+"Make sure you've highlighted everything in the ['top tips'](editor_tips) "
+"section of our docs."
+msgstr ""
+
+#: ../../editor_onboarding.md:82 ed7d3ee869a74d3ab0a208774debdcce
+msgid ""
+"Reinforce that this is a commitment, and thay regular attention to their "
+"submissions is absolutely critical (i.e., check in a couple of times per "
+"week)."
+msgstr ""
+
+#: ../../editor_onboarding.md:83 7f4f97f224a9454a89fcad728d2aec7c
+msgid ""
+"Ask if they would like to move forward or would like time to consider the"
+" opportunity."
+msgstr ""
+
+#: ../../editor_onboarding.md:84 1d4a5693fcf0457297ce32e038486299
+msgid ""
+"If they want to move forward, highlight they will receive a small number "
+"of invites: One to the JOSS editors GitHub team, a Slack invite, a Google"
+" Group invite, and an invite to the JOSS website to fill out their "
+"profile."
+msgstr ""
+
+#: ../../editor_onboarding.md:85 ad062cf91d9140008983e44436bf16bf
+msgid ""
+"If they are joining the team, make sure they mark themselves as "
+"unavailable in the [JOSS reviewers "
+"database](https://reviewers.joss.theoj.org/) (so they don't get asked to "
+"review any longer)."
+msgstr ""
+
+#: ../../editor_onboarding.md:86 959c06266b3340ccb404aa56a4515168
+msgid "Thank them again, and welcome them to the team."
+msgstr ""
+
+#: ../../editor_onboarding.md:88 57e5e7cc9d8c45a98704e42774733642
+msgid "**Communicate outcome to EiC**"
+msgstr ""
+
+#: ../../editor_onboarding.md:90 2695b240ae514e95b277e796e01d9d52
+msgid ""
+"Let the EiC know what the outcome was, and ask them to send out the "
+"invites to our various systems."
+msgstr ""
+
+#: ../../editor_onboarding.md:91 d3d7f5c61f004cd3831fc98199465ea9
+msgid "Work with EiC to identify onboarding buddy."
+msgstr ""
+
+#: ../../editor_onboarding.md:92 47c06ec3ec51411e85136587a501d84f
+msgid ""
+"Decide who is going to identify the first couple of papers for the editor"
+" to work on."
+msgstr ""
+
+#: ../../editor_onboarding.md:94 9103afd226aa4cfb93da986195af690d
+msgid "Editorial buddy"
+msgstr ""
+
+#: ../../editor_onboarding.md:96 52cc074f70f0452eb7aa5a54f58904e8
+msgid ""
+"New editors are assigned an editorial 'buddy' from the existing editorial"
+" team. The buddy is there to help the new editor onboard successfully and"
+" to provide a dedicated resource for any questions they might have but "
+"don't feel comfortable posting to the editor mailing list."
+msgstr ""
+
+#: ../../editor_onboarding.md:98 9b402229e4634e12a3be6084b380eb10
+msgid ""
+"Buddy assignments don't have a fixed term but generally require a "
+"commitment for 1-2 months."
+msgstr ""
+
+#: ../../editor_onboarding.md:100 c2e8c9ac253c48e08bf6919d135ec14d
+msgid "Some things you might need to do as a buddy for a new editor:"
+msgstr ""
+
+#: ../../editor_onboarding.md:102 93318044114a41c1a48256c92ba8839b
+msgid "Respond to questions via email or on GitHub review issues."
+msgstr ""
+
+#: ../../editor_onboarding.md:103 cf3e5a5a01464d21a0b380bb217202cf
+msgid ""
+"Check in with the new editor every couple of weeks if there hasn't been "
+"any other communication."
+msgstr ""
+
+#: ../../editor_onboarding.md:104 985001ec82aa4d67b2cb85a902d46531
+msgid "(Optionally) keep an eye on the new editor's submissions."
+msgstr ""
+
+#: ../../editor_onboarding.md:106 8b15cb26b49a482ab1161d587f7b4e85
+msgid "Managing notifications"
+msgstr ""
+
+#: ../../editor_onboarding.md:108 4b7b9807a9144dbba387399414759885
+msgid ""
+"Being on the JOSS editorial team means that there can be a _lot_ of "
+"notifications from GitHub if you don't take some proactive steps to "
+"minimize noise from the reviews repository."
+msgstr ""
+
+#: ../../editor_onboarding.md:110 4192d1ba00c44387b937cfe75bb00346
+msgid "Things you should do when joining the editorial team"
+msgstr ""
+
+#: ../../editor_onboarding.md:112 ff696e608e4a489abe1e1b1940566fc6
+msgid "**Curate your GitHub notifications experience**"
+msgstr ""
+
+#: ../../editor_onboarding.md:114 5651eddd6cc447a189ce01c753bd5263
+msgid ""
+"GitHub has extensive documentation on [managing "
+"notifications](https://help.github.com/en/articles/managing-your-"
+"notifications) which explains when and why different notifications are "
+"sent from a repository."
+msgstr ""
+
+#: ../../editor_onboarding.md:116 a51c81c5cf2f4c5b9d3678f6cfd63265
+msgid "**Set up email filters**"
+msgstr ""
+
+#: ../../editor_onboarding.md:118 aff07e303eb9460b9287e949edd244ec
+msgid ""
+"Email filters can be very useful for managing incoming email "
+"notifications, here are some recommended resources:"
+msgstr ""
+
+#: ../../editor_onboarding.md:120 b0784e8ba926473ab47e6b805ef7e761
+msgid ""
+"A GitHub blog post describing how to set up [email "
+"filters](https://github.blog/2017-07-18-managing-large-numbers-of-github-"
+"notifications/)."
+msgstr ""
+
+#: ../../editor_onboarding.md:122 3997825197d447a0b948aeaedd3cdc6c
+msgid "If you use Gmail:"
+msgstr ""
+
+#: ../../editor_onboarding.md:124 8e302db6f0ec4c139627255bd76d26e7
+msgid "https://gist.github.com/ldez/bd6e6401ad0855e6c0de6da19a8c50b5"
+msgstr ""
+
+#: ../../editor_onboarding.md:125 5b45a6e44a9d4546bb68495a5d6e8c53
+msgid "https://github.com/jessfraz/gmailfilters"
+msgstr ""
+
+#: ../../editor_onboarding.md:126 6fc0008f6d0f42ab89e74241d5c27c27
+msgid "https://hackernoon.com/how-to-never-miss-a-github-mention-fdd5a0f9ab6d"
+msgstr ""
+
+#: ../../editor_onboarding.md:128 dc6303ca879a468d810e323257f2ce35
+msgid "**Use a dedicated tool**"
+msgstr ""
+
+#: ../../editor_onboarding.md:130 a97e0e369ba64c18813e95ad318a2824
+msgid ""
+"For papers that you are already assigned to edit, the dedicated JOSS "
+"dashboard aggregates notifications associated with each paper. The "
+"dashboard is available at: "
+"`https://joss.theoj.org/dashboard/<yourgithubusername>`"
+msgstr ""
+
+#: ../../editor_onboarding.md:132 3337ea7412484660a8d38fad4340e16c
+msgid "Another tool you might want to try out is [Octobox](https://octobox.io/)."
+msgstr ""
+

--- a/docs/locale/nb/LC_MESSAGES/editor_tips.po
+++ b/docs/locale/nb/LC_MESSAGES/editor_tips.po
@@ -1,0 +1,142 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: nb\n"
+"Language-Team: nb <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../editor_tips.md:1 d749fc4d1210491180004f137656a576
+msgid "Top tips for JOSS editors"
+msgstr ""
+
+#: ../../editor_tips.md:3 fe01b068c66a4640b184ee34313798a8
+msgid "**Aim for reviewer redundancy**"
+msgstr ""
+
+#: ../../editor_tips.md:5 506d698bf9d74715b3e2a51baa97cb82
+msgid ""
+"If you have 3 people agree to review, take them up on their offer(s), "
+"that way if one person drops out, you'll have a backup and won't have to "
+"look for more reviewers. Also, when sending invites, try pinging a number"
+" of people at the same time rather than doing it one-by-one."
+msgstr ""
+
+#: ../../editor_tips.md:7 ba637b6b74fc45a5ad0802cba296d3b6
+msgid "**Email is a good backup**"
+msgstr ""
+
+#: ../../editor_tips.md:9 82b8d154d4ac4140b8ddca53676a282f
+msgid ""
+"Email is often the most reliable way of contacting people. Whether it's "
+"inviting reviewers, following up with reviewers or authors etc., if "
+"you've not heard back from someone on GitHub, try emailing them (their "
+"email is often available on their GitHub profile page)."
+msgstr ""
+
+#: ../../editor_tips.md:11 f6cb9d52f5ae488a8abb2ff29c8d32df
+msgid "**Default to over-communicating**"
+msgstr ""
+
+#: ../../editor_tips.md:13 6695c4e228e346d4a75e591262ae45cf
+msgid ""
+"When you take an action (even if it isn't on GitHub), share on the review"
+" thready what you're up to. For example, if you're looking for reviewers "
+"and are sending emails – leave a note on the review thread saying as "
+"much."
+msgstr ""
+
+#: ../../editor_tips.md:15 62e357fb51d3494499791cc65e29e31c
+msgid "**Use the JOSS Slack**"
+msgstr ""
+
+#: ../../editor_tips.md:17 2772614bb80c4087a5440566297059c8
+msgid ""
+"There's lots of historical knowledge in our Slack, and it's a great way "
+"to get questions answered."
+msgstr ""
+
+#: ../../editor_tips.md:19 efa88c0a4ded4ea8abe31c1351399c81
+msgid "**Ask reviewers to complete their review in 4-6 weeks**"
+msgstr ""
+
+#: ../../editor_tips.md:21 d77e168b384e4e0fbaf8d3f737851eea
+msgid ""
+"We aim for a total submission ... publication time of ~3 months. This "
+"means we ideally want reviewers to complete their review in 4-6 weeks "
+"(max)."
+msgstr ""
+
+#: ../../editor_tips.md:23 91ac07068efa4dcc9fd140f4dd07881a
+msgid "**Use saved replies on GitHub**"
+msgstr ""
+
+#: ../../editor_tips.md:25 66f9b3c7639c4d4c9be2e7e2a8b75f9e
+msgid ""
+"[Saved replies](https://docs.github.com/en/get-started/writing-on-github"
+"/working-with-saved-replies/using-saved-replies) on GitHub can be a huge "
+"productivity boost. Try making some using the example messages listed "
+"above."
+msgstr ""
+
+#: ../../editor_tips.md:27 08a7192f079847eaaad81d0d5681b1d4
+msgid "**Ping reviewers if they’ve not started after 2 weeks**"
+msgstr ""
+
+#: ../../editor_tips.md:29 78d6ae87e79744fe8295e3a4cdf254e1
+msgid ""
+"If a reviewer hasn't started within 1-2 weeks, you should probably give "
+"them a nudge. People often agree to review, and then forget about the "
+"review."
+msgstr ""
+
+#: ../../editor_tips.md:31 859a2e9877c4438ca943f94468d4a53b
+msgid "**Learn how to nudge gently, and often**"
+msgstr ""
+
+#: ../../editor_tips.md:33 2c1a7dbeb8c64edba0a8265789489cd4
+msgid ""
+"One of your jobs as the editor is to ensure the review keeps moving at a "
+"reasonable pace. If nothing has happened for a week or so, consider "
+"nudging the author or reviewers (depending upon who you're waiting for). "
+"A friendly _\"👋 reviewer, how are you getting along here\"_ can often be "
+"sufficient to get things moving again."
+msgstr ""
+
+#: ../../editor_tips.md:35 b1065cb4816f4cc08d9b63e4224432f0
+msgid "**Check in twice a week**"
+msgstr ""
+
+#: ../../editor_tips.md:37 effa9ac74ffc4db9bd03690bc60a1928
+msgid ""
+"Try to check in on your JOSS submissions twice per week, even if only for"
+" 5 minutes. Use your dashboard to stay on top of the current status of "
+"your submissions (i.e., who was the last person to comment on the "
+"thread)."
+msgstr ""
+
+#: ../../editor_tips.md:39 543a54fa561342b994523649f42b3ff4
+msgid "**Leave feedback on reviewers**"
+msgstr ""
+
+#: ../../editor_tips.md:41 6902b4e9f521488a900866b1592721cd
+msgid ""
+"Leave feedback on the [reviewers "
+"application](https://reviewers.joss.theoj.org/) at the end of the review."
+" This helps future editors when they're seeking out good reviewer "
+"candidates."
+msgstr ""
+

--- a/docs/locale/nb/LC_MESSAGES/editorial_bot.po
+++ b/docs/locale/nb/LC_MESSAGES/editorial_bot.po
@@ -1,0 +1,394 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: nb\n"
+"Language-Team: nb <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../editorial_bot.md:1 39acd70d3890461db4a421caea70b586
+msgid "Interacting with EditorialBot"
+msgstr ""
+
+#: ../../editorial_bot.md:3 6e5c118315d347549b4b783c80abe26f
+msgid ""
+"The Open Journals' editorial bot or `@editorialbot` on GitHub, is our "
+"editorial bot that interacts with authors, reviewers, and editors on JOSS"
+" reviews."
+msgstr ""
+
+#: ../../editorial_bot.md:5 034ec24930fa442282487029999399c2
+msgid ""
+"`@editorialbot` can do a bunch of different things. If you want to ask "
+"`@editorialbot` what it can do, simply type the following in a JOSS "
+"`review` or `pre-review` issue:"
+msgstr ""
+
+#: ../../editorial_bot.md:13 37c4358c69094920959adba7179a6576
+msgid ""
+"EditorialBot commands must be placed in the first line of a comment. "
+"Other text can be added after the first line with the command. Multiple "
+"commands are not allowed in the same comment, only the first one will be "
+"interpreted."
+msgstr ""
+
+#: ../../editorial_bot.md:16 79d66b5ff2a44ec58b6fe2582590f359
+msgid "Author and reviewers commands"
+msgstr ""
+
+#: ../../editorial_bot.md:18 722a20053ba74dd5bf80c265dcd7370e
+msgid ""
+"A subset of the EditorialBot commands are available to authors and "
+"reviewers:"
+msgstr ""
+
+#: ../../editorial_bot.md:20 3d4709ba4cc040d39be82497e5264a8f
+msgid "Compiling papers"
+msgstr ""
+
+#: ../../editorial_bot.md:22 329087aa872f4a2d86347f06dcd6f9df
+msgid ""
+"When a `pre-review` or `review` issue is opened, `@editorialbot` will try"
+" to compile the JOSS paper by looking for a `paper.md` file in the "
+"repository specified when the paper was submitted."
+msgstr ""
+
+#: ../../editorial_bot.md:24 5fe3cebe75d04022a072ef339b2909fe
+msgid ""
+"If it can't find the `paper.md` file it will say as much in the review "
+"issue. If it can't compile the paper (i.e. there's some kind of Pandoc "
+"error), it will try and report that error back in the thread too."
+msgstr ""
+
+#: ../../editorial_bot.md:27 beff48a007e444379df50e58937f3d27
+msgid ""
+"To compile the papers ``@editorialbot`` is running this `Docker image "
+"<https://github.com/openjournals/inara>`_."
+msgstr ""
+
+#: ../../editorial_bot.md:30 681cd9ecb4084a8aaa3d5a8f79c6f9e6
+msgid ""
+"Anyone can ask `@editorialbot` to compile the paper again (e.g. after a "
+"change has been made). To do this simply comment on the review thread as "
+"follows:"
+msgstr ""
+
+#: ../../editorial_bot.md:36 3f33e1ce9c8c4ac184f223dfba1a26d9
+msgid "Compiling papers from a specific branch"
+msgstr ""
+
+#: ../../editorial_bot.md:38 de44ff34a34848afb471e92e2b39db01
+msgid ""
+"By default, EditorialBot will look for papers in the branch set in the "
+"body of the issue (or in the default git branch if none is present). If "
+"you want to compile a paper from a specific branch (for instance: `my-"
+"custom-branch-name`), change that value with:"
+msgstr ""
+
+#: ../../editorial_bot.md:44 91b288f445cd45b6801f6ba4131e2737
+msgid "And then compile the paper normally:"
+msgstr ""
+
+#: ../../editorial_bot.md:50 5f048407817d418587b4069d5ae52baa
+msgid "Compiling preprint files"
+msgstr ""
+
+#: ../../editorial_bot.md:52 9218493b1e6c4a30b0f342357ed2e094
+msgid ""
+"If you need a generic paper file suitable for preprint servers (arXiv-"
+"like) you can use the following command that will generate a LaTeX file:"
+msgstr ""
+
+#: ../../editorial_bot.md:58 63abe318e90744bcabb914be85dbc8c8
+msgid "Finding reviewers"
+msgstr ""
+
+#: ../../editorial_bot.md:60 cb4985c235854d50a0b4632dfbafbee7
+msgid ""
+"Sometimes submitting authors suggest people the think might be "
+"appropriate to review their submission. If you want the link to the "
+"current list of JOSS reviewers, type the following in the review thread:"
+msgstr ""
+
+#: ../../editorial_bot.md:66 a53475cbbe5c4e829a5128eec29788eb
+msgid "Reviewers checklist command"
+msgstr ""
+
+#: ../../editorial_bot.md:68 59d7682aad184964b92f6e9e5b4e9e1f
+msgid ""
+"Once a user is assigned as reviewer and the review has started, the "
+"reviewer must type the following to get a review checklist:"
+msgstr ""
+
+#: ../../editorial_bot.md:74 b7c1bec8c7074b74b49214547c90b2ea
+msgid "Editorial commands"
+msgstr ""
+
+#: ../../editorial_bot.md:76 e8ee53cf551a428290fed02a51ca30dd
+msgid ""
+"Most of `@editorialbot`'s functionality can only be used by the journal "
+"editors."
+msgstr ""
+
+#: ../../editorial_bot.md:78 3649ad4afea04045888f03b418a67e49
+msgid "Assigning an editor"
+msgstr ""
+
+#: ../../editorial_bot.md:80 ccef8cbe57744489b3132de9e9bf0c4b
+msgid ""
+"Editors can either assign themselves or other editors as the editor of a "
+"submission as follows:"
+msgstr ""
+
+#: ../../editorial_bot.md:86 9f41cbfc147744f3a258c12f0b484fd5
+msgid "Inviting an editor"
+msgstr ""
+
+#: ../../editorial_bot.md:88 8459a863cecc41fdb46a1a6784a0b112
+msgid ""
+"EditorialBot can be used by EiCs to send email invites to registered "
+"editors as follows:"
+msgstr ""
+
+#: ../../editorial_bot.md:94 8efddf6295c04e1ba82440965ef33679
+msgid ""
+"This will send an automated email to the editor with a link to the GitHub"
+" `pre-review` issue."
+msgstr ""
+
+#: ../../editorial_bot.md:96 754bad1fbee2420482fbb9ab72b76cd1
+msgid "Adding and removing reviewers"
+msgstr ""
+
+#: ../../editorial_bot.md:98 926e3bce14ea48fc9b7259d6f1f455ac
+msgid "Reviewers should be assigned by using the following commands:"
+msgstr ""
+
+#: ../../editorial_bot.md:110 2689fcd6d2c64984a4d15988b0800a0d
+msgid "Starting the review"
+msgstr ""
+
+#: ../../editorial_bot.md:112 623edf03a5c644c2ad3585a866f58188
+msgid ""
+"Once the reviewer(s) and editor have been assigned in the `pre-review` "
+"issue, the editor starts the review with:"
+msgstr ""
+
+#: ../../editorial_bot.md:119 2962cbfb38a1482ca1cbb0d9ff40eb35
+msgid ""
+"If a reviewer recants their commitment or is unresponsive, editors can "
+"remove them with the command `@editorialbot remove @username from "
+"reviewers`. You can then delete that reviewer's checklist. You can also "
+"add new reviewers in the `REVIEW` issue with the command `@editorialbot "
+"add @username to reviewers`."
+msgstr ""
+
+#: ../../editorial_bot.md:122 7fd6f88a15de4d62a481cbf13d924336
+msgid "Reminding reviewers and authors"
+msgstr ""
+
+#: ../../editorial_bot.md:124 91f3ec6e1e9c4e61a87f4327e47c1114
+msgid ""
+"EditorialBot can remind authors and reviewers after a specified amount of"
+" time to return to the review issue. Reminders can only be set by "
+"editors, and only for REVIEW issues. For example:"
+msgstr ""
+
+#: ../../editorial_bot.md:142 53deec31cc8540399b9d6e5b36673991
+msgid ""
+"Most units of times are understood by EditorialBot e.g. "
+"`hour/hours/day/days/week/weeks`."
+msgstr ""
+
+#: ../../editorial_bot.md:145 160a106675bf4687a54aee81d86341b1
+msgid "Setting the software archive"
+msgstr ""
+
+#: ../../editorial_bot.md:147 8cde5b01e4d94b4dbfda848ec1a6f4e0
+msgid ""
+"When a submission is accepted, we ask that the authors to create an "
+"archive (on [Zenodo](https://zenodo.org/), "
+"[fig**share**](https://figshare.com/), or other) and post the archive DOI"
+" in the `REVIEW` issue. The editor should ask `@editorialbot` to add the "
+"archive to the issue as follows:"
+msgstr ""
+
+#: ../../editorial_bot.md:153 ddf0409112b744dca692a08eea0ce55d
+msgid "Changing the software version"
+msgstr ""
+
+#: ../../editorial_bot.md:155 d7163a45946e48398dfe080ea40bd5f0
+msgid ""
+"Sometimes the version of the software changes as a consequence of the "
+"review process. To update the version of the software do the following:"
+msgstr ""
+
+#: ../../editorial_bot.md:161 b8b4d78c6f264b8eb9f892c729c742ca
+msgid "Changing the git branch"
+msgstr ""
+
+#: ../../editorial_bot.md:163 a358f3205adb476caac745d1f609922c
+msgid ""
+"Sometimes the paper-md file is located in a topic branch. In order to "
+"have the PDF compiled from that branch it should be added to the issue. "
+"To update the branch value do the following (in the example, the name of "
+"the topic branch is _topic-branch-name_):"
+msgstr ""
+
+#: ../../editorial_bot.md:169 99cfd86ac4334d3a93a6fe6d5f468a0b
+msgid "Changing the repository"
+msgstr ""
+
+#: ../../editorial_bot.md:171 cc86ca0a157b4fba8180dec0b11e90f2
+msgid ""
+"Sometimes authors will move their software repository during the review. "
+"To update the value of the repository URL do the following:"
+msgstr ""
+
+#: ../../editorial_bot.md:178 55a044b6c92e4a6c9b2084a46ceef02c
+msgid "Check references"
+msgstr ""
+
+#: ../../editorial_bot.md:180 5b5719f0438e40a68b081b911b715d3a
+msgid ""
+"Editors can ask EditorialBot to check if the DOIs in the bib file are "
+"valid with the command:"
+msgstr ""
+
+#: ../../editorial_bot.md:187 3d85bd0c5ba54e51908722e5b1920804
+msgid ""
+"EditorialBot can verify that DOIs resolve, but cannot verify that the DOI"
+" associated with a paper is actually correct. In addition, DOI "
+"suggestions from EditorialBot are just that - i.e. they may not be "
+"correct."
+msgstr ""
+
+#: ../../editorial_bot.md:190 bcbc437df84e45e5ad79d999f957cc8e
+msgid "Repository checks"
+msgstr ""
+
+#: ../../editorial_bot.md:192 8727ffd998de498fb2c6e7de6051573a
+msgid ""
+"A series of checks can be run on the submitted repository with the "
+"command:"
+msgstr ""
+
+#: ../../editorial_bot.md:198 d5c1e29abff2449cac32014dd6116ec4
+msgid ""
+"EditorialBot will report back with an analysis of the source code and "
+"list authorship, contributions and file types information. EditorialBot "
+"will also label the issue with the top languages used in the repository, "
+"will count the number of words in the paper file, will look for an Open "
+"Source License and for a *Statement of need* section in the paper."
+msgstr ""
+
+#: ../../editorial_bot.md:200 0c6fbe9c4498459b83ec0b6951c8d470
+msgid "Post-review checklist"
+msgstr ""
+
+#: ../../editorial_bot.md:202 da7d497e843b46e59a81e65d3808a672
+msgid ""
+"Editors can get a checklist to remind all steps to do after the reviewers"
+" have finished their reviews and recommended the paper for acceptance:"
+msgstr ""
+
+#: ../../editorial_bot.md:208 0394e00296be44d5b93688847b8d13c5
+msgid "Flag a paper with query-scope"
+msgstr ""
+
+#: ../../editorial_bot.md:210 2e33d12745074fac95310cb1f8cd3b63
+msgid "Editors can flag a paper with query-scope with the command:"
+msgstr ""
+
+#: ../../editorial_bot.md:216 393ebbe4407b4ca0a0bdc945d22709d2
+msgid "Recommending a paper for acceptance"
+msgstr ""
+
+#: ../../editorial_bot.md:218 9bfe35851e6e450b8521b25cab769abe
+msgid ""
+"JOSS topic editors can recommend a paper for acceptance and ask for the "
+"final proofs to be created by EditorialBot with the following command:"
+msgstr ""
+
+#: ../../editorial_bot.md:224 18349f55da174b52b064ec5dcb3a04ab
+msgid ""
+"On issuing this command, EditorialBot will also check the references of "
+"the paper for any missing DOIs."
+msgstr ""
+
+#: ../../editorial_bot.md:227 f220421f146240b58642fb15e97d1782
+msgid "EiC-only commands"
+msgstr ""
+
+#: ../../editorial_bot.md:229 b274ce6a1fbe4e5c8a80fad4eaa00c12
+msgid "Only the JOSS editors-in-chief can accept, reject or withdraw papers."
+msgstr ""
+
+#: ../../editorial_bot.md:231 4d58a998d70e48e9b9dbc0b77f5fe48c
+msgid "Accepting a paper"
+msgstr ""
+
+#: ../../editorial_bot.md:233 a2e501ceaa9a486b903c55e39a9f27bd
+msgid ""
+"If everything looks good with the draft proofs from the `@editorialbot "
+"recommend acceptance` command, JOSS editors-in-chief can take the "
+"additional step of actually accepting the JOSS paper with the following "
+"command:"
+msgstr ""
+
+#: ../../editorial_bot.md:239 5ea840fce95540cea3e91e45ed2e42f8
+msgid ""
+"EditorialBot will accept the paper, assign it a DOI, deposit it and "
+"publish the paper."
+msgstr ""
+
+#: ../../editorial_bot.md:241 46d0d23563df44bdb17a9912edfc0c50
+msgid "Updating an already accepted paper"
+msgstr ""
+
+#: ../../editorial_bot.md:243 4e5a9ca95ae445dbbd0332c73ba5935b
+msgid ""
+"If the draft has been updated after a paper has been published, JOSS "
+"editors-in-chief can update the published info and PDF with the following"
+" command:"
+msgstr ""
+
+#: ../../editorial_bot.md:249 04866575ba564de58b51ae707d511c0a
+msgid "EditorialBot will update the published paper and re-deposit it."
+msgstr ""
+
+#: ../../editorial_bot.md:252 3036fdc2749f423591013b7a4a6725b6
+msgid "Rejecting a paper"
+msgstr ""
+
+#: ../../editorial_bot.md:254 1cb520f32bbe433eb78a87cedf1748cf
+msgid "JOSS editors-in-chief can reject a submission with the following command:"
+msgstr ""
+
+#: ../../editorial_bot.md:260 032b9e37e6494fe4aa2b29628f808f9b
+msgid "Withdrawing a paper"
+msgstr ""
+
+#: ../../editorial_bot.md:262 fc0a1690d4ec445596aaf5b5f2ac7723
+msgid ""
+"JOSS editors-in-chief can withdraw a submission with the following "
+"command:"
+msgstr ""
+
+#: ../../editorial_bot.md:268 5123958928554baeb31c1b3427955b7b
+msgid "The complete list of available commands"
+msgstr ""
+

--- a/docs/locale/nb/LC_MESSAGES/example_paper.po
+++ b/docs/locale/nb/LC_MESSAGES/example_paper.po
@@ -1,0 +1,54 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: nb\n"
+"Language-Team: nb <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../example_paper.md:1 8ca6579dcbc0405081c9234e3e25ddf9
+msgid "Example Paper"
+msgstr ""
+
+#: ../../example_paper.md:3 76c8bf09b0184b24810e7149e806adf0
+msgid ""
+"This example `paper.md` is adapted from _Gala: A Python package for "
+"galactic dynamics_ by Adrian M. Price-Whelan "
+"[http://doi.org/10.21105/joss.00388](http://doi.org/10.21105/joss.00388)."
+msgstr ""
+
+#: ../../example_paper.md:5 e6b48075e1114ec68c01114af4a4a757
+msgid ""
+"For a complete description of available options to describe author names "
+"[see here](author-names)."
+msgstr ""
+
+#: ../../example_paper.md:130 5f39e01834894da382cd056596155e04
+msgid "Example `paper.bib` file:"
+msgstr ""
+
+#: ../../example_paper.md:194 5bea5b8035d3406db5ea07d8efbff3c4
+msgid ""
+"Note that the paper begins by a metadata section (the enclosing --- lines"
+" are mandatory) and ends with a References heading, and the references "
+"are built automatically from the content in the `.bib` file. You should "
+"enter in-text citations in the paper body following correct [Markdown "
+"citation syntax](https://pandoc.org/MANUAL.html#extension-citations).  "
+"Also note that the references include full names of venues, e.g., "
+"journals and conferences, not abbreviations only understood in the "
+"context of a specific discipline."
+msgstr ""
+

--- a/docs/locale/nb/LC_MESSAGES/expectations.po
+++ b/docs/locale/nb/LC_MESSAGES/expectations.po
@@ -1,0 +1,172 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: nb\n"
+"Language-Team: nb <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../expectations.md:1 4c8612f8e66a48b494a730e3596c2063
+msgid "Expectations on JOSS editors"
+msgstr ""
+
+#: ../../expectations.md:3 0a07f881dd4f40f691a8af9001834a83
+msgid "Editorial load"
+msgstr ""
+
+#: ../../expectations.md:5 d2189641ac4f41f8b523f52a27043dff
+msgid ""
+"Our goal is for editors to handle between 3-4 submissions at any one "
+"time, and 8-12 submissions per year. During the trial period for editors "
+"(usually the first 90 days), we recommend new editors handle 1-2 "
+"submissions as they learn the JOSS editorial system and processes."
+msgstr ""
+
+#: ../../expectations.md:7 d17595ec867642bfa639f878662e2347
+msgid "Completing the trial period"
+msgstr ""
+
+#: ../../expectations.md:9 97492a5a6ec34c2580cba9bc426985ad
+msgid ""
+"JOSS has a 90-day trial period for new editors. At the end of the trial, "
+"the editor or JOSS editorial board can decide to part ways if either "
+"party determines editing for JOSS isn't a good fit for the editor. The "
+"most important traits the editorial board will be looking for with new "
+"editors are:"
+msgstr ""
+
+#: ../../expectations.md:11 caab6a9de39249d0af2b78753cb9447a
+msgid ""
+"Demonstrating professionalism in communications with authors, reviewers, "
+"and the wider editorial team."
+msgstr ""
+
+#: ../../expectations.md:12 36d289f2a08a402c864dc3d05c39051e
+msgid ""
+"Editorial responsibility, including [keeping up with their assigned "
+"submissions](#continued-attention-to-assigned-submissions)."
+msgstr ""
+
+#: ../../expectations.md:13 469696bcccdf43f985569eeefd85c7f2
+msgid ""
+"Encouraging good social (software community) practices. For example, "
+"thanking reviewers and making them feel like they are part of a team "
+"working together."
+msgstr ""
+
+#: ../../expectations.md:15 68060dfafa604f85a420dee7f417dd53
+msgid ""
+"If you're struggling with your editorial work, please let your buddy or "
+"an EiC know."
+msgstr ""
+
+#: ../../expectations.md:17 71f361156a5f442ab487707e693e9305
+msgid "Responding to editorial assignments"
+msgstr ""
+
+#: ../../expectations.md:19 7f904950b4314e0abbdff99c03a35775
+msgid ""
+"As documented above, usually, papers will be assigned to you by one of "
+"the TEiCs. We ask that editors do their best to respond in a timely "
+"fashion (~ 3 working days) to invites to edit a new submission."
+msgstr ""
+
+#: ../../expectations.md:21 861a33e26bf3481d8918b2f1a39cb670
+msgid "Continued attention to assigned submissions"
+msgstr ""
+
+#: ../../expectations.md:23 5c9cf961643b414a8c0759d3674c96b4
+msgid ""
+"As an editor, part of your role is to ensure that submissions you're "
+"responsible for are progressing smoothly through the editorial process. "
+"This means that:"
+msgstr ""
+
+#: ../../expectations.md:25 a3fe16f8e2094ea8a3be43e6f7625264
+msgid ""
+"During pre-review, and before reviewers have been identified, editors "
+"should be checking on their submissions twice per week to ensure "
+"reviewers are identified in a timely fashion."
+msgstr ""
+
+#: ../../expectations.md:26 104b72a966c94a8c8041ce1b4a4e9922
+msgid ""
+"During review, editors should check on their submissions once or twice "
+"per week (even for just a few minutes) to see if their input is required "
+"(e.g., if someone has asked a question that requires your input)."
+msgstr ""
+
+#: ../../expectations.md:28 509ff01f88764b589654025ead0d7107
+msgid ""
+"Your editorial dashboard (e.g. "
+"`https://joss.theoj.org/dashboard/youreditorname`) is the best place to "
+"check if there have been any updates to the papers you are editing."
+msgstr ""
+
+#: ../../expectations.md:30 7974f302790c43b38fe49a52acf17e44
+msgid "**If reviews go stale**"
+msgstr ""
+
+#: ../../expectations.md:32 1f2b12f8ff0f40f8ad2e1ed2376ecd82
+msgid ""
+"Sometimes reviews go quiet, either because a reviewer has failed to "
+"complete their review or an author has been slow to respond to a "
+"reviewer's feedback. **As the editor, we need you to prompt the author/or"
+" reviewer(s) to revisit the submission if there has been no response "
+"within 7-10 days unless there's a clear statement in the review thread "
+"that says an action is coming at a slightly later time, perhaps because a"
+" reviewer committed to a review by a certain date, or an author is making"
+" changes and says they will be done by a certain date.**"
+msgstr ""
+
+#: ../../expectations.md:34 6a6df7801ec74702aa36001f0787561f
+msgid ""
+"[EditorialBot has "
+"functionality](https://joss.readthedocs.io/en/latest/editorial_bot.html"
+"#reminding-reviewers-and-authors) to remind an author or review to return"
+" to a review at a certain point in the future. For example:"
+msgstr ""
+
+#: ../../expectations.md:40 9ef806aaf3114de4815903b063038340
+msgid "Out of office"
+msgstr ""
+
+#: ../../expectations.md:42 22b5920a8827483e87c893584ff63e86
+msgid ""
+"Sometimes we need time away from our editing duties at JOSS. If you're "
+"planning on being out of the office for more than two weeks, please let "
+"the JOSS editorial team know."
+msgstr ""
+
+#: ../../expectations.md:44 6796f6c4ca0944fdbf897e126f25a6f2
+msgid "Voting on papers flagged as potentially out of scope"
+msgstr ""
+
+#: ../../expectations.md:46 7fe0a02c7e70472d87e2cbea3e629f3d
+msgid ""
+"Once per week, an email is sent to all JOSS editors with a summary of the"
+" papers that are currently flagged as potentially out of scope. Editors "
+"are asked to review these submissions and vote on the JOSS website if "
+"they have an opinion about a submission."
+msgstr ""
+
+#: ../../expectations.md:49 f45c808931ce408c8b24362d20907faf
+msgid ""
+"Your input (vote) on submissions that are undergoing a scope review is "
+"incredibly valuable to the EiC team. Please try and vote early, and "
+"often!"
+msgstr ""
+

--- a/docs/locale/nb/LC_MESSAGES/index.po
+++ b/docs/locale/nb/LC_MESSAGES/index.po
@@ -1,0 +1,124 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: nb\n"
+"Language-Team: nb <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../index.rst:33
+msgid "Author Guides"
+msgstr ""
+
+#: ../../index.rst:42
+msgid "Reviewer Guides"
+msgstr ""
+
+#: ../../index.rst:50
+msgid "Editor Guides"
+msgstr ""
+
+#: ../../index.rst:60
+msgid "The Editorial Bot"
+msgstr ""
+
+#: ../../index.rst:66
+msgid "Developer Guides"
+msgstr ""
+
+#: ../../index.rst:2 0f9fd00d10994bde9487df77c173647c
+msgid "Journal of Open Source Software"
+msgstr ""
+
+#: ../../index.rst:4 b7f84e5ae46b4d7c9156aad67fb7cd0f
+msgid ""
+"The `Journal of Open Source Software <http://joss.theoj.org/>`_ (JOSS) is"
+" a developer friendly journal for research software packages."
+msgstr ""
+
+#: ../../index.rst:6 84ad65da2fbb4df4a39cf8defc685cf8
+msgid ""
+"JOSS is an academic journal (ISSN 2475-9066) with a formal peer-review "
+"process that is designed to *improve the quality of the software "
+"submitted*. Upon acceptance into JOSS, we mint a CrossRef DOI for your "
+"paper and we list it on the `JOSS website <http://joss.theoj.org/>`_."
+msgstr ""
+
+#: ../../index.rst:9 e44acbe63269418b90fa19eb9f3386a2
+msgid "About this site"
+msgstr ""
+
+#: ../../index.rst:11 1b295ccddd04446ca6ffd9d426fe18dd
+msgid ""
+"This site contains documentation for authors interested in submitting to "
+"JOSS, reviewers who have generously volunteered their time to review "
+"submissions, and editors who manage the JOSS editorial process."
+msgstr ""
+
+#: ../../index.rst:13 7bed16ea6e82428aa844436412867a22
+msgid "If you're interested in learning more about JOSS, you might want to read:"
+msgstr ""
+
+#: ../../index.rst:15 04b24557f26b44478abbf87be2c3f806
+msgid ""
+"`Our announcement blog post <http://www.arfon.org/announcing-the-journal-"
+"of-open-source-software>`_ describing some of the motivations for "
+"starting a new journal"
+msgstr ""
+
+#: ../../index.rst:16 56f0574fde3741419c77e3ded31340c4
+msgid ""
+"`The paper in Computing in Science and Engineering "
+"<https://doi.org/10.1109/MCSE.2018.03221930>`_ introducing JOSS"
+msgstr ""
+
+#: ../../index.rst:17 9d3759ade4a64885ae3954a27158631d
+msgid ""
+"`The paper in PeerJ CS <https://doi.org/10.7717/peerj-cs.147>`_ "
+"describing the first year of JOSS"
+msgstr ""
+
+#: ../../index.rst:18 fad5565d41484771ba10d89b2c5e3fbb
+msgid "The `about page <http://joss.theoj.org/about>`_ on the main JOSS site"
+msgstr ""
+
+#: ../../index.rst:21 22b4cf2291034a42bd88703454ed27a2
+msgid "Submitting a paper to JOSS"
+msgstr ""
+
+#: ../../index.rst:23 d79c0a72ff284f9dba237c4555df0303
+msgid ""
+"If you'd like to submit a paper to JOSS, please read the author "
+"submission guidelines in the :doc:`submitting` section."
+msgstr ""
+
+#: ../../index.rst:26 605a08afc01447dbb3f9ac1b93addf05
+msgid "Sponsors and affiliates"
+msgstr ""
+
+#: ../../index.rst:-1 9436c00eef0143748d00afeb40768f3b
+msgid "OSI & NumFOCUS"
+msgstr ""
+
+#: ../../index.rst:31 acf3af62f1724ef39d48d9109e26e4d6
+msgid ""
+"JOSS is a proud affiliate of the `Open Source Initiative "
+"<https://opensource.org/>`_. As such, we are committed to public support "
+"for open source software and the role OSI plays therein. In addition, "
+"Open Journals (the parent entity behind JOSS) is a `NumFOCUS-sponsored "
+"project <https://www.numfocus.org/project/open-journals>`_."
+msgstr ""
+

--- a/docs/locale/nb/LC_MESSAGES/installing.po
+++ b/docs/locale/nb/LC_MESSAGES/installing.po
@@ -1,0 +1,488 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: nb\n"
+"Language-Team: nb <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../installing.md:1 4f774171c24246e78329728517f8b9e7
+msgid "Installing the JOSS application"
+msgstr ""
+
+#: ../../installing.md:3 7c2d4ade22274352a9f442fae212c0c4
+msgid "Any Open Journal (JOSS, JOSE, etc.) can be considered in three parts:"
+msgstr ""
+
+#: ../../installing.md:5 e36bd80c5ce14615a804f4b4ba13cadf
+msgid "The website"
+msgstr ""
+
+#: ../../installing.md:6 a751dc18b8454069a019feca0b975ec1
+msgid "The Buffy gem to interface with GitHub"
+msgstr ""
+
+#: ../../installing.md:7 99d0865bd8244adc8104ef83a7094976
+msgid ""
+"Inara, a docker image to compile papers being used in GitHub actions and "
+"workflows"
+msgstr ""
+
+#: ../../installing.md:9 f3cb4da41c3641b793f534cbda979d72
+msgid "For JOSS, these correspond to the:"
+msgstr ""
+
+#: ../../installing.md:11 7706d290708e4215a0d1066c12ba8b70
+msgid "[JOSS](https://github.com/openjournals/joss),"
+msgstr ""
+
+#: ../../installing.md:12 9ce88ee192d74d75b21ff6c6473d9d57
+msgid "[Buffy](https://github.com/openjournals/buffy), and"
+msgstr ""
+
+#: ../../installing.md:13 18023f6691a24aed9f10eb211f20df23
+msgid "[Inara](https://github.com/openjournals/inara)"
+msgstr ""
+
+#: ../../installing.md:15 2af763723dec4b06a80b90108edc4a0a
+msgid "code bases."
+msgstr ""
+
+#: ../../installing.md:17 bfd72b4ceb2143f4a80dd5192fea6c84
+msgid "Setting up a local development environment"
+msgstr ""
+
+#: ../../installing.md:19 839f08a37e6643ddb15901d390c8db6a
+msgid ""
+"All Open Journals are coded in Ruby, with the website and Buffy developed"
+" as [Ruby on Rails](https://rubyonrails.org/inst) applications."
+msgstr ""
+
+#: ../../installing.md:23 448f1857fb7547b38869e65bece919a2
+msgid ""
+"If you'd like to develop these locally, you'll need a working Ruby on "
+"Rails development environment. For more information, please see [this "
+"official "
+"guide](https://guides.rubyonrails.org/getting_started.html#creating-a"
+"-new-rails-project-installing-rails)."
+msgstr ""
+
+#: ../../installing.md:28 6fceb023c1d140acb6aa84378b97a599
+msgid "Deploying your JOSS application"
+msgstr ""
+
+#: ../../installing.md:30 c36c4bc7d6b64237bb2041a5cea49030
+msgid ""
+"To deploy JOSS, you'll need a [Heroku "
+"account](https://signup.heroku.com/). We also recommend you gather the "
+"following information before deploying your application to Heroku:"
+msgstr ""
+
+#: ../../installing.md:34 bdd6ac4a32864b17a401073501a896ab
+msgid "A [public ORCID API](https://members.orcid.org/api/about-public-api) key"
+msgstr ""
+
+#: ../../installing.md:35 d3fea2ad0ad141f3823f465a1be8cb38
+msgid ""
+"A GitHub [Personal Access Token](https://docs.github.com/en/free-pro-"
+"team@latest/github/authenticating-to-github/creating-a-personal-access-"
+"token) for the automated account that users will interact with (e.g., "
+"`@editorialbot`, `@RoboNeuro`). In order to be able to send invitations "
+"to reviewers and collaborators, the automated GitHub account must be an "
+"admin of the organization the reviews take place at. And the Personal "
+"Access Token should include the `admin:org` scope."
+msgstr ""
+
+#: ../../installing.md:36 87d6be2a8ed349d2ae6ec252d618a94d
+msgid ""
+"An email address registered on a domain you control (i.e., not `gmail` or"
+" a related service)"
+msgstr ""
+
+#: ../../installing.md:39 ec245b6af1114e8c9c6b43dab184be7c
+msgid ""
+"Do not put these secrets directly into your code base! It is important "
+"that these keys are not under version control."
+msgstr ""
+
+#: ../../installing.md:42 6c24f4a22b9e4efda5ec5bf0a58d1c45
+msgid ""
+"There are different ways to make sure your application has access to "
+"these keys, depending on whether your code is being developed locally or "
+"on Heroku. Locally, you can store these locally in a .env file. The "
+".gitignore in JOSS is already set to ignore this file type."
+msgstr ""
+
+#: ../../installing.md:47 ac957a56a2f0488584b50444d074c0a4
+msgid ""
+"On Heroku, they will be config variables that you can set either with the"
+" Heroku CLI or directly on your application's dashboard. See [this guide "
+"from Heroku](https://devcenter.heroku.com/articles/config-vars#managing-"
+"config-vars) for more information."
+msgstr ""
+
+#: ../../installing.md:51 33ae259eb2884b89832f63790b710bbc
+msgid ""
+"Assuming you [have forked the JOSS GitHub "
+"repository](https://docs.github.com/en/free-pro-team@latest/github"
+"/getting-started-with-github/fork-a-repo) to your account, you can "
+"[configure Heroku as a git "
+"remote](https://devcenter.heroku.com/articles/git#prerequisites-install-"
+"git-and-the-heroku-cli) for your code. This makes it easy to keep your "
+"Heroku deployment in sync with your local development copy."
+msgstr ""
+
+#: ../../installing.md:56 7a74914499304caeb5aeebaf2ad12225
+msgid ""
+"On the JOSS Heroku deployment, you'll need to provision several [add-"
+"ons](https://elements.heroku.com/addons). Specifically, you'll need:"
+msgstr ""
+
+#: ../../installing.md:59 63e1a5bdf03947dbaf70911e67516b7a
+msgid "[Elasticsearch add-on](https://elements.heroku.com/addons/bonsai)"
+msgstr ""
+
+#: ../../installing.md:60 4db8faf5399342ea8bda26e2d590c72d
+msgid "[PostgreSQL add-on](https://elements.heroku.com/addons/heroku-postgresql)"
+msgstr ""
+
+#: ../../installing.md:61 125450c630f04cbdb696309f6cbae800
+msgid "[Scheduler add-on](https://devcenter.heroku.com/articles/scheduler)"
+msgstr ""
+
+#: ../../installing.md:63 f6c31a27438a4e27a8f4650f5a3764d6
+msgid ""
+"For the scheduler add-on, you'll need to designate which tasks it should "
+"run and when. These can be found in the `lib/tasks` folder, and involve "
+"things such as sending out weekly reminder emails to editors. Each task "
+"should be scheduled as a separate job; for example, `rake "
+"send_weekly_emails`."
+msgstr ""
+
+#: ../../installing.md:67 480effe493c745e49a6a46f680482be9
+msgid ""
+"You can also optionally configure the following add-ons (or simply set "
+"their secret keys in your config variables):"
+msgstr ""
+
+#: ../../installing.md:69 18bf6583b4ca4b5aa704859cb3bc8e50
+msgid ""
+"[SendGrid add-on](https://elements.heroku.com/addons/sendgrid) for "
+"sending emails"
+msgstr ""
+
+#: ../../installing.md:70 1ef8f6a531a540d0aae9ba991194e388
+msgid ""
+"[Honeybadger add-on](https://elements.heroku.com/addons/honeybadger) for "
+"error reporting"
+msgstr ""
+
+#: ../../installing.md:72 28a4c573c67b4182903e04d891c3c231
+msgid ""
+"Once you've pushed your application to Heroku and provisioned the "
+"appropriate add-ons, you're ready to update your config with the "
+"appropriate secrets. For a list of the expected secret key names, see the"
+" `app.json` file."
+msgstr ""
+
+#: ../../installing.md:77 6fd5c894e54f4bf185d27a7df1c5d9b5
+msgid ""
+"One \"gotcha\" when provisioning the Bonsai add-on is that it may only "
+"set the `BONSAI_URL` variable. Make sure that there is also an "
+"`ELASTICSEARCH_URL` which is set to the same address."
+msgstr ""
+
+#: ../../installing.md:81 a8d49a25ce6d466fb77c9eab1ac84315
+msgid ""
+"We will not cover Portico, as this requires that your application is a "
+"part of the `openjournals` organization. If you do not already have "
+"access to these keys, you can simply ignore them for now."
+msgstr ""
+
+#: ../../installing.md:85 9b8bd242eaa24872bf8f8a3b562fc579
+msgid ""
+"One secret key we have not covered thus far is `BOT_SECRET`. This is "
+"because it is not one that you obtain from a provide, but a secret key "
+"that you set yourself. We recommend using something like a random SHA1 "
+"string."
+msgstr ""
+
+#: ../../installing.md:90 a07f1080dac54cf69dfa63db432a6e7f
+msgid ""
+"It is important to remember this key, as you will need it when deploying "
+"your Buffy application."
+msgstr ""
+
+#: ../../installing.md:94 be0e73d9129b47a19c2ba229db91cff4
+msgid ""
+"After pushing your application to Heroku, provisioning the appropriate "
+"add-ons, and confirming that your config variables are set correctly, you"
+" should make sure that your username is registered as an admin on the "
+"application."
+msgstr ""
+
+#: ../../installing.md:98 51ac835ee244430d9f362bca2db59b58
+msgid ""
+"You can do this on a local Rails console, by logging in and setting the "
+"boolean field 'admin' on your user ID to True. If you'd prefer to do this"
+" on the Heroku deployment, make sure you've logged into the application. "
+"Then you can directly modify this attribute in the deployments Postgres "
+"database using SQL. For more information on accessing your application's "
+"Postgres database, see [the official "
+"docs](https://devcenter.heroku.com/articles/heroku-postgresql#pg-psql)."
+msgstr ""
+
+#: ../../installing.md:105 17b2ffdb4fc64475811b954d7af4a67a
+msgid "Making modifications to launch your own site"
+msgstr ""
+
+#: ../../installing.md:107 373595fdd5fe46fca658718f3acffad9
+msgid ""
+"Some times you may not want to launch an exact copy of JOSS, but a "
+"modified version. This can be especially useful if you're planning to "
+"spin up your own platform based on the Open Journals framework. "
+"[NeuroLibre](https://neurolibre.org/) is one such example use-case."
+msgstr ""
+
+#: ../../installing.md:112 8fcfc2f6b93e4c2091b2aadd1e8e4fcb
+msgid "Modifying your site configuration"
+msgstr ""
+
+#: ../../installing.md:114 6624ff396d3442e8bcfcf00ce6f7b875
+msgid ""
+"In this case, there are several important variables to be aware of and "
+"modify. Most of these are accessible in the `config` folder."
+msgstr ""
+
+#: ../../installing.md:117 9b4c51ceb34744afa07f805c2870c9f5
+msgid ""
+"First, there are three files which provide settings for your Rails "
+"application in different development contexts:"
+msgstr ""
+
+#: ../../installing.md:119 ../../installing.md:210
+#: 0da0106839214cc2b157be7c6d8feba7 fbdd0ac095944c7ca292eed10fe87092
+msgid "`settings-test.yml`"
+msgstr ""
+
+#: ../../installing.md:120 abd2fc35958a48c6bb958b53fc7a9671
+msgid "`settings-development.yml`"
+msgstr ""
+
+#: ../../installing.md:121 ../../installing.md:211
+#: 3f8bc2da9f75411ba083909f20b54964 ddc8e9cab50b4d1891e2c624589f5742
+msgid "`settings-production.yml`"
+msgstr ""
+
+#: ../../installing.md:123 b9c68715d55148e984be13fa178f4f19
+msgid ""
+"These each contain site-specific variables that should be modified if you"
+" are building off of the Open Journals framework."
+msgstr ""
+
+#: ../../installing.md:125 06b78fe89e454f599cdd523294c88eb8
+msgid ""
+"Next, you'll need to modify the `repository.yml` file. This file lists "
+"the GitHub repository where you expect papers to be published, as well as"
+" the editor team ID. For your GitHub organization, make sure you have "
+"created and populated a team called `editors`. Then, you can check its ID"
+" number as detailed in [this guide](https://fabian-"
+"kostadinov.github.io/2015/01/16/how-to-find-a-github-team-id). In "
+"`config` you should also modify the `orcid.yml` file to list your site as"
+" the production site."
+msgstr ""
+
+#: ../../installing.md:132 f13db8cf9e4644519ad56b82189a306c
+msgid ""
+"Finally, you'll need to set up a [GitHub "
+"webhook](https://docs.github.com/en/free-pro-team@latest/developers"
+"/webhooks-and-events/about-webhooks) for reviews repository. This should "
+"be a repository that you have write access to, where you expect most of "
+"the reviewer-author interaction to occur. For JOSS, this corresponds to "
+"the `openjournals/joss-reviews` GitHub repository."
+msgstr ""
+
+#: ../../installing.md:137 ../../installing.md:221
+#: a64d98ae21c24483915d4efc526de7da b45fc86903bb4d34bfd57621ee5cdcb3
+msgid ""
+"In this GitHub repository's settings, you can add a new webhook with the "
+"following configuration:"
+msgstr ""
+
+#: ../../installing.md:140 686a1bffb5e8446e8fa8ee9309d8824f
+msgid ""
+"Set the `Payload` URL to the `/dispatch` hook for your Heroku application"
+" URL. For example, https://neurolibre.herokuapp.com/dispatch"
+msgstr ""
+
+#: ../../installing.md:142 ../../installing.md:226
+#: 17a6db41035949f990e4d948f27424b7 4ddd63b0f6f643d5bd2b2016f6c7302b
+msgid "Set the `Content type` to `application/json`"
+msgstr ""
+
+#: ../../installing.md:143 ../../installing.md:227
+#: 9052e8d56f124cc78e097c27c7faaf98 ddb732f428924b0f96f1a7d69ba9ace3
+msgid ""
+"Set the secret to a high-entropy, random string as detailed in the "
+"[GitHub docs](https://docs.github.com/en/free-pro-team@latest/developers"
+"/webhooks-and-events/securing-your-webhooks#setting-your-secret-token)"
+msgstr ""
+
+#: ../../installing.md:144 ../../installing.md:228
+#: bd18d6eff9bc4c31bfeec584d7dcc8a1 da172741ab3a4d9997f25854ae69a198
+msgid "Set the webhook to deliver `all events`"
+msgstr ""
+
+#: ../../installing.md:146 bf68263770984fa38c91aa9285ef7a95
+msgid "Updating your application database"
+msgstr ""
+
+#: ../../installing.md:148 c5dc60327d3a414bb3b1f1af4cb4c62d
+msgid ""
+"Optionally, you can edit `seeds.rb`, a file in the `db` folder. \"DB\" is"
+" short for \"database,\" and this file _seeds_ the database with "
+"information about your editorial team. You can edit the file `seeds.rb` "
+"to remove any individuals who are not editors in your organization. This "
+"can be especially useful if you will be creating the database multiple "
+"times during development; for example, if you add in testing information "
+"that you'd later like to remove."
+msgstr ""
+
+#: ../../installing.md:154 23a7defba63e4d8199dce4c3e802a467
+msgid ""
+"You can reinitialize the database from your Heroku CLI using the "
+"following commands:"
+msgstr ""
+
+#: ../../installing.md:163 f2a8d9e5a8dc4ea39b7332bf84f9f6a8
+msgid "Modifying your site contents"
+msgstr ""
+
+#: ../../installing.md:165 67ffa2e9bc1848aa94aedb082bcadc90
+msgid ""
+"You can modify site content by updating files in the `app` and `docs` "
+"folders. For example, in `app/views/notifications` you can change the "
+"text for any emails that will be sent by your application."
+msgstr ""
+
+#: ../../installing.md:168 6a3bc644aed24f6bae19fccc6c80dd3b
+msgid ""
+"Note that files which end in `.html.erb` are treated as HTML files, and "
+"typical HTML formatting applies. You can set the HTML styling by "
+"modifying the Sass files for your application, located in "
+"`app/assets/stylesheets`."
+msgstr ""
+
+#: ../../installing.md:172 e4f19b8d33d545b08a4c919c3c618f28
+msgid ""
+"There are currently a few hard-coded variables in the application which "
+"you will also need to update. Note that these are mostly under "
+"`lib/tasks`. For example, in `stats.rake`, the reviewer sheet ID is hard-"
+"coded on line 37. You should update this to point to your own spreadsheet"
+" where you maintain a list of eligible reviewers."
+msgstr ""
+
+#: ../../installing.md:177 4b836fad75bf48daab9d5c1186b8e1d7
+msgid ""
+"In the same folder, `utils.rake` is currently hard-coded to alternate "
+"assignments of editor-in-chief based on weeks. You should modify this to "
+"either set a single editor-in-chief, or design your own scheme of "
+"alternating between members of your editorial board."
+msgstr ""
+
+#: ../../installing.md:181 b46f9ccf2df2437c91125f29645854df
+msgid "Deploying your Buffy Application"
+msgstr ""
+
+#: ../../installing.md:183 dcf8823d458446aea1fd61c3feb6bd42
+msgid ""
+"Buffy can also be deployed on Heroku. Note that &mdash; for full "
+"functionality &mdash; Buffy must be deployed on [Hobby "
+"dynos](https://devcenter.heroku.com/articles/dyno-types), rather than "
+"free dynos. Hobby dynos allow the Buffy application to run continuously, "
+"without falling asleep after 30 minutes of inactivity; this means that "
+"Buffy can respond to activity on GitHub at any time. Buffy specifically "
+"requires two Hobby dynos: one for the `web` service and one for the "
+"`worker` service."
+msgstr ""
+
+#: ../../installing.md:189 e812a9316c9f4959bd0298c4f43f169e
+msgid ""
+"For a complete step-by-step guide on installing and deploying Buffy, you "
+"can read the [Buffy documentation](https://buffy.readthedocs.io)."
+msgstr ""
+
+#: ../../installing.md:191 5f41ed6042284220a7bece9e43285b4f
+msgid ""
+"As before, once you've pushed your application to Heroku and provisioned "
+"the appropriate add-ons, you're ready to update your config with the "
+"appropriate secrets."
+msgstr ""
+
+#: ../../installing.md:194 622adbea9d8042649356223ef54f3b8c
+msgid ""
+"Specifically, the `JOSS_API_KEY`env var in Heroku should match the "
+"`BOT_SECRET` key that you created in your JOSS deployment."
+msgstr ""
+
+#: ../../installing.md:196 0d0ed34fb17649c3bb25bca81c145fe1
+msgid "Modifying your Buffy deployment"
+msgstr ""
+
+#: ../../installing.md:198 e0cd470cefb04da38734b7e246d48347
+msgid ""
+"Some times you may not want to launch an exact copy of the Buffy, but a "
+"modified version. This can be especially useful if you're planning to "
+"spin up your own platform based on the Open Journals framework. "
+"[rOpenSci-review-bot](https://github.com/ropensci-review-bot) and "
+"[Scoobies](https://github.com/scoobies) are examples of use-cases."
+msgstr ""
+
+#: ../../installing.md:203 54fb2e41380b4eccac2346c55ca57dd5
+msgid "Modifying your Buffy configuration"
+msgstr ""
+
+#: ../../installing.md:205 40dea617bd104bd0af00184cfe6ab720
+msgid ""
+"Similar to the JOSS deployment described above, the Buffy configuration "
+"is controlled through a series of YAML files included in the `config/` "
+"folder. Each of these files provide relevant configuration for a "
+"different development context. Specifically, two files are defined:"
+msgstr ""
+
+#: ../../installing.md:213 305e5b23bc2f4934b642d9605e7c0fcf
+msgid ""
+"which can be used to define testing and production environment variables,"
+" respectively."
+msgstr ""
+
+#: ../../installing.md:215 bee5692828314f52a82ee40bdf8a6250
+msgid ""
+"Finally, you'll need to set up a [GitHub "
+"webhook](https://docs.github.com/en/free-pro-team@latest/developers"
+"/webhooks-and-events/about-webhooks) for your reviews repository. As a "
+"reminder, this should be a repository that you have write access to. For "
+"JOSS, this corresponds to the `openjournals/joss-reviews` GitHub "
+"repository. **This is in addition to the webhook you previously created "
+"for the JOSS deployment, although it points to the same repository.**"
+msgstr ""
+
+#: ../../installing.md:224 e8b69180551748bf8a4a59d38e5d66de
+msgid ""
+"Set the `Payload` URL to the `/dispatch` hook for your Heroku application"
+" URL. For example, https://roboneuro.herokuapp.com/dispatch"
+msgstr ""
+

--- a/docs/locale/nb/LC_MESSAGES/paper.po
+++ b/docs/locale/nb/LC_MESSAGES/paper.po
@@ -1,0 +1,826 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: nb\n"
+"Language-Team: nb <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../paper.md:1 fa2014b0271a4a5dbcbdda71c3aea87f
+msgid "JOSS Paper Format"
+msgstr ""
+
+#: ../../paper.md:3 f435876e6c764e9c9a03c779beed7e5b
+msgid ""
+"Submitted articles must use Markdown and must provide a metadata section "
+"at the beginning of the article. Format metadata using YAML, a human-"
+"friendly data serialization language (The Official YAML Web Site, 2022). "
+"The information provided is included in the title and sidebar of the "
+"generated PDF."
+msgstr ""
+
+#: ../../paper.md:7 7f84aa3d14974a3783e82f225be7098a
+msgid "What should my paper contain?"
+msgstr ""
+
+#: ../../paper.md:10 bd929e02502549e9a986519beae8433d
+msgid ""
+"Begin your paper with a summary of the high-level functionality of your "
+"software for a non-specialist reader. Avoid jargon in this section."
+msgstr ""
+
+#: ../../paper.md:13 a86e5255e8de428093396370a3b63b72
+msgid ""
+"JOSS welcomes submissions from broadly diverse research areas. For this "
+"reason, we require that authors include in the paper some sentences that "
+"explain the software functionality and domain of use to a non-specialist "
+"reader. We also require that authors explain the research applications of"
+" the software. The paper should be between 250-1000 words. Authors "
+"submitting papers significantly longer than 1000 words may be asked to "
+"reduce the length of their paper."
+msgstr ""
+
+#: ../../paper.md:15 a2d5b50f11ec4ecaa8eb0a2e8e7184ad
+msgid "Your paper should include:"
+msgstr ""
+
+#: ../../paper.md:17 61fbc3484cd64b4388c3040e5179ede5
+msgid ""
+"A list of the authors of the software and their affiliations, using the "
+"correct format (see the example below)."
+msgstr ""
+
+#: ../../paper.md:18 b1150af4d7104633b3c06f1e13becdfb
+msgid ""
+"A summary describing the high-level functionality and purpose of the "
+"software for a diverse, *non-specialist audience*."
+msgstr ""
+
+#: ../../paper.md:19 ba5c62e4670c4c719b7bd39f28a0b338
+msgid ""
+"A *Statement of need* section that clearly illustrates the research "
+"purpose of the software and places it in the context of related work."
+msgstr ""
+
+#: ../../paper.md:20 9ca2a7e3312f451f86540f3bd34690f7
+msgid ""
+"A list of key references, including to other software addressing related "
+"needs. Note that the references should include full names of venues, "
+"e.g., journals and conferences, not abbreviations only understood in the "
+"context of a specific discipline."
+msgstr ""
+
+#: ../../paper.md:21 e5ebb30afd284a04a47caa540482d06e
+msgid ""
+"Mention (if applicable) a representative set of past or ongoing research "
+"projects using the software and recent scholarly publications enabled by "
+"it."
+msgstr ""
+
+#: ../../paper.md:22 2dec64a1a8a0420392dde5aa4e08f6f3
+msgid "Acknowledgement of any financial support."
+msgstr ""
+
+#: ../../paper.md:24 e876f741ede4426dbb62cf04d87acb5d
+msgid ""
+"As this short list shows, JOSS papers are only expected to contain a "
+"limited set of metadata (see example below), a Statement of need, "
+"Summary, Acknowledgements, and References sections. You can look at an "
+"[example accepted paper](example_paper). Given this format, a \"full "
+"length\" paper is not permitted, and software documentation such as API "
+"(Application Programming Interface) functionality should not be in the "
+"paper and instead should be outlined in the software documentation."
+msgstr ""
+
+#: ../../paper.md:27 ae2e048ffe834cf4b3068e48f886218c
+msgid ""
+"Your paper will be reviewed by two or more reviewers in a public GitHub "
+"issue. Take a look at the [review checklist](review_checklist) and  "
+"[review criteria](review_criteria) to better understand how your "
+"submission will be reviewed."
+msgstr ""
+
+#: ../../paper.md:30 cf85cd7d312145b6aba381d9888ac880
+msgid "Article metadata"
+msgstr ""
+
+#: ../../paper.md:33 7d59faef660b4b528d2b32c5f2574fb9
+msgid "Names"
+msgstr ""
+
+#: ../../paper.md:35 dd8ac44e573f475baa9166905eb83753
+msgid ""
+"Providing an author name is straight-forward: just set the `name` "
+"attribute. However, sometimes more control over the name is required."
+msgstr ""
+
+#: ../../paper.md:37 e5b4e44952cb429b974dbf8832df605b
+msgid "Name parts"
+msgstr ""
+
+#: ../../paper.md:39 67f20378d0c1421e8cb269c7c5c13159
+msgid ""
+"There are many ways to describe the parts of names; we support the "
+"following:"
+msgstr ""
+
+#: ../../paper.md:41 c869635f3e8d4a8e8570dd1806c41c96
+msgid "given names,"
+msgstr ""
+
+#: ../../paper.md:42 eb79984c537545d4be61899db1cfa065
+msgid "surname,"
+msgstr ""
+
+#: ../../paper.md:43 458fa74370974a149dc426d1c52405b1
+msgid "dropping particle,"
+msgstr ""
+
+#: ../../paper.md:44 93fc4ebe42e241ebbc0bd529c139f850
+msgid "non-dropping particle,"
+msgstr ""
+
+#: ../../paper.md:45 cba35b5262cb42bf94509372e0c977d1
+msgid "and suffix."
+msgstr ""
+
+#: ../../paper.md:47 60637395091f49aca67416f5605b5e6a
+msgid ""
+"We use a heuristic to parse names into these components. This parsing may"
+" produce the wrong result, in which case it is necessary to provide the "
+"relevant parts explicitly."
+msgstr ""
+
+#: ../../paper.md:49 f9412ec745274eca9be22b9cfc58390d
+msgid "The respective field names are"
+msgstr ""
+
+#: ../../paper.md:51 8b09eeceb8774b26a7a1accc275559db
+msgid "`given-names` (aliases: `given`, `first`, `firstname`)"
+msgstr ""
+
+#: ../../paper.md:52 047b49c2a7dd445a9c0d6a470c7b6bd3
+msgid "`surname` (aliases: `family`)"
+msgstr ""
+
+#: ../../paper.md:53 1399da8321a54c02ae4a16a764a7d9a6
+msgid "`suffix`"
+msgstr ""
+
+#: ../../paper.md:55 60a965723562460ab4ca4f3f4f26d66e
+msgid ""
+"The full display name will be constructed from these parts, unless the "
+"`name` attribute is given as well."
+msgstr ""
+
+#: ../../paper.md:57 e804dcbbe16d4b9194c8930c8b68fb71
+msgid "Particles"
+msgstr ""
+
+#: ../../paper.md:59 ecb8132848a04bab9788f7afd3cf0042
+msgid ""
+"It's usually enough to place particles like \"van\", \"von\", \"della\", "
+"etc. at the end of the given name or at the beginning of the surname, "
+"depending on the details of how the name is used."
+msgstr ""
+
+#: ../../paper.md:61 d21693e5142848d7a4cfd4058fe70d63
+msgid "`dropping-particle`"
+msgstr ""
+
+#: ../../paper.md:62 aa96722b312a4049bba3cb53b2c630f8
+msgid "`non-dropping-particle`"
+msgstr ""
+
+#: ../../paper.md:64 507def513a2c43a2bece07343c752ab2
+msgid "Literal names"
+msgstr ""
+
+#: ../../paper.md:66 114e5fd3f40a442d95c7282a0245a03d
+msgid ""
+"The automatic construction of the full name from parts is geared towards "
+"common Western names. It may therefore be necessary sometimes to provide "
+"the display name explicitly. This is possible by setting the `literal` "
+"field, e.g., `literal: Tachibana Taki`. This feature should only be used "
+"as a last resort. <!-- e.g., `literal: 宮水 三葉`. -->"
+msgstr ""
+
+#: ../../paper.md:68 2ece940089ea482693daa17ea2e389d0
+msgid "Example"
+msgstr ""
+
+#: ../../paper.md:87 0cdb10d51b2140a99d7d5cb4c2945264
+msgid "The name parts can also be collected under the author's `name`:"
+msgstr ""
+
+#: ../../paper.md:102 95cc4e2a1ef44eaaabb11b0249feb0da
+msgid "Internal references"
+msgstr ""
+
+#: ../../paper.md:104 4c14f1598b3f46f581e2a82e8abed510
+msgid ""
+"The goal of Open Journals is to provide authors with a seamless and "
+"pleasant writing experience. Since Markdown has no default mechanism to "
+"handle document internal references, known as “cross-references”, Open "
+"Journals supports a limited set of LaTex commands. In brief, elements "
+"that were marked with `\\label` and can be referenced with `\\ref` and "
+"`\\autoref`."
+msgstr ""
+
+#: ../../paper.md:112 b44070bda6a54e9c9b1de36173ede776
+msgid "Tables and figures"
+msgstr ""
+
+#: ../../paper.md:114 5880b4e4a8d54c2eaa2da191b4672bc8
+msgid ""
+"Tables and figures can be referenced if they are given a *label* in the "
+"caption. In pure Markdown, this can be done by adding an empty span "
+"`[]{label=\"floatlabel\"}` to the caption. LaTeX syntax is supported as "
+"well: `\\label{floatlabel}`."
+msgstr ""
+
+#: ../../paper.md:116 36b4c9eb2f014c8c8057252d016d38f8
+msgid ""
+"Link to a float element, i.e., a table or figure, with "
+"`\\ref{identifier}` or `\\autoref{identifier}`, where `identifier` must "
+"be defined in the float's caption. The former command results in just the"
+" float's number, while the latter inserts the type and number of the "
+"referenced float. E.g., in this document `\\autoref{proglangs}` yields "
+"\"\\autoref{proglangs}\", while `\\ref{proglangs}` gives "
+"\"\\ref{proglangs}\"."
+msgstr ""
+
+#: ../../paper.md:118 00f1a8c2974e4aa0a3d6de2134ecf323
+msgid ""
+": Comparison of programming languages used in the publishing tool. "
+"[]{label=\"proglangs\"}"
+msgstr ""
+
+#: ../../paper.md:126 6a6b07ce53a8441a8b7ab8ff293711a9
+msgid "Equations"
+msgstr ""
+
+#: ../../paper.md:128 39ad38abe7b2404abd476712b7fe20b5
+msgid ""
+"Cross-references to equations work similarly to those for floating "
+"elements. The difference is that, since captions are not supported for "
+"equations, the label must be included in the equation:"
+msgstr ""
+
+#: ../../paper.md:132 e2b44dcea679454fba346acc19bab564
+msgid ""
+"Referencing, however, is identical, with `\\autoref{eq:fermat}` resulting"
+" in \"\\autoref{eq:fermat}\"."
+msgstr ""
+
+#: ../../paper.md:134 cccf1e00213b47bbb562d831ef502339
+msgid "$$a^n + b^n = c^n \\label{eq:fermat}$$"
+msgstr ""
+
+#: ../../paper.md:136 0611b18dbc83421481f814a7a19e705a
+msgid ""
+"Authors who do not wish to include the label directly in the formula can "
+"use a Markdown span to add the label:"
+msgstr ""
+
+#: ../../paper.md:140 2a3bd0ce271840299c567e14657556b5
+msgid "Markdown"
+msgstr ""
+
+#: ../../paper.md:141 57aff3425b2041198fa569a3efa32452
+msgid ""
+"Markdown is a lightweight markup language used frequently in software "
+"development and online environments. Based on email conventions, it was "
+"developed in 2004 by John Gruber and Aaron Swartz."
+msgstr ""
+
+#: ../../paper.md:143 6297d980245f4f8996aa247167a4fc7c
+msgid "Inline markup"
+msgstr ""
+
+#: ../../paper.md:145 d8f21d85db4d425d8a0f4b1e38da0fda
+msgid ""
+"The markup in Markdown should be semantic, not presentations. The table "
+"below has some basic examples."
+msgstr ""
+
+#: ../../paper.md:26 d3df3328c4b64fc79997a1eb9b5aba15
+msgid "Markup"
+msgstr ""
+
+#: ../../paper.md:26 71e31d5f64224918affd375f45966558
+msgid "Markdown example"
+msgstr ""
+
+#: ../../paper.md:26 2dc916e2562649c7a74cf6c3aeac0874
+msgid "Rendered output"
+msgstr ""
+
+#: ../../paper.md:26 19cc622ca4494b8a9fa55b3a4388c2aa
+msgid "emphasis"
+msgstr ""
+
+#: ../../paper.md:26 a948a0a3802946478e2ff67ec0447655
+msgid "`*this*`"
+msgstr ""
+
+#: ../../paper.md:26 c58033ec56614927859e5e062d0bd345
+msgid "*this*"
+msgstr ""
+
+#: ../../paper.md:26 3e6cf5b487fb4a2689d8ac32c0788ca1
+msgid "strong emphasis"
+msgstr ""
+
+#: ../../paper.md:26 87febb945a3a4114ac4e4d8bbff65234
+msgid "`**that**`"
+msgstr ""
+
+#: ../../paper.md:26 a1765c48f9bb4e5883a902d91aa67278
+msgid "**that**"
+msgstr ""
+
+#: ../../paper.md:26 2ee0f00be1de4d638e605814fa02365f
+msgid "strikeout"
+msgstr ""
+
+#: ../../paper.md:26 885cb945571c4bb19bffa030446ca598
+msgid "`~~not this~~`"
+msgstr ""
+
+#: ../../paper.md:26 6fc0a89828d44669ac25de645a01f13a
+msgid "~~not this~~"
+msgstr ""
+
+#: ../../paper.md:26 385f870923b842eeabdda8c2244b885b
+msgid "subscript"
+msgstr ""
+
+#: ../../paper.md:26 a800ad356de940f8b902cf81915b4bd7
+msgid "`H~2~O`"
+msgstr ""
+
+#: ../../paper.md:26 03cf79ed62ad4410a5620c9515580c52
+msgid "H{sub}`2`O"
+msgstr ""
+
+#: ../../paper.md:26 d72212de80a44aab8408b46657caa9fe
+msgid "superscript"
+msgstr ""
+
+#: ../../paper.md:26 abd55b2a79af49728e32f3cba1d37811
+msgid "`Ca^2+^`"
+msgstr ""
+
+#: ../../paper.md:26 edef998bf9924bb19218abf4b07260e5
+msgid "Ca{sup}`2+`"
+msgstr ""
+
+#: ../../paper.md:26 2d13cc92c79d4f96afb59bd17f76a9f2
+msgid "underline"
+msgstr ""
+
+#: ../../paper.md:26 c6f3cde067ba4082906c6c064f7074f4
+msgid "`[underline]{.ul}`"
+msgstr ""
+
+#: ../../paper.md:26 7b4509b5bd7345888756987c4a8be939
+msgid "[underline]{.ul}"
+msgstr ""
+
+#: ../../paper.md:26 65162614eaac4acc96a0a3071cb8a3db
+msgid "small caps"
+msgstr ""
+
+#: ../../paper.md:26 91530edf3cb845caacc1e535364ca03e
+msgid "`[Small Caps]{.sc}`"
+msgstr ""
+
+#: ../../paper.md:26 45ab80e8677a43899fd1b35f6e7a8203
+msgid "[Small Caps]{.sc}"
+msgstr ""
+
+#: ../../paper.md:26 be91f863a4e8472cbf1e661551378429
+msgid "inline code"
+msgstr ""
+
+#: ../../paper.md:26 35992e1d02f746c1a80deaed97a40045
+msgid "`` `return 23` ``"
+msgstr ""
+
+#: ../../paper.md:26 50a8e17eb7444ab6b6a9d3a3386d3acd
+msgid "`return 23`"
+msgstr ""
+
+#: ../../paper.md:159 0d3c74f2e23a46929da8ff4443dc3f24
+msgid "Links"
+msgstr ""
+
+#: ../../paper.md:161 dc93319bdbfe4c8fbda1e72409ac8e1d
+msgid ""
+"Link syntax is `[link description](targetURL)`. E.g., this link to the "
+"[Journal of Open Source Software](https://joss.theoj.org/) is written as "
+"\\ `[Journal of Open Source Software](https://joss.theoj.org/)`."
+msgstr ""
+
+#: ../../paper.md:164 a46e19b9f7424c4ebc18a97071b16854
+msgid ""
+"Open Journal publications are not limited by the constraints of print "
+"publications. We encourage authors to use hyperlinks for websites and "
+"other external resources. However, the standard scientific practice of "
+"citing the relevant publications should be followed regardless."
+msgstr ""
+
+#: ../../paper.md:166 e7673ea4de8c41e5b647187597cf4438
+msgid "Grid Tables"
+msgstr ""
+
+#: ../../paper.md:168 a6f5f6ad8afb4076aef3a6a26e42bf3f
+msgid ""
+"Grid tables are made up of special characters which form the rows and "
+"columns, and also change table and style variables."
+msgstr ""
+
+#: ../../paper.md:170 d5ce43c9effb4504928b003a114ed47b
+msgid ""
+"Complex information can be conveyed by using the following features not "
+"found in other table styles:"
+msgstr ""
+
+#: ../../paper.md:172 18e1a75a972749a888862eb73b6182e5
+msgid "spanning columns"
+msgstr ""
+
+#: ../../paper.md:173 885f47fb518a4f8db6004b4680b63532
+msgid "adding footers"
+msgstr ""
+
+#: ../../paper.md:174 b3b4738e305047ca8c576bda1044e5d8
+msgid "using intra-cellular body elements"
+msgstr ""
+
+#: ../../paper.md:175 765a10f0d6ea48449a45f8bb917bc042
+msgid "creating multi-row headers"
+msgstr ""
+
+#: ../../paper.md:177 637517af24604afca5f59c7db1b5f470
+msgid ""
+"Grid table syntax uses the characters \"-\", \"=\", \"|\", and \"+\" to "
+"represent the table outline:"
+msgstr ""
+
+#: ../../paper.md:179 86751efbcd76472aa01f232810e33bea
+msgid "Hyphens (-) separate horizontal rows."
+msgstr ""
+
+#: ../../paper.md:180 caccc6e900e440ddac1d5e0ed3bd6593
+msgid ""
+"Equals signs (=) produce a header when used to create the row under the "
+"header text."
+msgstr ""
+
+#: ../../paper.md:181 c453086fc1754cfbb07b7e8fe800df08
+msgid ""
+"Equals signs (=) create a footer when used to enclose the last row of the"
+" table."
+msgstr ""
+
+#: ../../paper.md:182 97201779586f43f78b6083f89aabf9c3
+msgid "Vertical bars (|) separate columns and also adjusts the depth of a row."
+msgstr ""
+
+#: ../../paper.md:183 eda6f86cd1864a5885c9133f4df32357
+msgid "Plus signs (+) indicates a juncture between horizontal and parallel lines."
+msgstr ""
+
+#: ../../paper.md:185 cfbc0c2781684349b6b42e3e77b9f394
+msgid ""
+"Note: Inserting a colon (:) at the boundaries of the separator line after"
+" the header will change text alignment. If there is no header, insert "
+"colons into the top line."
+msgstr ""
+
+#: ../../paper.md:187 e7d4ac076a6e4b24bf520f1e30ea99b2
+msgid "Sample grid table:"
+msgstr ""
+
+#: ../../paper.md:204 68e153d4ff5b43538ab81db30e236a5b
+msgid "Figures and Images"
+msgstr ""
+
+#: ../../paper.md:206 d3dd4a2dc0064607b123dbed87a838df
+msgid ""
+"To create a figure, a captioned image must appear by itself in a "
+"paragraph. The Markdown syntax for a figure is a link, preceded by an "
+"exclamation point (!) and a description.   Example:   `![This description"
+" will be the figure caption](path/to/image.png)`"
+msgstr ""
+
+#: ../../paper.md:210 25374bd786624c4c8dd131cbd7ba12c9
+msgid ""
+"In order to create a figure rather than an image, there must be a "
+"description included and the figure syntax must be the only element in "
+"the paragraph, i.e., it must be surrounded by blank lines."
+msgstr ""
+
+#: ../../paper.md:212 afe902d108f54b1b8c09d40f691776eb
+msgid ""
+"Images that are larger than the text area are scaled to fit the page. You"
+" can give images an explicit height and/or width, e.g. when adding an "
+"image as part of a paragraph. The Markdown `![Nyan cat](nyan-"
+"cat.png){height=\"9pt\"}` includes the image saved as `nyan-cat.png` "
+"while scaling it to a height of 9 pt."
+msgstr ""
+
+#: ../../paper.md:214 d781dc3c1e0e4ec88d36b614f55f1d4a
+msgid "Citations"
+msgstr ""
+
+#: ../../paper.md:216 a308b28c59314248bcad2d66a5f81828
+msgid ""
+"Bibliographic data should be collected in a file `paper.bib`; it should "
+"be formatted in the BibLaTeX format, although plain BibTeX is acceptable "
+"as well. All major citation managers offer to export these formats."
+msgstr ""
+
+#: ../../paper.md:218 68879f46c083445189cd2ec5f2e24677
+msgid ""
+"Cite a bibliography entry by referencing its identifier: `[@upper1974]` "
+"will create the reference \"(Upper 1974)\". Omit the brackets when "
+"referring to the author as part of a sentence: \"For a case study on "
+"writers block, see Upper (1974).\" Please refer to the [pandoc "
+"manual](https://pandoc.org/MANUAL#extension-citations) for additional "
+"features, including page locators, prefixes, suffixes, and suppression of"
+" author names in citations."
+msgstr ""
+
+#: ../../paper.md:226 9ced5108486944279bbadf6acd752d6d
+msgid "The full citation will display as"
+msgstr ""
+
+#: ../../paper.md:228 b58d3000ebc14f6ea205d83d02d97ffe
+msgid ""
+"Upper, D. 1974. \"The Unsuccessful Self-Treatment of a Case of "
+"\\\"Writer's Block\\\".\" *Journal of Applied Behavior Analysis* 7 (3): "
+"497. <https://doi.org/10.1901/jaba.1974.7-497a>."
+msgstr ""
+
+#: ../../paper.md:232 83bffdb66e8c469e891be7c79776e24c
+msgid "Mathematical Formulæ"
+msgstr ""
+
+#: ../../paper.md:234 88f755b42e5f4f70ad0886fb02178d06
+msgid ""
+"Mark equations and other math content with dollar signs ($). Use a single"
+" dollar sign ($) for math that will appear directly within the text. Use "
+"two dollar signs ($$) when the formula is to be presented centered and on"
+" a separate line, in \"display\" style. The formula itself must be given "
+"using TeX syntax."
+msgstr ""
+
+#: ../../paper.md:236 c57d9b2d35344152b639f4665a30e1c0
+msgid ""
+"To give some examples: When discussing a variable *x* or a short formula "
+"like"
+msgstr ""
+
+#: ../../paper.md:238 84a73b2d6e43464498f0945bc8cb6d9f
+msgid "\\sin \\frac{\\pi}{2}"
+msgstr ""
+
+#: ../../paper.md:242 dea1c388f0544db69339d9736ec000b5
+msgid "we would write $x$ and"
+msgstr ""
+
+#: ../../paper.md:246 a97b8654f0da4367a248b0aebf7dbd58
+msgid ""
+"respectively. However, for more complex formulæ, display style is more "
+"appropriate. Writing"
+msgstr ""
+
+#: ../../paper.md:250 0f0329c771f44cb6a6efaafd1ad78646
+msgid "will give us"
+msgstr ""
+
+#: ../../paper.md:252 918f159918e6425cba03454fee55c46e
+msgid "$$\\int_{-\\infty}^{+\\infty} e^{-x^2} \\, dx = \\sqrt{\\pi}$$"
+msgstr ""
+
+#: ../../paper.md:254 ../../paper.md:272 200c575fa9724d6191d0ac3601ce1657
+#: 654239a09caa439db25316f6f862e3ed
+msgid "Footnotes"
+msgstr ""
+
+#: ../../paper.md:256 50bee0b418a74fd0b1553da10571d333
+msgid ""
+"Syntax for footnotes centers around the \"caret\" character `^`. The "
+"symbol is also used as a delimiter for superscript text and thereby "
+"mirrors the superscript numbers used to mark a footnote in the final "
+"text."
+msgstr ""
+
+#: ../../paper.md:265 b78a90e3ad884ad89029584ca691d168
+msgid "The above example results in the following output:"
+msgstr ""
+
+#: ../../paper.md:269 adf6b36b98e74cde95d2ae621d9d8cb4
+msgid ""
+"Articles are published under a Creative Commons license [#f1]_. Software "
+"should use an OSI-approved license."
+msgstr ""
+
+#: ../../paper.md:273 c2d72dc731f9452cb4eba7528bf9f3b3
+msgid "An open license that allows reuse."
+msgstr ""
+
+#: ../../paper.md:277 d8cecaaf776f437f8a3d75f4c3c4fe8f
+msgid ""
+"Note: numbers do not have to be sequential, they will be reordered "
+"automatically in the publishing step. In fact, the identifier of a note "
+"can be any sequence of characters, like `[^marker]`, but may not contain "
+"whitespace characters."
+msgstr ""
+
+#: ../../paper.md:280 b0b34a44b50f43c0b4f2dc2f7fb0da1f
+msgid "Blocks"
+msgstr ""
+
+#: ../../paper.md:282 b056c0cf16644fe7ab3c59aa8b23cd76
+msgid "The larger components of a document are called \"blocks\"."
+msgstr ""
+
+#: ../../paper.md:284 205d779737564263b3301c258d94a892
+msgid "Headings"
+msgstr ""
+
+#: ../../paper.md:286 7d07abf30db64a60a587faeaeb53ffff
+msgid ""
+"Headings are added with `#` followed by a space, where each additional "
+"`#` demotes the heading to a level lower in the hierarchy:"
+msgstr ""
+
+#: ../../paper.md:296 03bca033beee433d96a81737d3adcbf9
+msgid ""
+"Please start headings on the first level. The maximum supported level is "
+"5, but paper authors are encouraged to limit themselves to headings of "
+"the first two or three levels."
+msgstr ""
+
+#: ../../paper.md:298 545dbaf2d690400bb80f400e9a5db1d1
+msgid "Deeper nesting"
+msgstr ""
+
+#: ../../paper.md:300 6fc28f3a87ad460ab3c89394b150fad9
+msgid ""
+"Fourth- and fifth-level subsections – like this one and the following "
+"heading – are supported by the system; however, their use is discouraged."
+" Use lists instead of fourth- and fifth-level headings."
+msgstr ""
+
+#: ../../paper.md:303 907b61bed238496d8d774a7c4933d893
+msgid "Lists"
+msgstr ""
+
+#: ../../paper.md:305 34fbfc819c714c67a5e7e83e95af6289
+msgid ""
+"Bullet lists and numbered lists, a.k.a. enumerations, offer an additional"
+" method to present sequential and hierarchical information."
+msgstr ""
+
+#: ../../paper.md:314 e117581200c145db9836ca8670bafa45
+msgid "apples"
+msgstr ""
+
+#: ../../paper.md:315 df8b5cb323ee435cb354c118514ab0d5
+msgid "citrus fruits"
+msgstr ""
+
+#: ../../paper.md:316 b1e18a0e189646efb99c1048c7ca2ffb
+msgid "lemons"
+msgstr ""
+
+#: ../../paper.md:317 f63fd2fea04d4b2fa4cfc6d0e0e2bb4a
+msgid "oranges"
+msgstr ""
+
+#: ../../paper.md:319 d3c61a750d9c4f33b662bc3e6f39b2b6
+msgid ""
+"Enumerations start with the number of the first item. Using the the first"
+" two [laws of "
+"thermodynamics](https://en.wikipedia.org/wiki/Laws_of_thermodynamics) as "
+"example,"
+msgstr ""
+
+#: ../../paper.md:330 06cb1a1c2ed24fa8b6a14b4772b3c397
+msgid "Rendered:"
+msgstr ""
+
+#: ../../paper.md:332 2cf710ad67ae4c2ba56d655cc91662ed
+msgid ""
+"If two systems are each in thermal equilibrium with a third, they are "
+"also in thermal equilibrium with each other."
+msgstr ""
+
+#: ../../paper.md:333 af3e0769ebf54102be5e436699193ced
+msgid ""
+"In a process without transfer of matter, the change in internal energy, "
+"$\\Delta U$, of a thermodynamic system is equal to the energy gained as "
+"heat, $Q$, less the thermodynamic work, $W$, done by the system on its "
+"surroundings. $$\\Delta U = Q - W$$"
+msgstr ""
+
+#: ../../paper.md:336 e7942e2a2aed45a083f4736213905b84
+msgid "Checking that your paper compiles"
+msgstr ""
+
+#: ../../paper.md:338 87276e2613d946699125e8ff7e56341d
+msgid ""
+"JOSS uses Pandoc to compile papers from their Markdown form into a PDF. "
+"There are a few different ways you can test that your paper is going to "
+"compile properly for JOSS:"
+msgstr ""
+
+#: ../../paper.md:340 278486451bea43619f324ad6bab10fde
+msgid "GitHub Action"
+msgstr ""
+
+#: ../../paper.md:342 b6d499cea66f4dd7b73a26b06d2d13ee
+msgid ""
+"If you're using GitHub for your repository, you can use the [Open "
+"Journals GitHub Action](https://github.com/marketplace/actions/open-"
+"journals-pdf-generator) to automatically compile your paper each time you"
+" update your repository."
+msgstr ""
+
+#: ../../paper.md:344 e75e90a3f7794e239a964024a9b46db3
+msgid ""
+"The PDF is available via the Actions tab in your project and click on the"
+" latest workflow run. The zip archive file (including the `paper.pdf`) is"
+" listed in the run's Artifacts section."
+msgstr ""
+
+#: ../../paper.md:346 2ad09cdbb09f44bd93356b2a61bbbb80
+msgid "Docker"
+msgstr ""
+
+#: ../../paper.md:348 dffc31688cae44f08b93b3b9bc3b6b68
+msgid ""
+"If you have Docker installed on your local machine, you can use the same "
+"Docker Image to compile a draft of your paper locally. In the example "
+"below, the `paper.md` file is in the `paper` directory. Upon successful "
+"execution of the command, the `paper.pdf` file will be created in the "
+"same location as the `paper.md` file:"
+msgstr ""
+
+#: ../../paper.md:358 033a33ebf2ba4473907162b56a9c9f4a
+msgid "Locally"
+msgstr ""
+
+#: ../../paper.md:360 10a19a9058f842bba680a0cab71b851e
+msgid ""
+"The materials for the `inara` container image above are themselves open "
+"source and available in [its own "
+"repository](https://github.com/openjournals/inara). You can clone that "
+"repository and run the `inara` script locally with `make` after "
+"installing the necessary dependencies, which can be inferred from the "
+"[`Dockerfile`](https://github.com/openjournals/inara/blob/main/Dockerfile)."
+msgstr ""
+
+#: ../../paper.md:362 61413520e58d44b3b72760315e5aa7c5
+msgid "Behind the scenes"
+msgstr ""
+
+#: ../../paper.md:364 b0935bca284342188f389d7ab25691a2
+msgid ""
+"Readers may wonder about the reasons behind some of the choices made for "
+"paper writing. Most often, the decisions were driven by radical "
+"pragmatism. For example, Markdown is not only nearly ubiquitous in the "
+"realms of software, but it can also be converted into many different "
+"output formats. The archiving standard for scientific articles is JATS, "
+"and the most popular publishing format is PDF. Open Journals has built "
+"its pipeline based on [pandoc](https://pandoc.org), a universal document "
+"converter that can produce both of these publishing formats as well as "
+"many more."
+msgstr ""
+
+#: ../../paper.md:366 c49bc21e23344cb59e03d9194ac0e11d
+msgid ""
+"A common method for PDF generation is to go via LaTeX. However, support "
+"for tagging -- a requirement for accessible PDFs -- is not readily "
+"available for LaTeX. The current method used ConTeXt, to produce tagged "
+"PDF/A-3."
+msgstr ""
+

--- a/docs/locale/nb/LC_MESSAGES/policies.po
+++ b/docs/locale/nb/LC_MESSAGES/policies.po
@@ -1,0 +1,85 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: nb\n"
+"Language-Team: nb <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../policies.md:1 05bd176d1b3d4a84b95c1e98561974a7
+msgid "JOSS Policies"
+msgstr ""
+
+#: ../../policies.md:3 1a24f03bf77c44e5bc89d17ecd904804
+msgid "Animal research policy"
+msgstr ""
+
+#: ../../policies.md:5 a29e58a0a21447f1a28925c36a80f353
+msgid ""
+"In the exceptional case a JOSS submission contains original data on "
+"animal research, the corresponding author must confirm that the data was "
+"collected in accordance with the latest guidelines and applicable "
+"regulations. The manuscript must include complete reporting of the data, "
+"including the ways that the study was approved and relevant details of "
+"the sample. Authors are required to report either the "
+"[ARRIVE](https://arriveguidelines.org/) or "
+"[PREPARE](https://doi.org/10.1177/0023677217724823) guidelines for animal"
+" research in the submission."
+msgstr ""
+
+#: ../../policies.md:7 41e6fe0485154930a4a4630831b36898
+msgid ""
+"We recommend that authors replace, reduce, and refine animal research as "
+"promoted by the [N3RS](https://www.nc3rs.org.uk/)."
+msgstr ""
+
+#: ../../policies.md:9 0a44ed6a60e84552b1810e6aad1aa183
+msgid "Data sharing policy"
+msgstr ""
+
+#: ../../policies.md:11 6f14b42a55d34bb783de81296f134597
+msgid ""
+"If any original data analysis results are provided within the submitted "
+"work, such results have to be entirely reproducible by reviewers, "
+"including accessing the data."
+msgstr ""
+
+#: ../../policies.md:13 bfde40c520e74ffc9264824de2104fe9
+msgid ""
+"Submissions are, by definition, contained within one or multiple "
+"repositories, which we require authors to archive before we accept the "
+"submission. Any data contained within the software is made available "
+"accordingly."
+msgstr ""
+
+#: ../../policies.md:16 32119166412c467e927ba9c349404d68
+msgid "Human participants research policy"
+msgstr ""
+
+#: ../../policies.md:18 527c91102a9f44639f5edc8632fc3b59
+msgid ""
+"In the exceptional case a JOSS submission contains original data on human"
+" participants, the study must have been performed in accordance with the "
+"[Declaration of Helsinki](https://www.wma.net/policies-post/wma-"
+"declaration-of-helsinki-ethical-principles-for-medical-research-"
+"involving-human-subjects/). The manuscript must contain all relevant "
+"information regarding ethics approval, including but not limited to the "
+"responsible ethics committee and reference number. This also applies to "
+"ethics exemptions. Informed consent must be collected from all human "
+"research participants, and authors are required to state whether this "
+"occurred in the manuscript."
+msgstr ""
+

--- a/docs/locale/nb/LC_MESSAGES/review_checklist.po
+++ b/docs/locale/nb/LC_MESSAGES/review_checklist.po
@@ -1,0 +1,199 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: nb\n"
+"Language-Team: nb <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../review_checklist.md:1 66a6c65f275d44cbb2bf2b7d90818c3a
+msgid "Review checklist"
+msgstr ""
+
+#: ../../review_checklist.md:3 ab33d256eec14d68a92c5df919eb7ea3
+msgid ""
+"JOSS reviews are checklist-driven. That is, there is a checklist for each"
+" JOSS reviewer to work through when completing their review. A JOSS "
+"review is generally considered incomplete until the reviewer has checked "
+"off all of their checkboxes."
+msgstr ""
+
+#: ../../review_checklist.md:5 bdb4fdb8aa7d4521b7d8fb3ed024ad92
+msgid ""
+"Below is an example of the review checklist for the [Yellowbrick JOSS "
+"submission](https://github.com/openjournals/joss-reviews/issues/1075)."
+msgstr ""
+
+#: ../../review_checklist.md:9 ac29b31942e64e75a81f234148534d4e
+msgid ""
+"Note this section of our documentation only describes the JOSS review "
+"checklist. Authors and reviewers should consult the [review "
+"criteria](review_criteria) to better understand how these checklist items"
+" should be interpreted."
+msgstr ""
+
+#: ../../review_checklist.md:11 a5b9ebdb2c224bccb418db97543955fd
+msgid "Conflict of interest"
+msgstr ""
+
+#: ../../review_checklist.md:13 d9e6d5eef2514de981668ed987f0fa41
+msgid ""
+"I confirm that I have read the [JOSS conflict of interest "
+"policy](reviewer_guidelines.md#joss-conflict-of-interest-policy) and "
+"that: I have no COIs with reviewing this work or that any perceived COIs "
+"have been waived by JOSS for the purpose of this review."
+msgstr ""
+
+#: ../../review_checklist.md:15 b756fc2a709942baac7158306b73e675
+msgid "Code of Conduct"
+msgstr ""
+
+#: ../../review_checklist.md:17 f565cf05471743518d47a4dcde002be2
+msgid ""
+"I confirm that I read and will adhere to the [JOSS code of "
+"conduct](https://joss.theoj.org/about#code_of_conduct)."
+msgstr ""
+
+#: ../../review_checklist.md:19 a8b74cd44e3545d4964f0d2d28ee4928
+msgid "General checks"
+msgstr ""
+
+#: ../../review_checklist.md:21 47a2f9a832c14548be1b915bfa9aa4d1
+msgid ""
+"**Repository:** Is the source code for this software available at the <a "
+"target=\"_blank\" "
+"href=\"https://github.com/DistrictDataLabs/yellowbrick\">repository "
+"url</a>?"
+msgstr ""
+
+#: ../../review_checklist.md:22 0c35535cc6fe469188caf674344b3ba5
+msgid ""
+"**License:** Does the repository contain a plain-text LICENSE file with "
+"the contents of an [OSI "
+"approved](https://opensource.org/licenses/alphabetical) software license?"
+msgstr ""
+
+#: ../../review_checklist.md:23 62ebe9bb575643c29322218589461dbe
+msgid ""
+"**Contribution and authorship:** Has the submitting author made major "
+"contributions to the software? Does the full list of paper authors seem "
+"appropriate and complete?"
+msgstr ""
+
+#: ../../review_checklist.md:25 d697e71dad8a472c8821084c9a69704a
+msgid "Functionality"
+msgstr ""
+
+#: ../../review_checklist.md:27 043f354cc3634e31a57f6c02c4f98df4
+msgid ""
+"**Installation:** Does installation proceed as outlined in the "
+"documentation?"
+msgstr ""
+
+#: ../../review_checklist.md:28 40f63352e5fd4566abfab33af3e21c3f
+msgid ""
+"**Functionality:** Have the functional claims of the software been "
+"confirmed?"
+msgstr ""
+
+#: ../../review_checklist.md:29 4887147c31084be681cadd1d7c031f0a
+msgid ""
+"**Performance:** If there are any performance claims of the software, "
+"have they been confirmed? (If there are no claims, please check off this "
+"item.)"
+msgstr ""
+
+#: ../../review_checklist.md:31 040ce75ed5d34bfe84921ed499be6aa5
+msgid "Documentation"
+msgstr ""
+
+#: ../../review_checklist.md:33 ce980eb02c1a4bb6ba7c51f7ce7c2b03
+msgid ""
+"**A statement of need:** Do the authors clearly state what problems the "
+"software is designed to solve and who the target audience is?"
+msgstr ""
+
+#: ../../review_checklist.md:34 4b0a6f9b8a4d4f98b32efd462a30cb38
+msgid ""
+"**Installation instructions:** Is there a clearly-stated list of "
+"dependencies? Ideally these should be handled with an automated package "
+"management solution."
+msgstr ""
+
+#: ../../review_checklist.md:35 804ce952933a4ea2be9a7333cc78e95b
+msgid ""
+"**Example usage:** Do the authors include examples of how to use the "
+"software (ideally to solve real-world analysis problems)."
+msgstr ""
+
+#: ../../review_checklist.md:36 d7652d9182a848fbaff430778b15723a
+msgid ""
+"**Functionality documentation:** Is the core functionality of the "
+"software documented to a satisfactory level (e.g., API method "
+"documentation)?"
+msgstr ""
+
+#: ../../review_checklist.md:37 1690d7664c00418c9c66f3f5127fc584
+msgid ""
+"**Automated tests:** Are there automated tests or manual steps described "
+"so that the functionality of the software can be verified?"
+msgstr ""
+
+#: ../../review_checklist.md:38 be6c547613474995be785253c9ebbcfd
+msgid ""
+"**Community guidelines:** Are there clear guidelines for third parties "
+"wishing to 1) Contribute to the software 2) Report issues or problems "
+"with the software 3) Seek support"
+msgstr ""
+
+#: ../../review_checklist.md:40 ab745636d12945438b7d66d2deb64534
+msgid "Software paper"
+msgstr ""
+
+#: ../../review_checklist.md:42 61634e5a367b4123a26fd3005e19af68
+msgid ""
+"**Summary:** Has a clear description of the high-level functionality and "
+"purpose of the software for a diverse, non-specialist audience been "
+"provided?"
+msgstr ""
+
+#: ../../review_checklist.md:43 6b1c201f0b624ac5815b79eb1c119945
+msgid ""
+"**A statement of need:** Does the paper have a section titled 'Statement "
+"of need' that clearly states what problems the software is designed to "
+"solve, who the target audience is, and its relation to other work?"
+msgstr ""
+
+#: ../../review_checklist.md:44 918b339399514b9da9e93fdfa1ec098a
+msgid ""
+"**State of the field:** Do the authors describe how this software "
+"compares to other commonly-used packages?"
+msgstr ""
+
+#: ../../review_checklist.md:45 c767f227017641bb92d17fa4aadba03a
+msgid ""
+"**Quality of writing:** Is the paper well written (i.e., it does not "
+"require editing for structure, language, or writing quality)?"
+msgstr ""
+
+#: ../../review_checklist.md:46 281e3f89b1e24882a2f4a38d01c89fa7
+msgid ""
+"**References:** Is the list of references complete, and is everything "
+"cited appropriately that should be cited (e.g., papers, datasets, "
+"software)? Do references in the text use the proper [citation syntax]( "
+"https://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html#citation_syntax)?"
+msgstr ""
+

--- a/docs/locale/nb/LC_MESSAGES/review_criteria.po
+++ b/docs/locale/nb/LC_MESSAGES/review_criteria.po
@@ -1,0 +1,388 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: nb\n"
+"Language-Team: nb <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../review_criteria.md:1 a3ae2504cdaa47aeaa3da0fb14ab5a56
+msgid "Review criteria"
+msgstr ""
+
+#: ../../review_criteria.md:3 c49b5ecb47a84a32b6f5b3ee3715d525
+msgid "The JOSS paper"
+msgstr ""
+
+#: ../../review_criteria.md:5 93a2222f76c943dd84499681ef06115a
+msgid ""
+"As outlined in the [submission guidelines provided to authors](paper.md"
+"#what-should-my-paper-contain), the JOSS paper (the compiled PDF "
+"associated with this submission) should only include:"
+msgstr ""
+
+#: ../../review_criteria.md:7 1f4d9cc91cd84aaa9bb019fe4dba0dc8
+msgid "A list of the authors of the software and their affiliations."
+msgstr ""
+
+#: ../../review_criteria.md:8 c1fc8ff600484d3dab42a4daa19a5536
+msgid ""
+"A summary describing the high-level functionality and purpose of the "
+"software for a diverse, non-specialist audience."
+msgstr ""
+
+#: ../../review_criteria.md:9 aba52248ddba49299ca26939f4a55724
+msgid "A clear statement of need that illustrates the purpose of the software."
+msgstr ""
+
+#: ../../review_criteria.md:10 5432e875314441b08dadb882791eb795
+msgid ""
+"A description of how this software compares to other commonly-used "
+"packages in this research area."
+msgstr ""
+
+#: ../../review_criteria.md:11 290b1f2a97d344c491ef92b86b97498c
+msgid ""
+"Mentions (if applicable) of any ongoing research projects using the "
+"software or recent scholarly publications enabled by it."
+msgstr ""
+
+#: ../../review_criteria.md:12 862c8f7394104c96ac6b7900f1014999
+msgid "A list of key references including a link to the software archive."
+msgstr ""
+
+#: ../../review_criteria.md:15 d387e6729d58447da57400ea805b9ddc
+msgid ""
+"Note the paper *should not* include software documentation such as API "
+"(Application Programming Interface) functionality, as this should be "
+"outlined in the software documentation."
+msgstr ""
+
+#: ../../review_criteria.md:18 c3c635e88b274a3086ddda3ad4b1e176
+msgid "Review items"
+msgstr ""
+
+#: ../../review_criteria.md:21 c677627ec8a34ec7a23f7c58e5c70b10
+msgid ""
+"Note, if you've not yet been involved in a JOSS review, you can see an "
+"example JOSS review checklist [here](review_checklist)."
+msgstr ""
+
+#: ../../review_criteria.md:24 066ba8aa557d4a598cea9d5f302fe406
+msgid "Software license"
+msgstr ""
+
+#: ../../review_criteria.md:26 29bfcd0a730a42a6b230d4ab11897725
+msgid ""
+"There should be an [OSI "
+"approved](https://opensource.org/licenses/alphabetical) license included "
+"in the repository. Common licenses such as those listed on "
+"[choosealicense.com](https://choosealicense.com) are preferred. Note "
+"there should be an actual license file present in the repository not just"
+" a reference to the license."
+msgstr ""
+
+#: ../../review_criteria.md:28 c6803cd60a494344846c83ad030e05e9
+msgid ""
+"**Acceptable:** A plain-text LICENSE or COPYING file with the contents of"
+" an OSI approved license<br />             **Not acceptable:** A phrase "
+"such as 'MIT license' in a README file"
+msgstr ""
+
+#: ../../review_criteria.md:31 04833d2d9e924b539b619745a7a9cd0d
+msgid "Substantial scholarly effort"
+msgstr ""
+
+#: ../../review_criteria.md:33 30bac5e4746e4f448ac0115fb7e272a1
+msgid ""
+"Reviewers should verify that the software represents substantial "
+"scholarly effort. As a rule of thumb, JOSS' minimum allowable "
+"contribution should represent **not less than** three months of work for "
+"an individual. Signals of effort may include:"
+msgstr ""
+
+#: ../../review_criteria.md:35 7477cde373f0429480d60affc9bd8f25
+msgid ""
+"Age of software (is this a well-established software project) / length of"
+" commit history."
+msgstr ""
+
+#: ../../review_criteria.md:36 0cf8268b8f464abf9c8c17f76fadc30a
+msgid "Number of commits."
+msgstr ""
+
+#: ../../review_criteria.md:37 c674174db0f24c299a27e7def881586a
+msgid "Number of authors."
+msgstr ""
+
+#: ../../review_criteria.md:38 a40a69e54f2347069f5f48bce39d053a
+msgid ""
+"Lines of code (LOC): These statistics are usually reported by "
+"EditorialBot in the `pre-review` issue thread."
+msgstr ""
+
+#: ../../review_criteria.md:39 824bad6c28e34daf8cc2af69e6834cc0
+msgid "Whether the software has already been cited in academic papers."
+msgstr ""
+
+#: ../../review_criteria.md:40 9cac14af8bd34ff9b14aca3dadb45d9c
+msgid ""
+"Whether the software is sufficiently useful that it is _likely to be "
+"cited_ by other researchers working in this domain."
+msgstr ""
+
+#: ../../review_criteria.md:42 c7e64a5ebbe54d2f8df4184127bbefc8
+msgid ""
+"These guidelines are not meant to be strictly prescriptive. Recently "
+"released software may not have been around long enough to gather "
+"citations in academic literature. While some authors contribute openly "
+"and accrue a long and rich commit history before submitting, others may "
+"upload their software to GitHub shortly before submitting their JOSS "
+"paper.  Reviewers should rely on their expert understanding of their "
+"domain to judge whether the software is of broad interest (_likely to be "
+"cited by other researchers_) or more narrowly focused around the needs of"
+" an individual researcher or lab."
+msgstr ""
+
+#: ../../review_criteria.md:45 14e061e917a34d84bd1b45fbd683c521
+msgid ""
+"The decision on scholarly effort is ultimately one made by JOSS editors. "
+"Reviewers are asked to flag submissions of questionable scope during the "
+"review process so that the editor can bring this to the attention of the "
+"JOSS editorial team."
+msgstr ""
+
+#: ../../review_criteria.md:48 bc63b89e20f54816b2c6fa2bd7631a72
+msgid "Documentation"
+msgstr ""
+
+#: ../../review_criteria.md:50 762d838e2b6342e2aa20e552cff0281c
+msgid ""
+"There should be sufficient documentation for you, the reviewer to "
+"understand the core functionality of the software under review. A high-"
+"level overview of this documentation should be included in a `README` "
+"file (or equivalent). There should be:"
+msgstr ""
+
+#: ../../review_criteria.md:52 cdbfad5d318f495ca77ff18e66a48c26
+msgid "A statement of need"
+msgstr ""
+
+#: ../../review_criteria.md:54 b64bdb4ac55d45f281f55d3a240ce249
+msgid ""
+"The authors should clearly state what problems the software is designed "
+"to solve, who the target audience is, and its relation to other work."
+msgstr ""
+
+#: ../../review_criteria.md:56 b94ecbcfa45a42c7a68caca936983ff2
+msgid "Installation instructions"
+msgstr ""
+
+#: ../../review_criteria.md:58 04c1fd41940943a0b240a2426431c51d
+msgid ""
+"Software dependencies should be clearly documented and their installation"
+" handled by an automated procedure. Where possible, software installation"
+" should be managed with a package manager. However, this criterion "
+"depends upon the maturity and availability of software packaging and "
+"distribution in the programming language being used. For example, Python "
+"packages should be `pip install`able, and have adopted [packaging "
+"conventions](https://packaging.python.org), while Fortran submissions "
+"with a Makefile may be sufficient."
+msgstr ""
+
+#: ../../review_criteria.md:60 423ec8bc924d45e3a8a68f1a52ba46ad
+msgid ""
+"**Good:** The software is simple to install, and follows established "
+"distribution and dependency management approaches for the language being "
+"used<br /> **OK:** A list of dependencies to install, together with some "
+"kind of script to handle their installation (e.g., a Makefile)<br /> "
+"**Bad (not acceptable):** Dependencies are unclear, and/or installation "
+"process lacks automation"
+msgstr ""
+
+#: ../../review_criteria.md:64 99c4a218ff0b475d8fb1519284276fd9
+msgid "Example usage"
+msgstr ""
+
+#: ../../review_criteria.md:66 93205fb027ac4d7ab35b410f0128cb4a
+msgid ""
+"The authors should include examples of how to use the software (ideally "
+"to solve real-world analysis problems)."
+msgstr ""
+
+#: ../../review_criteria.md:68 cf0cd14d290d47439729b5d22edfd9e2
+msgid "API documentation"
+msgstr ""
+
+#: ../../review_criteria.md:70 742f31db489740669c3b2daeeef92d17
+msgid ""
+"Reviewers should check that the software API is documented to a suitable "
+"level."
+msgstr ""
+
+#: ../../review_criteria.md:72 bb9dd3804e264b9888e5628d92711333
+msgid ""
+"**Good:** All functions/methods are documented including example inputs "
+"and outputs<br /> **OK:** Core API functionality is documented<br /> "
+"**Bad (not acceptable):** API is undocumented"
+msgstr ""
+
+#: ../../review_criteria.md:77 7ca53aa3538c4b46a4332b7cfe5c2195
+msgid ""
+"The decision on API documentation is left largely to the discretion of "
+"the reviewer and their experience of evaluating the software."
+msgstr ""
+
+#: ../../review_criteria.md:80 4f72d30f771d4d7f8a552288047c7258
+msgid "Community guidelines"
+msgstr ""
+
+#: ../../review_criteria.md:82 366133c9c36a4406a00140fdff344f46
+msgid "There should be clear guidelines for third-parties wishing to:"
+msgstr ""
+
+#: ../../review_criteria.md:84 3cfd6451af164fd8acc6792d2319d05a
+msgid "Contribute to the software"
+msgstr ""
+
+#: ../../review_criteria.md:85 387acec0c9134ec99118b0a4a0b7de4e
+msgid "Report issues or problems with the software"
+msgstr ""
+
+#: ../../review_criteria.md:86 e862f9edf72a4cd6869dab2578a0ddf4
+msgid "Seek support"
+msgstr ""
+
+#: ../../review_criteria.md:88 ac41672935d7481fb21fcd597a34fb5d
+msgid "Functionality"
+msgstr ""
+
+#: ../../review_criteria.md:90 ec0fd30c7a7e4f36bfc8b38410305be9
+msgid ""
+"Reviewers are expected to install the software they are reviewing and to "
+"verify the core functionality of the software."
+msgstr ""
+
+#: ../../review_criteria.md:92 f090de964a8c43e0a8c990ee6d4800da
+msgid "Tests"
+msgstr ""
+
+#: ../../review_criteria.md:94 e65f9d63fb1a48d08d5ce15aa49f9735
+msgid ""
+"Authors are strongly encouraged to include an automated test suite "
+"covering the core functionality of their software."
+msgstr ""
+
+#: ../../review_criteria.md:96 089c873fc04040bfb2ee1834edf23802
+msgid ""
+"**Good:** An automated test suite hooked up to continuous integration "
+"(GitHub Actions, Circle CI, or similar)<br /> **OK:** Documented manual "
+"steps that can be followed to objectively check the expected "
+"functionality of the software (e.g., a sample input file to assert "
+"behavior)<br /> **Bad (not acceptable):** No way for you, the reviewer, "
+"to objectively assess whether the software works"
+msgstr ""
+
+#: ../../review_criteria.md:100 ebb1b4031d094c5594972efd0a2a835b
+msgid "Other considerations"
+msgstr ""
+
+#: ../../review_criteria.md:102 86cfff0974ac429bb5f3b5a0ffcc5761
+msgid "Authorship"
+msgstr ""
+
+#: ../../review_criteria.md:104 fb9888066a4044ffbf7d1021d1ab3fa4
+msgid ""
+"As part of the review process, you are asked to check whether the "
+"submitting author has made a 'substantial contribution' to the submitted "
+"software (as determined by the commit history) and to check that 'the "
+"full list of paper authors seems appropriate and complete?'"
+msgstr ""
+
+#: ../../review_criteria.md:106 a1199fe7c5144a11a60643dd829bfe6d
+msgid ""
+"As discussed in the [submission guidelines for "
+"authors](submitting.md#authorship), authorship is a complex topic with "
+"different practices in different communities.  Ultimately, the authors "
+"themselves are responsible for deciding which contributions are "
+"sufficient for co-authorship, although JOSS policy is that purely "
+"financial contributions are not considered sufficient. Your job as a "
+"reviewer is to check that the list of authors appears reasonable, and if "
+"it's not obviously complete/correct, to raise this as a question during "
+"the review."
+msgstr ""
+
+#: ../../review_criteria.md:108 2a98da4cffce4906ab6de24f09322c25
+msgid "An important note about 'novel' software and citations of relevant work"
+msgstr ""
+
+#: ../../review_criteria.md:110 525c4a7e843147fe99eddcd11fff5fbe
+msgid ""
+"Submissions that implement solutions already solved in other software "
+"packages are accepted into JOSS provided that they meet the criteria "
+"listed above and cite prior similar work. Reviewers should point out "
+"relevant published work which is not yet cited."
+msgstr ""
+
+#: ../../review_criteria.md:112 3f8680b3074b45cd8c9d73cb69ffb1cb
+msgid "What happens if the software I'm reviewing doesn't meet the JOSS criteria?"
+msgstr ""
+
+#: ../../review_criteria.md:114 0f4ae26b8fa2418393f9280bfde27152
+msgid ""
+"We ask that reviewers grade submissions in one of three categories: 1) "
+"Accept 2) Minor Revisions 3) Major Revisions. Unlike some journals we do "
+"not reject outright submissions requiring major revisions - we're more "
+"than happy to give the author as long as they need to make these "
+"modifications/improvements."
+msgstr ""
+
+#: ../../review_criteria.md:116 2d3fb95950504a8f9805e879737a7f0d
+msgid ""
+"What about submissions that rely upon proprietary languages/development "
+"environments?"
+msgstr ""
+
+#: ../../review_criteria.md:118 28a5400b4e234c6f8656ae98057b751f
+msgid ""
+"As outlined in our author guidelines, submissions that rely upon a "
+"proprietary/closed source language or development environment are "
+"acceptable provided that they meet the other submission requirements and "
+"that you, the reviewer, are able to install the software & verify the "
+"functionality of the submission as required by our reviewer guidelines."
+msgstr ""
+
+#: ../../review_criteria.md:120 9d2bcdbbff5a40e68ed6cfb4a3f30852
+msgid ""
+"If an open source or free variant of the programming language exists, "
+"feel free to encourage the submitting author to consider making their "
+"software compatible with the open source/free variant."
+msgstr ""
+
+#: ../../review_criteria.md:122 b48c8ad73ef84644ab7f489a5335dd18
+msgid "Where can the repository be hosted?"
+msgstr ""
+
+#: ../../review_criteria.md:124 239c57cd8c514639a01b029768e59a6e
+msgid ""
+"Repositories must be hosted at a location that allows outside users to "
+"freely open issues and propose code changes, such as GitHub, GitLab, "
+"Bitbucket, etc. Submissions will not be accepted if the repository is "
+"hosted at a location where accounts must be manually approved (or paid "
+"for), regardless of if this approval is done by the owners of the "
+"repository or some other entity."
+msgstr ""
+

--- a/docs/locale/nb/LC_MESSAGES/reviewer_guidelines.po
+++ b/docs/locale/nb/LC_MESSAGES/reviewer_guidelines.po
@@ -1,0 +1,129 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: nb\n"
+"Language-Team: nb <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../reviewer_guidelines.md:1 a419474b5d484081ac03bf756dc47be2
+msgid "Reviewing for JOSS"
+msgstr ""
+
+#: ../../reviewer_guidelines.md:3 6f0fdd54d4174b4595d47c2b51ca3d61
+msgid ""
+"Firstly, thank you so much for agreeing to review for the Journal of Open"
+" Source Software (JOSS), we're delighted to have your help. This document"
+" is designed to outline our editorial guidelines and help you understand "
+"our requirements for accepting a submission into the JOSS. Our review "
+"process is based on a tried-and-tested approach of the [rOpenSci "
+"collaboration](http://ropensci.org/blog/2016/03/28/software-review)."
+msgstr ""
+
+#: ../../reviewer_guidelines.md:5 d5e8babfd2064983aa963d6a55fe50fa
+msgid "Guiding principles"
+msgstr ""
+
+#: ../../reviewer_guidelines.md:7 e9542046504d4ac8a187bd3008f57960
+msgid ""
+"We like to think of JOSS as a 'developer friendly' journal. That is, if "
+"the submitting authors have followed best practices (have documentation, "
+"tests, continuous integration, and a license) then their review should be"
+" rapid."
+msgstr ""
+
+#: ../../reviewer_guidelines.md:9 c4a4f8320cda4a24885dcce346f51047
+msgid ""
+"For those submissions that don't quite meet the bar, please try to give "
+"clear feedback on how authors could improve their submission. A key goal "
+"of JOSS is to raise the quality of research software generally and you "
+"(the experienced reviewer) are well placed to give this feedback."
+msgstr ""
+
+#: ../../reviewer_guidelines.md:11 c0da10831e7e434abf4b8a055a939ea5
+msgid ""
+"A JOSS review involves checking submissions against a checklist of "
+"essential software features and details in the submitted paper. This "
+"should be objective, not subjective; it should be based on the materials "
+"in the submission as perceived without distortion by personal feelings, "
+"prejudices, or interpretations."
+msgstr ""
+
+#: ../../reviewer_guidelines.md:13 f8fcae6e6d2149468bfe9f42b965a85d
+msgid ""
+"We encourage reviewers to file issues against the submitted repository's "
+"issue tracker. **When you have completed your review, please leave a "
+"comment in the review issue saying so.**"
+msgstr ""
+
+#: ../../reviewer_guidelines.md:15 1e6f2e4fec2d44178087bb2565ae4b21
+msgid ""
+"You can include in your review links to any new issues that you the "
+"reviewer believe to be impeding the acceptance of the repository. "
+"(Similarly, if the submitted repository is a GitHub repository, "
+"mentioning the review issue URL in the submitted repository's issue "
+"tracker will create a mention in the review issue's history.)"
+msgstr ""
+
+#: ../../reviewer_guidelines.md:17 efc7dd0cb2b94f26bc26af6c2c612cb5
+msgid "JOSS Conflict of Interest Policy"
+msgstr ""
+
+#: ../../reviewer_guidelines.md:19 579958bd5d754abea42dacc3dfbb13be
+msgid ""
+"The definition of a conflict of Interest in peer review is a circumstance"
+" that makes you \"unable to make an impartial scientific judgment or "
+"evaluation.\" ([PNAS Conflict of Interest "
+"Policy](http://www.pnas.org/site/authors/coi.xhtml)). JOSS is concerned "
+"with avoiding any actual conflicts of interest, and being sufficiently "
+"transparent that we avoid the appearance of conflicts of interest as "
+"well."
+msgstr ""
+
+#: ../../reviewer_guidelines.md:21 2bcd98fbb8054a0493f210435d102957
+msgid ""
+"As a reviewer (or editor), COIs are your present or previous association "
+"with any authors of a submission: recent (past four years) collaborators "
+"in funded research or work that is published; and lifetime for the family"
+" members, business partners, and thesis student/advisor or mentor. In "
+"addition, your recent (past year) association with the same organization "
+"of a submitter is a COI, for example, being employed at the same "
+"institution."
+msgstr ""
+
+#: ../../reviewer_guidelines.md:23 3e219416fb1b41f6be1daed87f710feb
+msgid ""
+"If you have a conflict of interest with a submission, you should disclose"
+" the specific reason to the submissions' editor (or to an EiC if you are "
+"an editor, or to the other EiCs if you are an EiC). This may lead to you "
+"not being able to review or edit the submission, but some conflicts may "
+"be recorded and then waived, and if you think you are able to make an "
+"impartial assessment of the work, you should request that the conflict be"
+" waived. For example, if you and a submitter were two of 2000 authors of "
+"a high energy physics paper but did not actually collaborate. Or if you "
+"and a submitter worked together 6 years ago, but due to delays in the "
+"publishing industry, a paper from that collaboration with both of you as "
+"authors was published 2 years ago. Or if you and a submitter are both "
+"employed by the same very large organization but in different units "
+"without any knowledge of each other."
+msgstr ""
+
+#: ../../reviewer_guidelines.md:25 20b6775665854597b7c9a1e07e37d175
+msgid ""
+"Declaring actual, perceived, and potential conflicts of interest is "
+"required under professional ethics. If in doubt: ask the editors."
+msgstr ""
+

--- a/docs/locale/nb/LC_MESSAGES/sample_messages.po
+++ b/docs/locale/nb/LC_MESSAGES/sample_messages.po
@@ -1,0 +1,53 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: nb\n"
+"Language-Team: nb <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../sample_messages.md:1 cef95ca5eb52466087ac6592b8313bc2
+msgid "Sample messages for authors and reviewers"
+msgstr ""
+
+#: ../../sample_messages.md:3 4cc65d85532a4849b89d03bd9f2df182
+msgid "Sample email to potential reviewers"
+msgstr ""
+
+#: ../../sample_messages.md:38 75d2d7121efb4d739fc9ccee78cd9590
+msgid "Query scope of submission"
+msgstr ""
+
+#: ../../sample_messages.md:50 b1bf7b7a0f1a4a308ace2cc4ae649d71
+msgid "GitHub invite to potential reviewers"
+msgstr ""
+
+#: ../../sample_messages.md:56 88bea41bab0f4aa68bd78b43f506f193
+msgid "Message to reviewers at the start of a review"
+msgstr ""
+
+#: ../../sample_messages.md:76 2fed1a4176bd444f8e00e87dd5bb5521
+msgid "Message to authors at the end of a review"
+msgstr ""
+
+#: ../../sample_messages.md:88 c726398e48664dbc97293c9d76bd2ed6
+msgid "Rejection due to out of scope/failing substantial scholarly effort test"
+msgstr ""
+
+#: ../../sample_messages.md:90 1813d0630c2b491e816e004cf1e16d04
+msgid "(Note that rejections are handled by EiCs and not individual editors)."
+msgstr ""
+

--- a/docs/locale/nb/LC_MESSAGES/submitting.po
+++ b/docs/locale/nb/LC_MESSAGES/submitting.po
@@ -1,0 +1,527 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: nb\n"
+"Language-Team: nb <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../submitting.md:1 71cbc32ad5bf43439a801a3bd72ab616
+msgid "Submitting a paper to JOSS"
+msgstr ""
+
+#: ../../submitting.md:3 ce6cc30f0f5742389088b8ca91bf4cea
+msgid ""
+"If you've already developed a fully featured research code, released it "
+"under an [OSI-approved license](https://opensource.org/licenses), and "
+"written good documentation and tests, then we expect that it should take "
+"perhaps an hour or two to prepare and submit your paper to JOSS. But "
+"please read these instructions carefully for a streamlined submission."
+msgstr ""
+
+#: ../../submitting.md:6 be732c65a672404fb848550294f9dd33
+msgid "Submission requirements"
+msgstr ""
+
+#: ../../submitting.md:8 fd0c74f034f8459bbc39cd47a2179404
+msgid ""
+"The software must be open source as per the [OSI "
+"definition](https://opensource.org/osd)."
+msgstr ""
+
+#: ../../submitting.md:9 177b6f6b577848b081b1b3a885a0fc34
+msgid ""
+"The software must be hosted at a location where users can open issues and"
+" propose code changes without manual approval of (or payment for) "
+"accounts."
+msgstr ""
+
+#: ../../submitting.md:10 81033d1871ec4a14a360bd8427c4061e
+msgid "The software must have an **obvious** research application."
+msgstr ""
+
+#: ../../submitting.md:11 e2fa627d3e534e168ccd394e8e1aa99b
+msgid ""
+"You must be a major contributor to the software you are submitting, and "
+"have a GitHub account to participate in the review process."
+msgstr ""
+
+#: ../../submitting.md:12 9eb67b83630b41558fdab6b507408a07
+msgid ""
+"Your paper must not focus on new research results accomplished with the "
+"software."
+msgstr ""
+
+#: ../../submitting.md:13 7a7b9c123a364cec93888316cee67854
+msgid ""
+"Your paper (`paper.md` and BibTeX files, plus any figures) must be hosted"
+" in a Git-based repository together with your software."
+msgstr ""
+
+#: ../../submitting.md:14 1966b52d0e7942228fe11f836d43911e
+msgid ""
+"The paper may be in a short-lived branch which is never merged with the "
+"default, although if you do this, make sure this branch is _created_ from"
+" the default so that it also includes the source code of your submission."
+msgstr ""
+
+#: ../../submitting.md:16 4522f942cd214907949aae02b4c51bb0
+msgid "In addition, the software associated with your submission must:"
+msgstr ""
+
+#: ../../submitting.md:18 7f9d57e5b3f941b496a57903370962f1
+msgid "Be stored in a repository that can be cloned without registration."
+msgstr ""
+
+#: ../../submitting.md:19 195c2e675de44629a06315c28b1c3942
+msgid "Be stored in a repository that is browsable online without registration."
+msgstr ""
+
+#: ../../submitting.md:20 92aafa33002e4bab93d1636798edac83
+msgid "Have an issue tracker that is readable without registration."
+msgstr ""
+
+#: ../../submitting.md:21 481c9906fc414102850fd47d4387a1d5
+msgid "Permit individuals to create issues/file tickets against your repository."
+msgstr ""
+
+#: ../../submitting.md:23 30106fab445b4df49a92acc026401e20
+msgid "What we mean by research software"
+msgstr ""
+
+#: ../../submitting.md:25 c90e60057d834a2494df62e9d7687a23
+msgid ""
+"JOSS publishes articles about research software. This definition includes"
+" software that: solves complex modeling problems in a scientific context "
+"(physics, mathematics, biology, medicine, social science, neuroscience, "
+"engineering); supports the functioning of research instruments or the "
+"execution of research experiments; extracts knowledge from large data "
+"sets; offers a mathematical library, or similar. While useful for many "
+"areas of research, pre-trained machine learning models and notebooks are "
+"not in-scope for JOSS."
+msgstr ""
+
+#: ../../submitting.md:27 ae9ca5bd94884dd8bd0327ed4cbfcee9
+msgid "Substantial scholarly effort"
+msgstr ""
+
+#: ../../submitting.md:29 4df6f96e766b4979b64a65dd02ee1d04
+msgid ""
+"JOSS publishes articles about software that represent substantial "
+"scholarly effort on the part of the authors. Your software should be a "
+"significant contribution to the available open source software that "
+"either enables some new research challenges to be addressed or makes "
+"addressing research challenges significantly better (e.g., faster, "
+"easier, simpler)."
+msgstr ""
+
+#: ../../submitting.md:31 6e18cc918f19432faf5ccbedff57edfb
+msgid ""
+"As a rule of thumb, JOSS' minimum allowable contribution should represent"
+" **not less than** three months of work for an individual. Some factors "
+"that may be considered by editors and reviewers when judging effort "
+"include:"
+msgstr ""
+
+#: ../../submitting.md:33 9b107a1e586d4d9bb3435aa25c7b078a
+msgid ""
+"Age of software (is this a well-established software project) / length of"
+" commit history."
+msgstr ""
+
+#: ../../submitting.md:34 7ec26d3e19fa408a813b80a864297808
+msgid "Number of commits."
+msgstr ""
+
+#: ../../submitting.md:35 44355accc3ff464d88a9b0993cf9fad2
+msgid "Number of authors."
+msgstr ""
+
+#: ../../submitting.md:36 5a295caed8b0403ca4c94f914ab90722
+msgid ""
+"Total lines of code (LOC). Submissions under 1000 LOC will usually be "
+"flagged, those under 300 LOC will be desk rejected."
+msgstr ""
+
+#: ../../submitting.md:37 8da115eebe0147d1810885380da53882
+msgid "Whether the software has already been cited in academic papers."
+msgstr ""
+
+#: ../../submitting.md:38 3c7ffb04490d4e70b2deede95f59a3ea
+msgid ""
+"Whether the software is sufficiently useful that it is _likely to be "
+"cited_ by your peer group."
+msgstr ""
+
+#: ../../submitting.md:40 ca3f0849aa9c49a7827756a6b0279698
+msgid ""
+"In addition, JOSS requires that software should be feature-complete "
+"(i.e., no half-baked solutions), packaged appropriately according to "
+"common community standards for the programming language being used (e.g.,"
+" [Python](https://packaging.python.org), "
+"[R](https://r-pkgs.org/index.html)), and designed for maintainable "
+"extension (not one-off modifications of existing tools). \"Minor "
+"utility\" packages, including \"thin\" API clients, and single-function "
+"packages are not acceptable."
+msgstr ""
+
+#: ../../submitting.md:42 05900ce680f74068b3d2b2234e835913
+msgid "A note on web-based software"
+msgstr ""
+
+#: ../../submitting.md:44 0fa3a80b5753418eb40586ad94d41213
+#, python-format
+msgid ""
+"Many web-based research tools are out of scope for JOSS due to a lack of "
+"modularity and challenges testing and maintaining the code. Web-based "
+"tools may be considered 'in scope' for JOSS, provided that they meet one "
+"or both of the following criteria: 1) they are are built around and "
+"expose a 'core library' through a web-based experience (e.g., "
+"R/[Shiny](https://www.rstudio.com/products/shiny/) applications) or 2) "
+"the web application demonstrates a high-level of rigor with respect to "
+"domain modeling and testing (e.g., adopts and implements a design pattern"
+" such as "
+"[MVC](https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93controller)"
+" using a framework such as [Django](https://www.djangoproject.com/))."
+msgstr ""
+
+#: ../../submitting.md:46 a7a177222c5a4338af4683c9e830e978
+msgid ""
+"Similar to other categories of submission to JOSS, it's essential that "
+"any web-based tool can be tested easily by reviewers locally (i.e., on "
+"their local machine)."
+msgstr ""
+
+#: ../../submitting.md:48 e062985b56ee4940a02dafc8d0110f03
+msgid "Co-publication of science, methods, and software"
+msgstr ""
+
+#: ../../submitting.md:50 7463266f25d24104b732b5cc847b5739
+msgid ""
+"Sometimes authors prepare a JOSS publication alongside a contribution "
+"describing a science application, details of algorithm development, "
+"and/or methods assessment. In this circumstance, JOSS considers "
+"submissions for which the implementation of the software itself reflects "
+"a substantial scientific effort. This may be represented by the design of"
+" the software, the implementation of the algorithms, creation of "
+"tutorials, or any other aspect of the software. We ask that authors "
+"indicate whether related publications (published, in review, or nearing "
+"submission) exist as part of submitting to JOSS."
+msgstr ""
+
+#: ../../submitting.md:52 980ec3e752254675a5fcbba6fe1d427f
+msgid "Other venues for reviewing and publishing software packages"
+msgstr ""
+
+#: ../../submitting.md:54 885a143d4e9e4b068ccc4368d41e1fc0
+msgid ""
+"Authors wishing to publish software deemed out of scope for JOSS have a "
+"few options available to them:"
+msgstr ""
+
+#: ../../submitting.md:56 43ba4588359841f0933b8f80396d0a3d
+msgid ""
+"Follow [GitHub's guide](https://guides.github.com/activities/citable-"
+"code/) on how to create a permanent archive and DOI for your software. "
+"This DOI can then be used by others to cite your work."
+msgstr ""
+
+#: ../../submitting.md:57 0c1921b7858540afbed5f145221c4e4c
+msgid ""
+"Enquire whether your software might be considered by communities such as "
+"[rOpenSci](https://ropensci.org) and [pyOpenSci](https://pyopensci.org)."
+msgstr ""
+
+#: ../../submitting.md:59 4201ae50bb354bcabc952a4933fbaffd
+msgid "Should I write my own software or contribute to an existing package?"
+msgstr ""
+
+#: ../../submitting.md:61 c295535022b642cfb470639de383178a
+msgid ""
+"While we are happy to review submissions in standalone repositories, we "
+"also review submissions that are significant contributions made to "
+"existing packages. It is often better to have an integrated library or "
+"package of methods than a large number of single-method packages."
+msgstr ""
+
+#: ../../submitting.md:63 0201c8f9c91d490ab4e4f5574774e250
+msgid "Policies"
+msgstr ""
+
+#: ../../submitting.md:65 aa37ca3febd7418cb10d12b2b82ea741
+msgid ""
+"**Disclosure:** All authors must disclose any potential conflicts of "
+"interest related to the research in their manuscript, including "
+"financial, personal, or professional relationships that may affect their "
+"objectivity. This includes any financial relationships, such as "
+"employment, consultancies, honoraria, stock ownership, or other financial"
+" interests that may be relevant to the research."
+msgstr ""
+
+#: ../../submitting.md:67 7da66e89310a4a368f5e5d13db4598c4
+msgid ""
+"**Acknowledgement:** Authors should acknowledge all sources of financial "
+"support for the work and include a statement indicating whether or not "
+"the sponsor had any involvement in it."
+msgstr ""
+
+#: ../../submitting.md:69 676858145ce44bd88f2d1acc8e00303e
+msgid ""
+"**Review process:** Editors and reviewers must be informed of any "
+"potential conflicts of interest before reviewing the manuscript to ensure"
+" unbiased evaluation of the research."
+msgstr ""
+
+#: ../../submitting.md:71 e17ce766ddf54a99a34152e02f590de6
+msgid ""
+"**Compliance:** Authors who fail to comply with the COI policy may have "
+"their manuscript rejected or retracted if a conflict is discovered after "
+"publication."
+msgstr ""
+
+#: ../../submitting.md:73 f082af420013469ea87e5e47602ede5b
+msgid ""
+"**Review and Update:** This COI policy will be reviewed and updated "
+"regularly to ensure it remains relevant and effective."
+msgstr ""
+
+#: ../../submitting.md:75 1b6123be3aa9458ca1abe472bfc6a73a
+msgid "Conflict of Interest policy for authors"
+msgstr ""
+
+#: ../../submitting.md:77 dfe5a74b60e840fab111d4a239be2092
+msgid ""
+"An author conflict of interest (COI) arises when an author has financial,"
+" personal, or other interests that may influence their research or the "
+"interpretation of its results. In order to maintain the integrity of the "
+"work published in JOSS, we require that authors disclose any potential "
+"conflicts of interest at submission time."
+msgstr ""
+
+#: ../../submitting.md:79 eae21d8642ae4e06893e671d7e50b8a8
+msgid "Preprint Policy"
+msgstr ""
+
+#: ../../submitting.md:81 d34627f972a0467195f060a48e97035f
+msgid ""
+"Authors are welcome to submit their papers to a preprint server "
+"([arXiv](https://arxiv.org/), [bioRxiv](https://www.biorxiv.org/), "
+"[SocArXiv](https://socopen.org/), [PsyArXiv](https://psyarxiv.com/) etc.)"
+" at any point before, during, or after the submission and review process."
+msgstr ""
+
+#: ../../submitting.md:83 d7139daf4aee486cb97d6ce667ee7f03
+msgid ""
+"Submission to a preprint server is _not_ considered a previous "
+"publication."
+msgstr ""
+
+#: ../../submitting.md:85 dd31368d70844c2ba70ddf4e0fc3aa1b
+msgid "Authorship"
+msgstr ""
+
+#: ../../submitting.md:87 080b12bc710e4465b136748026764e6b
+msgid ""
+"Purely financial (such as being named on an award) and organizational "
+"(such as general supervision of a research group) contributions are not "
+"considered sufficient for co-authorship of JOSS submissions, but active "
+"project direction and other forms of non-code contributions are. The "
+"authors themselves assume responsibility for deciding who should be "
+"credited with co-authorship, and co-authors must always agree to be "
+"listed. In addition, co-authors agree to be accountable for all aspects "
+"of the work, and to notify JOSS if any retraction or correction of "
+"mistakes are needed after publication."
+msgstr ""
+
+#: ../../submitting.md:89 155e841452dc4a03a996f9cad264c0fe
+msgid "Submissions using proprietary languages/development environments"
+msgstr ""
+
+#: ../../submitting.md:91 2da8c3a5108b445886c4fd0fa14f1706
+msgid ""
+"We strongly prefer software that doesn't rely upon proprietary (paid for)"
+" development environments/programming languages. However, provided _your "
+"submission meets our requirements_ (including having a valid open source "
+"license) then we will consider your submission for review. Should your "
+"submission be accepted for review, we may ask you, the submitting author,"
+" to help us find reviewers who already have the required development "
+"environment installed."
+msgstr ""
+
+#: ../../submitting.md:93 3a154b0142da47ef977734c5cae46c2f
+msgid "Submission Process"
+msgstr ""
+
+#: ../../submitting.md:95 aedcc91a3841485683a22414ecccae2f
+msgid "Before you submit, you should:"
+msgstr ""
+
+#: ../../submitting.md:97 5ec969a179bb454c8c059c7ba7e35f1b
+msgid ""
+"Make your software available in an open repository (GitHub, Bitbucket, "
+"etc.) and include an [OSI approved open source "
+"license](https://opensource.org/licenses)."
+msgstr ""
+
+#: ../../submitting.md:98 9f5479a2846e4f2dada98e900de5d858
+msgid ""
+"Make sure that the software complies with the [JOSS review "
+"criteria](review_criteria). In particular, your software should be full-"
+"featured, well-documented, and contain procedures (such as automated "
+"tests) for checking correctness."
+msgstr ""
+
+#: ../../submitting.md:99 b18084fdb5764ba38ab6bfb4f7829dd9
+msgid ""
+"Write a short paper in Markdown format using `paper.md` as file name, "
+"including a title, summary, author names, affiliations, and key "
+"references. See our [example paper](example_paper) to follow the correct "
+"format."
+msgstr ""
+
+#: ../../submitting.md:100 f91d9e13cd814e0e9aceb3888e5ee21d
+msgid ""
+"(Optional) create a metadata file describing your software and include it"
+" in your repository. We provide [a "
+"script](https://gist.github.com/arfon/478b2ed49e11f984d6fb) that "
+"automates the generation of this metadata."
+msgstr ""
+
+#: ../../submitting.md:102 a075ecd3fbca4896b053977cb2c441fa
+msgid "Submitting your paper"
+msgstr ""
+
+#: ../../submitting.md:104 7129a25f2dfb445da6465a68a9d5cb73
+msgid "Submission is as simple as:"
+msgstr ""
+
+#: ../../submitting.md:106 7616900c2ae54bf1aa3d7266b05129ff
+msgid "Filling in the [short submission form](http://joss.theoj.org/papers/new)"
+msgstr ""
+
+#: ../../submitting.md:107 a99c4e5802ea4f85bc8826256000daf1
+msgid ""
+"Waiting for the managing editor to start a pre-review issue over in the "
+"JOSS reviews repository: https://github.com/openjournals/joss-reviews"
+msgstr ""
+
+#: ../../submitting.md:109 3586343bfb9d4d36b0500ffbe6476716
+msgid "No submission fees"
+msgstr ""
+
+#: ../../submitting.md:111 fa914426586e4013a9774d2a273fa493
+msgid ""
+"There are no fees for submitting or publishing in JOSS. You can read more"
+" about our [cost and sustainability "
+"model](http://joss.theoj.org/about#costs)."
+msgstr ""
+
+#: ../../submitting.md:113 1890cf9ebb07463d855f2321ef97a341
+msgid "Review Process"
+msgstr ""
+
+#: ../../submitting.md:115 fad65e22fa3d4763a8364dc654735ed6
+msgid "After submission:"
+msgstr ""
+
+#: ../../submitting.md:117 7ef0f9d383394a039c02d02bccb37d7e
+msgid ""
+"An Associate Editor-in-Chief will carry out an initial check of your "
+"submission, and proceed to assign a handling editor."
+msgstr ""
+
+#: ../../submitting.md:118 b69093aef0544b7d986ab71eed8ecaf9
+msgid ""
+"The handling editor will assign two or more JOSS reviewers, and the "
+"review will be carried out in the [JOSS reviews "
+"repository](https://github.com/openjournals/joss-reviews)."
+msgstr ""
+
+#: ../../submitting.md:119 a124181eeaf14a21b56ee720011fcd6d
+msgid ""
+"Authors will respond to reviewer-raised issues (if any are raised) on the"
+" submission repository's issue tracker. Reviewer and editor "
+"contributions, like any other contributions, should be acknowledged in "
+"the repository."
+msgstr ""
+
+#: ../../submitting.md:120 42ce72f09737477f9734c8b21f653b97
+msgid ""
+"**JOSS reviews are iterative and conversational in nature.** Reviewers "
+"are encouraged to post comments/questions/suggestions in the review "
+"thread as they arise, and authors are expected to respond in a timely "
+"fashion."
+msgstr ""
+
+#: ../../submitting.md:121 ee84f73437f44e5b84c8d81a97a6fd18
+msgid ""
+"Authors and reviewers are asked to be patient when waiting for a response"
+" from an editor. Please allow a week for an editor to respond to a "
+"question before prompting them for further action."
+msgstr ""
+
+#: ../../submitting.md:122 5c004698eab4486798f76d010ab7555d
+msgid ""
+"Upon successful completion of the review, authors will make a tagged "
+"release of the software, and deposit a copy of the repository with a "
+"data-archiving service such as [Zenodo](https://zenodo.org/) or "
+"[figshare](https://figshare.com/), get a DOI for the archive, and update "
+"the review issue thread with the version number and DOI."
+msgstr ""
+
+#: ../../submitting.md:123 e9a1850c91664d9d82885b19f94c08c5
+msgid ""
+"After we assign a DOI for your accepted JOSS paper, its metadata is "
+"deposited with CrossRef and listed on the JOSS website."
+msgstr ""
+
+#: ../../submitting.md:124 f4726f1773f44fd5beed4c2e8d04a5ca
+msgid ""
+"The review issue will be closed, and automatic posts from [@JOSS_TheOJ at"
+" Twitter](https://twitter.com/JOSS_TheOJ) and [@JOSS at "
+"Mastodon](https://fosstodon.org/@joss) will announce it!"
+msgstr ""
+
+#: ../../submitting.md:126 ac2cccc96054481e9da17a5f7ab487a5
+msgid ""
+"If you want to learn more details about the review process, take a look "
+"at the [reviewer guidelines](reviewer_guidelines)."
+msgstr ""
+
+#: ../../submitting.md:128 918c5067728d42d0a81dbe095682832a
+msgid "Confidential requests"
+msgstr ""
+
+#: ../../submitting.md:130 04fed9904c5d40b4a5cf50ab9f708a60
+msgid ""
+"Please write admin@theoj.org with confidential matters such as retraction"
+" requests, report of misconduct, and retroactive author name changes."
+msgstr ""
+
+#: ../../submitting.md:132 c57a3a1aee824bd98b028fa7d25c43e9
+msgid ""
+"In the event of a name change request, the DOI will remain unchanged, and"
+" the paper will be updated without the publication of a correction "
+"notice. Please note that because JOSS submissions are managed publicly, "
+"updates to papers are visible in the public record (e.g., in the [JOSS "
+"papers repository](https://github.com/openjournals/joss-papers) commit "
+"history)."
+msgstr ""
+
+#: ../../submitting.md:134 d4ed5f2a5fe842b191c5708f33bf7e89
+msgid "JOSS will also update Crossref metadata."
+msgstr ""
+

--- a/docs/locale/nb/LC_MESSAGES/translating.po
+++ b/docs/locale/nb/LC_MESSAGES/translating.po
@@ -1,0 +1,124 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 13:00-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: nb\n"
+"Language-Team: nb <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../translating.md:1 dc0404984ec141be90f2c0ab0b08952e
+msgid "Contributing to Translation"
+msgstr ""
+
+#: ../../translating.md:3 436d651294454374ad5e679c4d227a60
+msgid ""
+"These docs and the main journal website welcome corrections or "
+"translations into additional languages."
+msgstr ""
+
+#: ../../translating.md:6 61edeeb8b3d4438a88d83dcbbf9a28f6
+msgid ""
+"Both are available in the same repository "
+"[openjournals/joss](https://github.com/openjournals/joss) with slightly "
+"different contributor workflows:"
+msgstr ""
+
+#: ../../translating.md:9 646240381af84c869dd9dcfd5910e4d3
+msgid "Python Docs"
+msgstr ""
+
+#: ../../translating.md:11 1bc1a234c2da449a90e5f6d7d1da7bfa
+msgid ""
+"The documents in the `docs` directory (this site) are built with `sphinx`"
+" and internationalized with `sphinx-intl`. These translations use "
+"standard `gettext`-style `.pot` and `.po` files."
+msgstr ""
+
+#: ../../translating.md:15 67377f2b156543c193d7089c35864d73
+msgid ""
+"The `.pot` files are generated from the source pages on each update and "
+"not versioned, and the translations are contained within `.po` files in "
+"the `locale` directory. A CI action ensures that any change to the "
+"english source text is reflected in the generated `.po` files."
+msgstr ""
+
+#: ../../translating.md:20 a71c1369388a4a9fa5f4359e8bcd71c9
+msgid "Adding a new language"
+msgstr ""
+
+#: ../../translating.md:22 b2f7d9c4ff87411a98ce8c5ea6aba22d
+msgid ""
+"Install the requirements, ideally in a virtual environment:  `python -m "
+"pip install -r requirements.txt`"
+msgstr ""
+
+#: ../../translating.md:24 6ec9f8d4512648af8911082fab6e2d3e
+msgid ""
+"Add a new "
+"[ISO-639](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes) "
+"code to the `languages` list in `conf.py`"
+msgstr ""
+
+#: ../../translating.md:26 1e4917f5f5df46ca84277ea8969c87d5
+msgid ""
+"Run `make i18n` (which just calls `update_i18n.py`) to generate the `.po`"
+" files"
+msgstr ""
+
+#: ../../translating.md:27 609caf2c695e4f9599080559bb527f57
+msgid ""
+"Open a PR with the empty `.po` files - the maintainers of the site will "
+"have to add the new language as a [readthedocs "
+"project](https://docs.readthedocs.io/en/stable/localization.html"
+"#projects-with-multiple-translations), so this early PR gives them time "
+"to get that ready by the time the translation is relatively complete"
+msgstr ""
+
+#: ../../translating.md:30 17bcfc9e6a5d467484b9bf6298ae6cb1
+msgid "Work on the translations in the `.po` files!"
+msgstr ""
+
+#: ../../translating.md:32 48c06b282fec40638c03fa2746b75734
+msgid "Translating"
+msgstr ""
+
+#: ../../translating.md:34 a1b5330df5c4410f851a8f295c0b8034
+msgid ""
+"You can run the `sphinx-intl stat` command to get a sense of what files "
+"need the most work:"
+msgstr ""
+
+#: ../../translating.md:37 77325337d66047aa995749393e3bbae9
+msgid "From `docs`:"
+msgstr ""
+
+#: ../../translating.md:59 7cd4308945884faea16c3fa9d1dd6d56
+msgid ""
+"See the [pyopensci `TRANSLATING.md` guide in the `python-package-"
+"guide`](https://github.com/pyOpenSci/python-package-"
+"guide/blob/main/TRANSLATING.md) for further instructions!"
+msgstr ""
+
+#: ../../translating.md:62 fac172f90d63435cbf1dd8ff06adecb0
+msgid ""
+"After you are finished, run `make i18n` again to reformat your strings to"
+" fit the standard style that the CI will check for."
+msgstr ""
+
+#: ../../translating.md:65 1ad35b647a5845208e9d30cbe5168562
+msgid "JOSS Website"
+msgstr ""
+

--- a/docs/locale/nb/LC_MESSAGES/venv.po
+++ b/docs/locale/nb/LC_MESSAGES/venv.po
@@ -1,0 +1,903 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: nb\n"
+"Language-Team: nb <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../venv/lib/python3.11/site-packages/MarkupSafe-2.1.5.dist-info/LICENSE.rst:1
+#: 4b04f57e9705450b9306605acd594245
+msgid "Copyright 2010 Pallets"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/MarkupSafe-2.1.5.dist-info/LICENSE.rst:3
+#: ../../venv/lib/python3.11/site-packages/click-8.1.7.dist-info/LICENSE.rst:3
+#: ../../venv/lib/python3.11/site-packages/idna-3.8.dist-info/LICENSE.md:6
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:10
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:44
+#: 1c4ecad3a0424d278d60922719a1bd17 52fbaf4189b2418891a406cc66dfea0b
+#: bfb06a8d236443628369f31abfe6c5a5 c44159ded9ac490fbf34569fb4b5e505
+#: dc0fa4a1b4994b5990003a4f8be3018e
+msgid ""
+"Redistribution and use in source and binary forms, with or without "
+"modification, are permitted provided that the following conditions are "
+"met:"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/MarkupSafe-2.1.5.dist-info/LICENSE.rst:7
+#: ../../venv/lib/python3.11/site-packages/alabaster-0.7.16.dist-info/LICENSE.rst:12
+#: ../../venv/lib/python3.11/site-packages/click-8.1.7.dist-info/LICENSE.rst:7
+#: ../../venv/lib/python3.11/site-packages/idna-3.8.dist-info/LICENSE.md:10
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:14
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:48
+#: 0a8e3445bb9045aaa841f636280c29e9 50113402d53346e8b923c2791161f01e
+#: 6d0e378e76a44454a0b8e54e701b4696 99979e2633bb42d6a30709742d964325
+#: f0f15fee79ed4b40ae793c9a39b91bf0 fa525a2654e74ef38a3627c05034bffe
+msgid ""
+"Redistributions of source code must retain the above copyright notice, "
+"this list of conditions and the following disclaimer."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/MarkupSafe-2.1.5.dist-info/LICENSE.rst:10
+#: ../../venv/lib/python3.11/site-packages/alabaster-0.7.16.dist-info/LICENSE.rst:15
+#: ../../venv/lib/python3.11/site-packages/click-8.1.7.dist-info/LICENSE.rst:10
+#: ../../venv/lib/python3.11/site-packages/idna-3.8.dist-info/LICENSE.md:13
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:17
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:50
+#: 0031803d4c2d4c2ca18f449baefa0288 02124d671c794341906e400a07da7441
+#: 09b72535bd7a4abca7204af33a35ec0d 224b40621fba4ad5b474748d7844882b
+#: 9dc8f8e5362441f29805a535a6c346be c62e1ce755f84d55aa0895f42813eceb
+msgid ""
+"Redistributions in binary form must reproduce the above copyright notice,"
+" this list of conditions and the following disclaimer in the "
+"documentation and/or other materials provided with the distribution."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/MarkupSafe-2.1.5.dist-info/LICENSE.rst:14
+#: ../../venv/lib/python3.11/site-packages/click-8.1.7.dist-info/LICENSE.rst:14
+#: ../../venv/lib/python3.11/site-packages/idna-3.8.dist-info/LICENSE.md:17
+#: 4de8e3ea9944403e868dfe5117f95570 a7e7f1a47d64472998a37ca0df813f2c
+#: ba2cd4afb9e140dc90a0fed6a5642677
+msgid ""
+"Neither the name of the copyright holder nor the names of its "
+"contributors may be used to endorse or promote products derived from this"
+" software without specific prior written permission."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/MarkupSafe-2.1.5.dist-info/LICENSE.rst:18
+#: ../../venv/lib/python3.11/site-packages/click-8.1.7.dist-info/LICENSE.rst:18
+#: ../../venv/lib/python3.11/site-packages/idna-3.8.dist-info/LICENSE.md:21
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:21
+#: 714609d72fe247c8ad7729ac1f599b1f b8eacd94e15b4a6199fe0065a84e1cc7
+#: c3270b0b2f504737aef0391ae710c590 f0f3f4fb89af44b08e1db0d4d9e3c2e8
+msgid ""
+"THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS "
+"IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED "
+"TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A "
+"PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER"
+" OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,"
+" EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, "
+"PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR "
+"PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF "
+"LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING "
+"NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS "
+"SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/alabaster-0.7.16.dist-info/LICENSE.rst:1
+#: dfcb151fc3914bdd8ec2a51b56633fbf
+msgid "Copyright (c) 2020 Jeff Forcier."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/alabaster-0.7.16.dist-info/LICENSE.rst:3
+#: bef43b50d4ac4d0d8a49beddecaad047
+msgid ""
+"Based on original work copyright (c) 2011 Kenneth Reitz and copyright (c)"
+" 2010 Armin Ronacher."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/alabaster-0.7.16.dist-info/LICENSE.rst:6
+#: 565f5758f467498abf005b476600b18a
+msgid "Some rights reserved."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/alabaster-0.7.16.dist-info/LICENSE.rst:8
+#: 5c13cb064db14e03b7874927cb3567a2
+msgid ""
+"Redistribution and use in source and binary forms of the theme, with or "
+"without modification, are permitted provided that the following "
+"conditions are met:"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/alabaster-0.7.16.dist-info/LICENSE.rst:20
+#: a0cc506593fb41bdb6af104b963f3a1a
+msgid ""
+"The names of the contributors may not be used to endorse or promote "
+"products derived from this software without specific prior written "
+"permission."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/alabaster-0.7.16.dist-info/LICENSE.rst:24
+#: c75de0dede354a8ba06bcf63b2049444
+msgid ""
+"THIS THEME IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS "
+"IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED "
+"TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A "
+"PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER "
+"OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, "
+"EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, "
+"PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR "
+"PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF "
+"LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING "
+"NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS THEME,"
+" EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/click-8.1.7.dist-info/LICENSE.rst:1
+#: 77270f4e7f2a4a4da5fe29bfaa4a3688
+msgid "Copyright 2014 Pallets"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/idna-3.8.dist-info/LICENSE.md:1
+#: 12a5eef7249e48d5a9d9ad59ccf233af
+msgid "BSD 3-Clause License"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/idna-3.8.dist-info/LICENSE.md:3
+#: de0055e0f911416fa5f584514d6240ba
+msgid "Copyright (c) 2013-2024, Kim Davies and contributors. All rights reserved."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/imagesize-1.4.1.dist-info/LICENSE.rst:2
+#: 6dd5458610ed4e9cba29810165da96ce
+msgid "The MIT License (MIT)"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/imagesize-1.4.1.dist-info/LICENSE.rst:4
+#: 9f00b96eb75f4a049843504e6bd8eb4a
+msgid "Copyright © 2016 Yoshiki Shibukawa"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/imagesize-1.4.1.dist-info/LICENSE.rst:6
+#: 1852768a207148e8a640eb1acc076ab7
+msgid ""
+"Permission is hereby granted, free of charge, to any person obtaining a "
+"copy of this software and associated documentation files (the "
+"“Software”), to deal in the Software without restriction, including "
+"without limitation the rights to use, copy, modify, merge, publish, "
+"distribute, sublicense, and/or sell copies of the Software, and to permit"
+" persons to whom the Software is furnished to do so, subject to the "
+"following conditions:"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/imagesize-1.4.1.dist-info/LICENSE.rst:12
+#: c58be8ee3c8f473f813bde5daeafa536
+msgid ""
+"The above copyright notice and this permission notice shall be included "
+"in all copies or substantial portions of the Software."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/imagesize-1.4.1.dist-info/LICENSE.rst:15
+#: bcc0103fc9e548e89f1d6b5bc7c98b31
+msgid ""
+"THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS "
+"OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF "
+"MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN"
+" NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,"
+" DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR "
+"OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE"
+" USE OR OTHER DEALINGS IN THE SOFTWARE."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:1
+#: e49e03c1886844259db71a8b0da9789b
+msgid "markdown-it-container"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:3
+#: a88b013cb1a14120b1d5a9ecea4ce9e8
+msgid ""
+"[![Build Status](https://img.shields.io/travis/markdown-it/markdown-it-"
+"container/master.svg?style=flat)](https://travis-ci.org/markdown-it"
+"/markdown-it-container) [![NPM version](https://img.shields.io/npm/v"
+"/markdown-it-container.svg?style=flat)](https://www.npmjs.org/package"
+"/markdown-it-container) [![Coverage "
+"Status](https://img.shields.io/coveralls/markdown-it/markdown-it-"
+"container/master.svg?style=flat)](https://coveralls.io/r/markdown-it"
+"/markdown-it-container?branch=master)"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:3
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:3
+#: 643fb1c2331c444d9eebcd59b0d84541 cbb138ffd079476e9fe9d321fc8140c3
+msgid "Build Status"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:3
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:3
+#: 445043497ac446d5b5d8faaae13e055c fb3a1e66cb544d44a6830d3373fee4b1
+msgid "NPM version"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:3
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:3
+#: 675a06e31cd54cb4af1320b991125f4a 72f10afff03e4b4794fd68d69afcd9d2
+msgid "Coverage Status"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:7
+#: 8be808a359e54b2492064927350fba55
+msgid ""
+"Plugin for creating block-level custom containers for [markdown-"
+"it](https://github.com/markdown-it/markdown-it) markdown parser."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:9
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:9
+#: 631b149484d24e069016c7c1532d2d2a b767f0ca917a44de82f46da9e24e96e0
+msgid "__v2.+ requires `markdown-it` v5.+, see changelog.__"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:11
+#: 223eb6d266f64663862ff0cdef64a2d6
+msgid "With this plugin you can create block containers like:"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:19
+#: 140f37968c6544cab5bdbfb02d68faaf
+msgid ""
+".... and specify how they should be rendered. If no renderer defined, "
+"`<div>` with container name class will be created:"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:28
+#: 60fd44e6161d42c597c5cc42d2eed050
+msgid ""
+"Markup is the same as for [fenced code "
+"blocks](http://spec.commonmark.org/0.18/#fenced-code-blocks). Difference "
+"is, that marker use another character and content is rendered as markdown"
+" markup."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:32
+#: 1ceac555acc142ee8eeacaefafaa3f59
+msgid "Installation"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:34
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:16
+#: 86896043684e479dbd1adef4bcac2d7d b8e71f9c76714680aeb2932862327ceb
+msgid "node.js, browser:"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:42
+#: 7b65b1f4c2724172bb8c7b295b2e4020
+msgid "API"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:49
+#: e5471c7e42184b81b02e665a8a581796
+msgid "Params:"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:51
+#: 4e3326221502434b86c72ef95b41eb1c
+msgid "__name__ - container name (mandatory)"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:52
+#: 8ed63f922bec4da6b4f8bf2c4f25744f
+msgid "__options:__"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:53
+#: 8ae43dd5876a4aa6b280d2c4a1136da5
+msgid ""
+"__validate__ - optional, function to validate tail after opening marker, "
+"should return `true` on success."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:55
+#: 92c1d59d17d54ababefbb54659ad6e55
+msgid "__render__ - optional, renderer function for opening/closing tokens."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:56
+#: dc129b03265c4b358f333b46c657e072
+msgid "__marker__ - optional (`:`), character to use in delimiter."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:59
+#: bdf4b7ccb1674f76b933dec24378a70b
+msgid "Example"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:93
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:36
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:1
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:133
+#: 267559600a324daf8006b181564ce566 a79d787bc551494d9ca6a05f14b8e305
+#: df86e1c582764592b97e877a242c6754 e734876cb52e46e7b6a3bac331c58bda
+msgid "License"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:95
+#: 0869b2da52404f49aa98f1bd9f537651
+msgid ""
+"[MIT](https://github.com/markdown-it/markdown-it-"
+"container/blob/master/LICENSE)"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:1
+#: cc74ddf7f726442a85770d6a72aeb251
+msgid "markdown-it-deflist"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:3
+#: 31b33cfff4184aaf9f43a3e90efe371d
+msgid ""
+"[![Build Status](https://img.shields.io/travis/markdown-it/markdown-it-"
+"deflist/master.svg?style=flat)](https://travis-ci.org/markdown-it"
+"/markdown-it-deflist) [![NPM version](https://img.shields.io/npm/v"
+"/markdown-it-deflist.svg?style=flat)](https://www.npmjs.org/package"
+"/markdown-it-deflist) [![Coverage "
+"Status](https://img.shields.io/coveralls/markdown-it/markdown-it-"
+"deflist/master.svg?style=flat)](https://coveralls.io/r/markdown-it"
+"/markdown-it-deflist?branch=master)"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:7
+#: 7d21759f971b4214afcfa828d381248f
+msgid ""
+"Definition list (`<dl>`) tag plugin for [markdown-it](https://github.com"
+"/markdown-it/markdown-it) markdown parser."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:11
+#: 987f97e09dc54604953d756f606dcb80
+msgid ""
+"Syntax is based on [pandoc definition "
+"lists](http://johnmacfarlane.net/pandoc/README.html#definition-lists)."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:14
+#: ed30c3a0e7ac4ac8bb5bc6b3ef717acc
+msgid "Install"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:23
+#: 5b56c9e9862040c4a3021651b5d92687
+msgid "Use"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:32
+#: 32291d893f79454e80caa070b39edd1d
+msgid ""
+"_Differences in browser._ If you load script directly into the page, "
+"without package system, module will add itself globally as "
+"`window.markdownitDeflist`."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:38
+#: 41fce509e63049ac8424e184b06b5109
+msgid ""
+"[MIT](https://github.com/markdown-it/markdown-it-"
+"deflist/blob/master/LICENSE)"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:1
+#: e057db94d78a4d14ad08b3011dfbc477
+msgid ""
+"[![License](https://img.shields.io/github/license/goessner/markdown-it-"
+"texmath.svg)](https://github.com/goessner/markdown-it-"
+"texmath/blob/master/licence.txt) [![npm](https://img.shields.io/npm/v"
+"/markdown-it-texmath.svg)](https://www.npmjs.com/package/markdown-it-"
+"texmath) [![npm](https://img.shields.io/npm/dt/markdown-it-"
+"texmath.svg)](https://www.npmjs.com/package/markdown-it-texmath)"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:1
+#: 74576af3ad9a4ee39bfe44e316de5fb1 c4872ca8b32c4a4790ab0597faf8a8a6
+msgid "npm"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:5
+#: 157e5a3dd0264571916e500b8de44002
+msgid "markdown-it-texmath"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:7
+#: 309e16f425964b159a4ba307590e184f
+msgid ""
+"Add TeX math equations to your Markdown documents rendered by [markdown-"
+"it](https://github.com/markdown-it/markdown-it) parser. "
+"[KaTeX](https://github.com/Khan/KaTeX) is used as a fast math renderer."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:9
+#: f8a4e94757f2422187c6435994cf7371
+msgid "Features"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:10
+#: 4f9f5dd8bf7f4854b4e5638e412ee282
+msgid ""
+"Simplify the process of authoring markdown documents containing math "
+"formulas. This extension is a comfortable tool for scientists, engineers "
+"and students with markdown as their first choice document format."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:13
+#: b0aa32493be546e58e566fc4747d46dd
+msgid "Macro support"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:14
+#: c00e2c3e083f4388bc7037ba1498dd18
+msgid "Simple formula numbering"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:15
+#: 695beb0db9c34573b5938bca9ee90e4f
+msgid "Inline math with tables, lists and blockquote."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:16
+#: be57ab220b7540888023ab3059f71bc7
+msgid "User setting delimiters:"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:17
+#: a30604d94dce451daafcdb5bc890d3ac
+msgid "`'dollars'` (default)"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:18
+#: 6f0461a9f63345c09a4d0178947dbb68
+msgid "inline: `$...$`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:19
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:35
+#: 12142a76d44d4ce5a16c4d5a158a9637 dc1b9cbd2f82487891503c0bafeda846
+msgid "display: `$$...$$`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:20
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:36
+#: 7e3c7d4b5bd54953bbdbd63bc6d7d2b5 f877016f55b7445ba30eabbe42b70592
+msgid "display + equation number: `$$...$$ (1)`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:21
+#: b8672b73a3354b7da686ae497556ff0e
+msgid "`'brackets'`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:22
+#: 75b30e1f2b0b4e3d986b1cd299422178
+msgid "inline: `\\(...\\)`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:23
+#: 1fb03d476a78432fb6df765247a9756d
+msgid "display: `\\[...\\]`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:24
+#: 83ef05ce21aa4e2d85d4d6e6ae9792d0
+msgid "display + equation number: `\\[...\\] (1)`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:25
+#: fe4d88fc08214241881129b5809e626d
+msgid "`'gitlab'`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:26
+#: d3abb6d66da44a79922e6d4e6c591cfe
+msgid "inline: ``$`...`$``"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:27
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:31
+#: 27a059ce708a4188a0bb041a725a3a20 cb0b71fa64334a71ad45ae199735edf8
+msgid "display: `` ```math ... ``` ``"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:28
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:32
+#: 3fde380aaa3945098eb8c7d3f1ca0fee eb7c543e030d4bc8ae1363703dc98995
+msgid "display + equation number: `` ```math ... ``` (1)``"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:29
+#: 17b547696b3a49ffb84ca24d282958c9
+msgid "`'julia'`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:30
+#: a537a5dc24534cb890e59dd3b1812a7e
+msgid "inline: `$...$`  or ``` ``...`` ```"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:33
+#: d36e5471714647f9ab6d1fbb7fa35cae
+msgid "`'kramdown'`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:34
+#: 15f31bf2467f42298aa5f8c26c6e586e
+msgid "inline: ``$$...$$``"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:38
+#: 94fed257197541c0bf7e9f8fb6d18733
+msgid "Show me"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:40
+#: e874f0a1930b4a5b8113d67bbca00bfd
+msgid ""
+"View a [test table](https://goessner.github.io/markdown-it-"
+"texmath/index.html)."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:42
+#: aa9577bc494a4effadf83ecc4027026b
+msgid ""
+"[try it out ...](https://goessner.github.io/markdown-it-texmath/markdown-"
+"it-texmath-demo.html)"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:44
+#: aee8284928ba4f8eb1632e3a2c551fa6
+msgid "Use with `node.js`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:46
+#: bb77829871ba4620b31bed6d2e78816b
+msgid ""
+"Install the extension. Verify having `markdown-it` and `katex` already "
+"installed ."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:50
+#: 23a36619cd544731943d0b39c03abbbf
+msgid "Use it with JavaScript."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:59
+#: 7cc8519d35664f64aecb71811907b28e
+msgid "Use in Browser"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:83
+#: b92a92ced9ef40d8b39e21ad0e8e2c27
+msgid "CDN"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:85
+#: bf5f80a2ccca4fb2930d7aac38f18edc
+msgid "Use following links for `texmath.js` and `texmath.css`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:86
+#: d4a48801bb9f4a3994af4674142e785b
+msgid "`https://gitcdn.xyz/cdn/goessner/markdown-it-texmath/master/texmath.js`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:87
+#: f80a34376a374cca938d70c30c25fb51
+msgid "`https://gitcdn.xyz/cdn/goessner/markdown-it-texmath/master/texmath.css`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:89
+#: 31a28aa4a3e94a5996ebc74e4193808f
+msgid "Dependencies"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:91
+#: 9848d2d73f914656b6c171d05b7d8bb3
+msgid ""
+"[`markdown-it`](https://github.com/markdown-it/markdown-it): Markdown "
+"parser done right. Fast and easy to extend."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:92
+#: fa7ced3164cb48e49bdd4932a9a4f39d
+msgid ""
+"[`katex`](https://github.com/Khan/KaTeX): This is where credits for fast "
+"rendering TeX math in HTML go to."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:94
+#: 9efc2dd198d6436f94d82e29f6a01ddd
+msgid "ToDo"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:96
+#: 496b6811181140d1b87b046e281ee0c9
+msgid "nothing yet"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:98
+#: 5d717d64ba734c43a58128212dd36e0a
+msgid "FAQ"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:100
+#: 061ba8572ca048d190a69f157744524a
+msgid "__`markdown-it-texmath` with React Native does not work, why ?__"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:101
+#: 77e5944397a7463e9a73036487698715
+msgid ""
+"`markdown-it-texmath` is using regular expressions with `y` [(sticky) "
+"property](https://developer.mozilla.org/en-"
+"US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/sticky) and cannot"
+" avoid this. The use of the `y` flag in regular expressions means the "
+"plugin is not compatible with React Native (which as of now doesn't "
+"support it and throws an error `Invalid flags supplied to RegExp "
+"constructor`)."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:103
+#: cbe91ac47621429e94e3d2b7dd2835e0
+msgid "CHANGELOG"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:105
+#: cf019dffbb1a4b0e86c9d6f3bf053cec
+msgid "[0.6.0] on October 04, 2019"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:106
+#: 05490a0fff214b72ba3e1924fe73ec4f
+msgid ""
+"Add support for [Julia "
+"Markdown](https://docs.julialang.org/en/v1/stdlib/Markdown/) on "
+"[request](https://github.com/goessner/markdown-it-texmath/issues/15)."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:108
+#: 2093987c7b3b411bb5f6247aa287c147
+msgid "[0.5.5] on February 07, 2019"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:109
+#: 5269b5c18ce241d1a255e3ab2c68baef
+msgid ""
+"Remove [rendering bug with brackets "
+"delimiters](https://github.com/goessner/markdown-it-texmath/issues/9)."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:111
+#: 6aaf8d7a4e064bb3b98a5edae720fe8c
+msgid "[0.5.4] on January 20, 2019"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:112
+#: 75fabae3db7343879034b56ae4299a77
+msgid ""
+"Remove pathological [bug within "
+"blockquotes](https://github.com/goessner/mdmath/issues/50)."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:114
+#: 7f4b1fc7dc8045f8988333ff58e8f07c
+msgid "[0.5.3] on November 11, 2018"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:115
+#: b39e4ea4dad641178b78ff31ce51b458
+msgid ""
+"Add support for Tex macros (https://katex.org/docs/supported.html#macros)"
+" ."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:116
+#: 3c4d1c6e691e405a8410a3bf5d567a62
+msgid ""
+"Bug with [brackets delimiters](https://github.com/goessner/markdown-it-"
+"texmath/issues/9) ."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:118
+#: 715aaf957c2f45f68aa18fb6adcecae1
+msgid "[0.5.2] on September 07, 2018"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:119
+#: 1c21dcd8158e4b7380335032f8488823
+msgid "Add support for [Kramdown](https://kramdown.gettalong.org/) ."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:121
+#: 8c40cb3b696d400581aafbffe01a2863
+msgid "[0.5.0] on August 15, 2018"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:122
+#: b0703ac4821f4ec6ab431d8b4ff0c713
+msgid ""
+"Fatal blockquote bug investigated. Implemented workaround to vscode bug, "
+"which has finally gone with vscode 1.26.0 ."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:124
+#: 07f70dde3d0b49d7bf4b46e7b43fc60c
+msgid "[0.4.6] on January 05, 2018"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:125
+#: 2ccc50aeca474fd3ab8fd4414e678598
+msgid "Escaped underscore bug removed."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:127
+#: 59f4f020ddb7424fa3fa5d217b9457b9
+msgid "[0.4.5] on November 06, 2017"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:128
+#: 681997521a854dc4bdc39d2eaa888c34
+msgid "Backslash bug removed."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:130
+#: 531fd1ab52274de3801dc5911ee09ad2
+msgid "[0.4.4] on September 27, 2017"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:131
+#: 31968e82ca544532bec7bc26ef8ed9f9
+msgid ""
+"Modifying the `block` mode regular expression with `gitlab` delimiters, "
+"so removing the `newline` bug."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:135
+#: 52c2b744570047b3b3a075714536978d
+msgid "`markdown-it-texmath` is licensed under the [MIT License](./license.txt)"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:137
+#: 89bc025154c44499bf25fd4a6621ba0d
+msgid "© [Stefan Gössner](https://github.com/goessner)"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:2
+#: e2034c149edf4233ba2d239de2bc5a37
+msgid "License for Sphinx"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:4
+#: 0724495e2bf4464d912bb8b932511a88
+msgid ""
+"Unless otherwise indicated, all code in the Sphinx project is licenced "
+"under the two clause BSD licence below."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:7
+#: a54d7f8a1705480d94cc3228b74332d2
+msgid ""
+"Copyright (c) 2007-2024 by the Sphinx team (see AUTHORS file). All rights"
+" reserved."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:35
+#: ff1b2ef9d7374205ba6c12fddff922ab
+msgid "Licenses for incorporated software"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:37
+#: 1323d5c2d81442e7bf615b20ad8c4d3c
+msgid ""
+"The included implementation of "
+"NumpyDocstring._parse_numpydoc_see_also_section was derived from code "
+"under the following license:"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:42
+#: 4e59393bef704f569239fae16276714f
+msgid ""
+"Copyright (C) 2008 Stefan van der Walt <stefan@mentat.za.net>, Pauli "
+"Virtanen <pav@iki.fi>"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:55
+#: 2608a2347fc24391a73c6841ab66828d
+msgid ""
+"THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR "
+"IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES"
+" OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. "
+"IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, "
+"INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT "
+"NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,"
+" DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY "
+"THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT "
+"(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF "
+"THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx/ext/autosummary/templates/autosummary/base.rst:1
+#: ../../venv/lib/python3.11/site-packages/sphinx/ext/autosummary/templates/autosummary/class.rst:1
+#: ../../venv/lib/python3.11/site-packages/sphinx/ext/autosummary/templates/autosummary/module.rst:1
+#: 0451370ee9314f7c906ab2836764c47a 34eae62f4d5740edb136c49059b2f68a
+#: 9fa2c23ace9742ef857c70bd4efa6475
+msgid "{{ fullname | escape | underline}}"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx/ext/autosummary/templates/autosummary/module.rst:49
+#: 2a32ebb5750d4a979e7eb61b0b2a43d1
+msgid "{%- block modules %} {%- if modules %} .. rubric:: Modules"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx/ext/autosummary/templates/autosummary/module.rst:56
+#: d57cb8ab9dca45e4aea575779c41d097
+#, python-format
+msgid "{% for item in modules %}"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx/ext/autosummary/templates/autosummary/module.rst:57
+#: 7cceed397e184649b97d1c43c3bdf7cc
+msgid "{{ item }}"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx/ext/autosummary/templates/autosummary/module.rst:58
+#: 92d7e04737254ad29257454aef84d60e
+#, python-format
+msgid "{%- endfor %} {% endif %} {%- endblock %}"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx_intl-2.2.0.dist-info/AUTHORS.rst:3
+#: bcacc45f6d95492d8bad5f48f0118261
+msgid "AUTHORS"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx_intl-2.2.0.dist-info/AUTHORS.rst:5
+#: 593ea41c5a514301b5452416e55ede81
+msgid "Takayuki Shimizukawa <https://github.com/shimizukawa>"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx_intl-2.2.0.dist-info/AUTHORS.rst:6
+#: e742c33eb1364000ba767acc24bfa569
+msgid "Takeshi Komiya <https://github.com/tk0miya>"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx_intl-2.2.0.dist-info/AUTHORS.rst:9
+#: 44931f9b8feb4787ab34eb833e84679d
+msgid "Original"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx_intl-2.2.0.dist-info/AUTHORS.rst:11
+#: 9f8934708c8843d08acf1b7ee6f45a3b
+msgid "This utility derived from these projects."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx_intl-2.2.0.dist-info/AUTHORS.rst:13
+#: 967f61e50bfc436b8f5d6b4bf16d2534
+msgid "https://bitbucket.org/tk0miya/sphinx-gettext-helper"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx_intl-2.2.0.dist-info/AUTHORS.rst:14
+#: cdbc970fd030448782c80d668fa88cf6
+msgid "https://bitbucket.org/shimizukawa/sphinx-transifex"
+msgstr ""
+

--- a/docs/locale/pl/LC_MESSAGES/editing.po
+++ b/docs/locale/pl/LC_MESSAGES/editing.po
@@ -1,0 +1,800 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: pl\n"
+"Language-Team: pl <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../editing.md:1 ba75e061942846b39d6400279abb3237
+msgid "Editorial Guide"
+msgstr ""
+
+#: ../../editing.md:3 4425ba5e1b67491e91d218933ae1bedc
+msgid ""
+"The Journal of Open Source Software (JOSS) conducts all peer review and "
+"editorial processes in the open, on the GitHub issue tracker."
+msgstr ""
+
+#: ../../editing.md:5 588c730a7e6140ea92d7ef96a144ba34
+msgid ""
+"JOSS editors manage the review workflow with the help of our bot, "
+"`@editorialbot`. The bot is summoned with commands typed directly on the "
+"GitHub review issues. For a list of commands, type: `@editorialbot "
+"commands`."
+msgstr ""
+
+#: ../../editing.md:8 ea507efa5e7c4203af483f907285e322
+msgid ""
+"To learn more about `@editorialbot`'s functionalities, take a look at our"
+" [dedicated guide](editorial_bot)."
+msgstr ""
+
+#: ../../editing.md:11 01a2380aa2e84215bf133d231a693ea1
+msgid "Overview of editorial process"
+msgstr ""
+
+#: ../../editing.md:13 1d0e9c7d61634731889074477da77a8e
+msgid "**Step 1: An author submits a paper.**"
+msgstr ""
+
+#: ../../editing.md:15 be3c1216b0ef4b4eb0ce620c0486ce3a
+msgid ""
+"The author can choose to select an preferred editor based on the "
+"information available in our biographies. This can be changed later."
+msgstr ""
+
+#: ../../editing.md:17 e89317316a414f3997d43046e0ebca4f
+msgid ""
+"**Step 2: If you are selected as an editor you get @-mentioned in the "
+"pre-review issue.**"
+msgstr ""
+
+#: ../../editing.md:19 7dfb3122440545e2abf13fbce2590990
+msgid ""
+"This doesn’t mean that you’re the editor, just that you’ve been suggested"
+" by the author."
+msgstr ""
+
+#: ../../editing.md:21 3bd75b6544eb40f4a8632660039bfe66
+msgid ""
+"**Step 3: Once you are the editor, find the link to the code repository "
+"in the `pre-review` issue**"
+msgstr ""
+
+#: ../../editing.md:23 5d43095e44a14c4793ad6f4495a55247
+msgid ""
+"If the paper is not in the default branch, add it to the issue with the "
+"command: `@editorialbot set branch-where-paper-is as branch`."
+msgstr ""
+
+#: ../../editing.md:25 dc2a2117853f4cf98427079ca7959f87
+msgid ""
+"**Step 4: The editor looks at the software submitted and checks to see "
+"if:**"
+msgstr ""
+
+#: ../../editing.md:27 c2fa085a985240b5a09962904479e0b5
+msgid "There’s a general description of the software"
+msgstr ""
+
+#: ../../editing.md:28 d08990aef10944a29ce0c0ff47222780
+msgid "The software is within scope as research software"
+msgstr ""
+
+#: ../../editing.md:29 aa784fe1458146bcbf4a6357a20aa4dd
+msgid "It has an OSI-approved license"
+msgstr ""
+
+#: ../../editing.md:31 1616e7978406420985cb59579086bdc9
+msgid ""
+"**Step 5: The editor responds to the author saying that things look in "
+"line (or not) and will search for reviewer**"
+msgstr ""
+
+#: ../../editing.md:33 8d341ffd2d5748a7a2873fe78c1f54f3
+msgid "**Step 6: The editor finds >= 2 reviewers**"
+msgstr ""
+
+#: ../../editing.md:35 f6e3b8184f6448b7987dc9d1856febae
+msgid ""
+"Use the list of reviewers: type the command `@editorialbot list "
+"reviewers` or look at use the [Reviewers Management "
+"System](https://reviewers.joss.theoj.org)"
+msgstr ""
+
+#: ../../editing.md:37 9d1e2e91340549c5a7115b4781afd5ae
+msgid ""
+"If people are in the review list, the editor can @-mention them on the "
+"issue to see if they will review: e.g. `@person1 @person2 can you review "
+"this submission for JOSS?`"
+msgstr ""
+
+#: ../../editing.md:38 bc55566434724ed9bca98d34b52fdead
+msgid ""
+"Or solicit reviewers outside the list. Send an email to people describing"
+" what JOSS is and asking if they would be interested in reviewing."
+msgstr ""
+
+#: ../../editing.md:39 80c9c8dfcae14f43bfc7ff51dfe90c78
+msgid ""
+"If you ask the author to suggest potential reviewers, please be sure to "
+"tell the author not to @-tag their suggestions."
+msgstr ""
+
+#: ../../editing.md:41 50d524d4d91242d89e3d8b53172027c0
+msgid "**Step 7: Editor tells EditorialBot to assign the reviewers to the paper**"
+msgstr ""
+
+#: ../../editing.md:43 ee6ceff15aec4326a765b27464e4e151
+msgid "Use `@editorialbot add @reviewer as reviewer`"
+msgstr ""
+
+#: ../../editing.md:44 faacbbf290f04780b04687fc697eb7a7
+msgid "To add a second reviewer use `@editorialbot add @reviewer2 as reviewer`"
+msgstr ""
+
+#: ../../editing.md:46 2247f7a372ad4610860360322b89a8b9
+msgid "**Step 8: Create the actual review issue**"
+msgstr ""
+
+#: ../../editing.md:48 9f059ce78963480fb5630d0619c405fc
+msgid "Use `@editorialbot start review`"
+msgstr ""
+
+#: ../../editing.md:49 5cce03e372f348b2bbd2bc8bb7ea4255
+msgid ""
+"An issue is created with the review checklist, one per reviewer, e.g. "
+"https://github.com/openjournals/joss-reviews/issues/717"
+msgstr ""
+
+#: ../../editing.md:51 8fec36d962204eb08ac273f7d87f4a91
+msgid "**Step 9: Close the pre-review issue**"
+msgstr ""
+
+#: ../../editing.md:53 8dfb216bd6594395a11a5a73a0ab0665
+msgid "**Step 10: The actual JOSS review**"
+msgstr ""
+
+#: ../../editing.md:55 afd01c95bf5e465d80168253137007ae
+msgid ""
+"The reviewer reviews the paper and has a conversation with the author. "
+"The editor lurks on this conversation and comes in if needed for "
+"questions (or CoC issues)."
+msgstr ""
+
+#: ../../editing.md:56 298bde930f5540d794bb912008afea98
+msgid ""
+"The reviewer potentially asks for changes and the author makes changes. "
+"Everyone agrees it’s ready."
+msgstr ""
+
+#: ../../editing.md:58 e82ce62ae4434ce8a860d7e380585acd
+msgid "**Step 11: The editor pings the EiC team to get the paper published**"
+msgstr ""
+
+#: ../../editing.md:60 3c0819139b644e1090266a2c3f8dfb09
+msgid ""
+"Make a final check of the paper with `@editorialbot generate pdf` and "
+"that all references have DOIs (where appropriate) with `@editorialbot "
+"check references`."
+msgstr ""
+
+#: ../../editing.md:61 8e1bcc08da4f45a3ad2cd0cc88eccb53
+msgid ""
+"If everything looks good, ask the author to make a new release (if "
+"possible) of the software being reviewed and deposit a new archive the "
+"software with Zenodo/figshare. Update the review thread with this archive"
+" DOI: `@editorialbot set 10.5281/zenodo.xxxxxx as archive`."
+msgstr ""
+
+#: ../../editing.md:62 3bdfdd0fffbe4486b9d3eaa0fcc285e5
+msgid ""
+"Editors can get a checklist of the final steps using the `@editorialbot "
+"create post-review checklist` command"
+msgstr ""
+
+#: ../../editing.md:63 dc8a53ae589b4714b782d44e169c6eb4
+msgid ""
+"Finally, use `@editorialbot recommend-accept` on the review thread to "
+"ping the `@openjournals/joss-eics` team letting them know the paper is "
+"ready to be accepted."
+msgstr ""
+
+#: ../../editing.md:65 4ef13c64642d4dddb985e7d7443b615c
+msgid ""
+"**Step 12: Celebrate publication! Tweet! Thank reviewers! Say thank you "
+"on issue.**"
+msgstr ""
+
+#: ../../editing.md:67 abc94aab3bb847aaabd9b314068f769e
+msgid "Visualization of editorial flow"
+msgstr ""
+
+#: ../../editing.md:69 780171765db2498cbffedd0d64336c5f
+msgid "![Editorial flow](images/JOSS-flowchart.png)"
+msgstr ""
+
+#: ../../editing.md:69 49ebbf2f618b4e4aa1d887ee92d811c1
+msgid "Editorial flow"
+msgstr ""
+
+#: ../../editing.md:72 da842b437107499d9f5f02d98142d0ca
+msgid "Pre-review"
+msgstr ""
+
+#: ../../editing.md:74 0dea21b9176141998658732613afcbae
+msgid ""
+"Once a submission comes in, it will be in the queue for a quick check by "
+"the Track Editor-in-chief (TEiC). From there, it moves to a `PRE-REVIEW` "
+"issue, where the TEiC will assign a handling editor, and the author can "
+"suggest reviewers. Initial direction to the authors for improving the "
+"paper can already happen here, especially if the paper lacks some "
+"requested sections."
+msgstr ""
+
+#: ../../editing.md:77 804139f147a14d7a8494d05a58fbda97
+msgid ""
+"If the paper is out-of-scope for JOSS, editors assess this and notify the"
+" author in the ``PRE-REVIEW`` issue."
+msgstr ""
+
+#: ../../editing.md:80 98e964c5547b4becbcdaf2f51775354e
+msgid ""
+"Editors can flag submissions of questionable scope using the command "
+"`@editorialbot query scope`."
+msgstr ""
+
+#: ../../editing.md:82 44c33ad2bbfa430ba1d2ec0031f3d8ed
+msgid ""
+"The TEiC assigns an editor (or a volunteering editor self-assigns) with "
+"the command `@editorialbot assign @username as editor` in a comment."
+msgstr ""
+
+#: ../../editing.md:85 92e566f78ff84e148a7e62170b2b8b6e
+msgid ""
+"Please check in on the "
+"[dashboard](https://joss.theoj.org/dashboard/incoming) semi-regularly to "
+"see which papers are currently without an editor, and if possible, "
+"volunteer to edit papers that look to be in your domain. If you choose to"
+" be an editor in the issue thread type the command `@editorialbot assign "
+"@yourhandle as editor` or simply `@editorialbot assign me as editor`"
+msgstr ""
+
+#: ../../editing.md:88 96324eec2dff4339a9097d19f4f88dbe
+msgid "How papers are assigned to editors"
+msgstr ""
+
+#: ../../editing.md:90 014c09095aeb4cf1b5bc42650b1d168e
+msgid ""
+"By default, unless an editor volunteers, the Track Editor-in-chief (TEiC)"
+" on duty will attempt to assign an incoming paper to the most suitable "
+"handling editor. While TEiC will make every effort to match a submission "
+"with the most appropriate editor, there are a number of situations where "
+"an TEiC may assign a paper to an editor that doesn't fit entirely within "
+"the editor's research domains:"
+msgstr ""
+
+#: ../../editing.md:92 fac8f2d244fd41759d31f0b68f21272f
+msgid "If there's no obvious fit to _any_ of the JOSS editors"
+msgstr ""
+
+#: ../../editing.md:93 87f3e1b98650471fac5779492f60f6c2
+msgid "If the most suitable editor is already handling a large number of papers"
+msgstr ""
+
+#: ../../editing.md:94 6af7d1f654964f4a81937920c4f81453
+msgid "If the chosen editor has a lighter editorial load than other editors"
+msgstr ""
+
+#: ../../editing.md:96 fcee040231ea469a98208739ff188df8
+msgid ""
+"In most cases, the TEiC will ask one or more editors to edit a submission"
+" (e.g. `@editor1, @editor 2 - would one of you be willing to edit this "
+"submission for JOSS`). If the editor doesn't respond within ~3 working "
+"days, the TEiC may assign the paper to the editor regardless."
+msgstr ""
+
+#: ../../editing.md:98 7ead8edc335b4f539c9b9f2b2e18fc0c
+msgid ""
+"Editors may also be invited to edit over email when an TEiC runs the "
+"command `@editorialbot invite @editor1 as editor`."
+msgstr ""
+
+#: ../../editing.md:100 3bf16fb790074ada87a3d4aeb9f427ea
+msgid "Finding reviewers"
+msgstr ""
+
+#: ../../editing.md:102 8dc3490e7abd4a8186526a8eb64fb943
+msgid ""
+"At this point, the handling editor's job is to identify reviewers who "
+"have sufficient expertise in the field of software and in the field of "
+"the submission. JOSS papers have to have a minimum of two reviewers per "
+"submission, except for papers that have previously been peer-reviewed via"
+" rOpenSci. In some cases, the editor also might want to formally add "
+"themselves as one of the reviewers. If the editor feels particularly "
+"unsure of the submission, a third (or fourth) reviewer can be recruited."
+msgstr ""
+
+#: ../../editing.md:104 4bad7fcd46c7403aa7758ed50bd77e66
+msgid ""
+"To recruit reviewers, the handling editor can mention them in the `PRE-"
+"REVIEW` issue with their GitHub handle, ping them on Twitter, or email "
+"them. After expressing initial interest, candidate reviewers may need a "
+"longer explanation via email. See sample reviewer invitation email, "
+"below."
+msgstr ""
+
+#: ../../editing.md:106 682e99ffe4e241eaaf9e3993356ab10a
+msgid "**Reviewer Considerations**"
+msgstr ""
+
+#: ../../editing.md:108 edf7d8efffb045e0965b6b9293648a03
+msgid ""
+"It is rare that all reviewers have the expertise to cover all aspects of "
+"a submission (e.g., knows the language really well and knows the "
+"scientific discipline well). As such, a good practice is to try and make "
+"sure that between the two or three reviewers, all aspects of the "
+"submission are covered."
+msgstr ""
+
+#: ../../editing.md:109 4f10a84abdd14117a2a3152e849c5be5
+msgid ""
+"Selection and assignment of reviewers should adhere to the [JOSS COI "
+"policy](https://joss.theoj.org/about#ethics)."
+msgstr ""
+
+#: ../../editing.md:111 2104a69a5a9042bead939ae983b3c7a0
+msgid "**Potential ways to find reviewers**"
+msgstr ""
+
+#: ../../editing.md:113 136014fdf9e547db8f7b3be69cbd5f00
+msgid ""
+"Finding reviewers can be challenging, especially if a submission is "
+"outside of your immediate area of expertise. Some strategies you can use "
+"to identify potential candidates:"
+msgstr ""
+
+#: ../../editing.md:115 1d3468cc8f104c929ec80034bec03e35
+msgid ""
+"Search the [reviewer application](https://reviewers.joss.theoj.org) of "
+"volunteer reviewers."
+msgstr ""
+
+#: ../../editing.md:116 24b24f22566b400e9d984588466bb29a
+msgid ""
+"When using this spreadsheet, pay attention to the number of reviews this "
+"individual is already doing to avoid overloading them."
+msgstr ""
+
+#: ../../editing.md:117 5ecccfbb623042939b0e2825f92f9b3c
+msgid ""
+"It can be helpful to use the \"Data > Filter Views\" capability to "
+"temporarily filter the table view to include only people with language or"
+" domain expertise matching the paper."
+msgstr ""
+
+#: ../../editing.md:118 89e4d0c5f2c54f5bab1af508c97869c2
+msgid ""
+"Ask the author(s): You are free to ask the submitting author to suggest "
+"possible reviewers by using the [reviewer "
+"application](https://reviewers.joss.theoj.org) and also people from their"
+" professional network. In this situation, the editor still needs to "
+"verify that their suggestions are appropriate."
+msgstr ""
+
+#: ../../editing.md:119 c1f2ce44cb154c3682ace1d6796a6aaa
+msgid ""
+"Use your professional network: You're welcome to invite people you know "
+"of who might be able to give a good review."
+msgstr ""
+
+#: ../../editing.md:120 e49dc26b10b943eea7f86075231528c2
+msgid ""
+"Search Google and GitHub for related work, and write to the authors of "
+"that related work."
+msgstr ""
+
+#: ../../editing.md:121 c8c6d4f9aec24548be6f2a2d26ad284f
+msgid ""
+"Ask on social networks: Sometimes asking on Twitter for reviewers can "
+"identify good candidates."
+msgstr ""
+
+#: ../../editing.md:122 29ba76f084644361b591486d0c4661ab
+msgid "Check the work being referenced in the submission:"
+msgstr ""
+
+#: ../../editing.md:123 8f788d2e5ed34216a7e0434cd7931844
+msgid ""
+"Authors of software that is being built on might be interested in "
+"reviewing the submission."
+msgstr ""
+
+#: ../../editing.md:124 aecd3f6132b548138055f4b72f5ed1ff
+msgid ""
+"Users of the software that is being submission be interested in reviewing"
+" the submission"
+msgstr ""
+
+#: ../../editing.md:125 294125b1c6654509a55a4a87e71bd443
+msgid ""
+"Avoid asking JOSS editors to review: If at all possible, avoid asking "
+"JOSS editors to review as they are generally very busy editing their own "
+"papers."
+msgstr ""
+
+#: ../../editing.md:127 79d5e0b0ef3b486fb67f3fe0511645b2
+msgid ""
+"Once a reviewer accepts, the handling editor runs the command "
+"`@editorialbot add @username as reviewer` in the `PRE-REVIEW` issue. Add "
+"more reviewers with the same command. Under the uncommon circumstance "
+"that a review must be started before all reviewers have been identified "
+"(e.g., if finding a second reviewer is taking a long time and the first "
+"reviewer wants to get started), an editor may elect to start the review "
+"and add the remaining reviewers later. To accomplish this, the editor "
+"will need to hand-edit the review checklist to create space for the "
+"reviewers added after the review issues is created."
+msgstr ""
+
+#: ../../editing.md:130 16ba9cbed3c94a629a7aff1bd90c6291
+msgid "Starting the review"
+msgstr ""
+
+#: ../../editing.md:132 ccd53f6c37f242b1b911877fa7e9c1b9
+msgid ""
+"Next, run the command `@editorialbot start review`. If you haven't "
+"assigned an editor and reviewer, this command will fail and "
+"`@editorialbot` will tell you this. This will open the `REVIEW` issue, "
+"with prepared review checklists for each reviewer, and instructions. The "
+"editor should move the conversation to the separate `REVIEW` issue."
+msgstr ""
+
+#: ../../editing.md:134 3cbe8574ab8f4792ae7f8fe839e05c89
+msgid "Review"
+msgstr ""
+
+#: ../../editing.md:136 bf31464bd63349f3ba503187408dac67
+msgid ""
+"The `REVIEW` issue contains some instructions for the reviewers to get a "
+"checklist using the command `@editorialbot generate my checklist`. The "
+"reviewer(s) should check off items of the checklist one-by-one, until "
+"done. In the meantime, reviewers can engage the authors freely in a "
+"conversation aimed at improving the paper."
+msgstr ""
+
+#: ../../editing.md:138 dcd070b1d78e440099f479ff0a2a7e9e
+msgid ""
+"If a reviewer recants their commitment or is unresponsive, editors can "
+"remove them with the command `@editorialbot remove @username from "
+"reviewers`. You can also add new reviewers in the `REVIEW` issue."
+msgstr ""
+
+#: ../../editing.md:140 e3e6abaa736c4364b7a380072fbdefe9
+msgid ""
+"Comments in the `REVIEW` issue should be kept brief, as much as possible,"
+" with more lengthy suggestions or requests posted as separate issues, "
+"directly in the submission repository. A link-back to those issues in the"
+" `REVIEW` is helpful."
+msgstr ""
+
+#: ../../editing.md:142 6dc3f0fe1e9c4c8bae2c397282f35570
+msgid ""
+"When the reviewers are satisfied with the improvements, we ask that they "
+"confirm their recommendation to accept the submission."
+msgstr ""
+
+#: ../../editing.md:144 3d33796171b4423b9498b2019870a5bb
+msgid "Adding a new reviewer once the review has started"
+msgstr ""
+
+#: ../../editing.md:146 223e9320e2f241fbad473c96d116ec25
+msgid ""
+"Sometimes you'll need to add a new reviewer once the main review (i.e. "
+"post pre-review) is already underway. In this situation you should do the"
+" following:"
+msgstr ""
+
+#: ../../editing.md:148 2c32f175245f49e4bbfb7b9cbba3f175
+msgid "In the review thread, do `@editorialbot add @newreviewer as reviewer`."
+msgstr ""
+
+#: ../../editing.md:149 ee79dc393c664659a4630aae28ac15cf
+msgid ""
+"The new reviewer must use the command `@editorialbot generate my "
+"checklist` to get a checklist."
+msgstr ""
+
+#: ../../editing.md:152 98b3a290d25d4f2b81fe1a2c529f8aaa
+msgid "Post-review"
+msgstr ""
+
+#: ../../editing.md:154 b0385263d4914f7f95ad0ba80654bda3
+msgid ""
+"When a submission is ready to be accepted, we ask that the authors issue "
+"a new tagged release of the software (if changed), and archive it (on "
+"[Zenodo](https://zenodo.org/), [fig**share**](https://figshare.com/), or "
+"other). The authors then post the version number and archive DOI in the "
+"`REVIEW` issue. The handling editor executes the pre-publication steps, "
+"and pings the Track Editor-in-Chief for final processing."
+msgstr ""
+
+#: ../../editing.md:156 dd52392784634b948e15a964b80cc429
+msgid ""
+"Optionally you can ask EditorialBot to generate a checklist with all the "
+"post-review steps running the command: `@editorialbot create post-review "
+"checklist`"
+msgstr ""
+
+#: ../../editing.md:158 ee9fcf7e3bce4bf68049aa27061cfa26
+msgid "Pre-publication steps:"
+msgstr ""
+
+#: ../../editing.md:159 c1789b1a6ebd45de969fdd00d51e3384
+msgid "(Optional) Run `@editorialbot create post-review checklist`"
+msgstr ""
+
+#: ../../editing.md:160 ab121be0a95345ea93212c99be108c04
+msgid "Get a new proof with the `@editorialbot generate pdf` command."
+msgstr ""
+
+#: ../../editing.md:161 fe48b1e1bb3b4016a571de52fcb8acdb
+msgid ""
+"Download the proof, check all references have DOIs, follow the links and "
+"check the references."
+msgstr ""
+
+#: ../../editing.md:162 96ff3f242de14c91b1b16b870cf57190
+msgid ""
+"EditorialBot can help check references with the command `@editorialbot "
+"check references`"
+msgstr ""
+
+#: ../../editing.md:163 d101dc7a7cf44f42b1435e34cd9945a8
+msgid ""
+"Proof-read the paper and ask authors to fix any remaining typos, badly "
+"formed citations, awkward wording, etc.."
+msgstr ""
+
+#: ../../editing.md:164 2ffdfd41c5d34a12b80a07a8be7255ab
+msgid ""
+"Ask the author to make a tagged release and archive, and report the "
+"version number and archive DOI in the review thread."
+msgstr ""
+
+#: ../../editing.md:165 3051b32771ed4fa6beb9efa4f8bc99da
+msgid "Check the archive deposit has the correct metadata (title and author list)"
+msgstr ""
+
+#: ../../editing.md:166 ccf9d0666940483f8d57c5642b830627
+msgid ""
+"In most situations, the two author lists should match. Authors and "
+"editors should review the two, and any differences need to be explained."
+msgstr ""
+
+#: ../../editing.md:167 ac196a6ce5104305ad119ebce0706214
+msgid ""
+"Other contributors can be present (and they should be marked as such, if "
+"possible)"
+msgstr ""
+
+#: ../../editing.md:168 7c48124d7b1f42a1a82476eb5fc66d14
+msgid "Check that the all authors of the paper are in the archive metadata"
+msgstr ""
+
+#: ../../editing.md:169 40166d1d39d24148a9100d4360f6ca19
+msgid "Eventually, ask for the reason why the two lists differ"
+msgstr ""
+
+#: ../../editing.md:170 cd935c631a74446bbfc43553b9bb07e6
+msgid "Run `@editorialbot set <doi> as archive`."
+msgstr ""
+
+#: ../../editing.md:171 368d9095453b4bd18c092dc6e21e04c1
+msgid "Run `@editorialbot set <v1.x.x> as version` if the version was updated."
+msgstr ""
+
+#: ../../editing.md:172 9ac44e6c0edb46868744955ea9c0150d
+msgid ""
+"Run `@editorialbot recommend-accept` to generate the final proofs, which "
+"has EditorialBot notify the `@openjournals/joss-eics` team that the paper"
+" is ready for final processing."
+msgstr ""
+
+#: ../../editing.md:174 badc1c00d346425281eade6905e889fd
+msgid ""
+"At this point, the EiC/AEiC will take over to make final checks and "
+"publish the paper."
+msgstr ""
+
+#: ../../editing.md:176 77f1a1c6606547e3ab5ea9ca88f7d7dd
+msgid ""
+"It’s also a good idea to ask the authors to check the proof. We’ve had a "
+"few papers request a post-publication change of author list, for "
+"example—this requires a manual download/compile/deposit cycle and should "
+"be a rare event."
+msgstr ""
+
+#: ../../editing.md:179 c5a921af2ecc436eb220853ae603677a
+msgid "Rejecting a paper"
+msgstr ""
+
+#: ../../editing.md:181 8efdd60bb1cb44bdb5051d9d1a7566aa
+msgid ""
+"If you believe a submission should be rejected, for example, because it "
+"is out of scope for JOSS, then you should:"
+msgstr ""
+
+#: ../../editing.md:183 cf41a6d5b66d4a5987759324687f6bcc
+msgid ""
+"Ask EditorialBot to flag the submission as potentially out of scope with "
+"the command `@editorialbot query scope`. This command adds the `query-"
+"scope` label to the issue."
+msgstr ""
+
+#: ../../editing.md:184 fae66735afaa4048a0dbf3c52e71361a
+msgid ""
+"Mention to the author your reasons for flagging the submission as "
+"possibly out of scope, and _optionally_ give them an opportunity to "
+"defend their submission."
+msgstr ""
+
+#: ../../editing.md:185 f8412a3f08914dbd85c5da0f52ebe973
+msgid ""
+"During the scope review process, the editorial team may ask the authors "
+"to provide additional information about their submission to assist the "
+"editorial board with their decision."
+msgstr ""
+
+#: ../../editing.md:186 968111ab343f41ce81c9d602c9b5278f
+msgid ""
+"The TEiC will make a final determination of whether a submission is in "
+"scope, taking into account the feedback of other editors."
+msgstr ""
+
+#: ../../editing.md:188 6ec183d943404235a37ba3d47089981f
+msgid "**Scope reviews for resubmissions**"
+msgstr ""
+
+#: ../../editing.md:190 68327f04c16a46fbb0d61cb884365a69
+msgid ""
+"In the event that an author re-submits a paper to JOSS that was "
+"previously rejected, the TEiC will use their discretion to determine: 1) "
+"whether a full scope review by the entire editorial team is necessary, 2)"
+" if the previous reasons for rejection remain valid, or 3) if there have "
+"been enough updates to warrant sending the submission out for review."
+msgstr ""
+
+#: ../../editing.md:192 d326cebcc2c645e78ff94af22dd9cedd
+msgid "JOSS Collaborations"
+msgstr ""
+
+#: ../../editing.md:194 f99912839e0344578a143c27763823ae
+msgid "AAS publishing"
+msgstr ""
+
+#: ../../editing.md:196 e3b861edaece45999cf91c771506c552
+msgid ""
+"JOSS is collaborating with [AAS publishing](https://journals.aas.org/) to"
+" offer software review for some of the papers submitted to their "
+"journals. A detailed overview of the motivations/background is available "
+"in the [announcement blog post](https://blog.joss.theoj.org/2018/12/a"
+"-new-collaboration-with-aas-publishing), here we document the additional "
+"editorial steps that are necessary for JOSS to follow:"
+msgstr ""
+
+#: ../../editing.md:198 430ed54db1b84ce3b8fc3454c026de24
+msgid "**Before/during review**"
+msgstr ""
+
+#: ../../editing.md:200 2824e9d988df40d39bd555ab5021a72b
+#, python-format
+msgid ""
+"If the paper is a joint publication, make sure you apply the "
+"[`AAS`](https://github.com/openjournals/joss-"
+"reviews/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3AAAS+) label to both "
+"the `pre-review` and the `review` issues."
+msgstr ""
+
+#: ../../editing.md:201 fbab9c2ddbf24bc3be059c5caff98168
+msgid ""
+"Before moving the JOSS paper from `pre-review` to `review`, ensure that "
+"you (the JOSS editor) make the reviewers aware that JOSS will be "
+"receiving a small financial donation from AAS publishing for this review "
+"(e.g. [like this](https://github.com/openjournals/joss-"
+"reviews/issues/1852#issuecomment-553203738))."
+msgstr ""
+
+#: ../../editing.md:203 bd6a4d0ce06b4ef992111f0b0fab8ec9
+msgid "**After the paper has been accepted by JOSS**"
+msgstr ""
+
+#: ../../editing.md:205 15fc7b6817dd4a34a3738b6ddf38803f
+msgid ""
+"Once the JOSS review is complete, ask the author for the status of their "
+"AAS publication, specifically if they have the AAS paper DOI yet."
+msgstr ""
+
+#: ../../editing.md:206 1f05887484b3458c919fb4e94c3d54a7
+msgid ""
+"Once this is available, ask the author to add this information to their "
+"`paper.md` YAML header as documented in the [submission "
+"guidelines](paper.md#what-should-my-paper-contain)."
+msgstr ""
+
+#: ../../editing.md:215 451308dd5cd24ada9f6722ba8c1a0af9
+msgid ""
+"Pause the review (by applying the `paused` label) to await notification "
+"that the AAS paper is published."
+msgstr ""
+
+#: ../../editing.md:217 4ff28cbd250c4fceb96de378b856ac9b
+msgid "**Once the AAS paper is published**"
+msgstr ""
+
+#: ../../editing.md:219 bf3b62f96e854102825cd412df62de48
+msgid ""
+"Ask the EiC on rotation to publish the paper as normal (by tagging "
+"`@openjournals/joss-eics`)."
+msgstr ""
+
+#: ../../editing.md:221 a93e797d3cf34ede894cb4b3b3c8b0b4
+msgid "rOpenSci-reviewed or pyOpenSci-reviewed and accepted submissions"
+msgstr ""
+
+#: ../../editing.md:223 d405d6dec9e14b038b65cfc2b48521be
+msgid ""
+"If a paper has already been reviewed and accepted by rOpenSci or "
+"pyOpenSci, the streamlined JOSS review process is:"
+msgstr ""
+
+#: ../../editing.md:225 428f938147824290aaaed1b3fc54a753
+msgid "Assign yourself as editor and reviewer"
+msgstr ""
+
+#: ../../editing.md:226 564417ceb9e649d2bd8c9a9bfb405a6b
+msgid ""
+"Add a comment in the pre-review issue pointing to the rOpenSci or "
+"pyOpenSci review"
+msgstr ""
+
+#: ../../editing.md:227 8b7f7c94e76441c6ae25d3737691114d
+msgid "Add the rOpenSci/pyOpenSci label to the pre-review issue"
+msgstr ""
+
+#: ../../editing.md:228 cfd6fcb87a664d24993490dbb413a97f
+msgid "Start the review issue"
+msgstr ""
+
+#: ../../editing.md:229 cf1a6126e15a4f00acbde92f4ecda2f6
+msgid ""
+"Add a comment in the review issue pointing to the rOpenSci or pyOpenSci "
+"review"
+msgstr ""
+
+#: ../../editing.md:230 e6326b05c5ce4cce8be342399b12699a
+msgid "Compile the paper and check it looks OK"
+msgstr ""
+
+#: ../../editing.md:231 4054dfb927f34f0ebb7728cb76dcf2c2
+msgid "Go to to the source code repo and grab the Zenodo DOI"
+msgstr ""
+
+#: ../../editing.md:232 4be4829b0bc740f293b518b74c728de1
+msgid "Accept and publish the paper"
+msgstr ""
+

--- a/docs/locale/pl/LC_MESSAGES/editor_onboarding.po
+++ b/docs/locale/pl/LC_MESSAGES/editor_onboarding.po
@@ -1,0 +1,502 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: pl\n"
+"Language-Team: pl <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../editor_onboarding.md:1 ddb34aa291fa467782c10edc4e35d8ec
+msgid "Editor Onboarding"
+msgstr ""
+
+#: ../../editor_onboarding.md:3 4470f6e71d994a41bc3b0be762b41e49
+msgid "Onboarding a new JOSS editor"
+msgstr ""
+
+#: ../../editor_onboarding.md:5 7a2a0c328d17494296e4f01b7422db62
+msgid ""
+"All new editors at JOSS have an onboarding call with an Editor-in-Chief. "
+"You can use the structure below to make sure you highlight the most "
+"important aspects of being an editor."
+msgstr ""
+
+#: ../../editor_onboarding.md:7 f980df4541fe4b068ece12e9398edac7
+msgid "**Thing to check before the call**"
+msgstr ""
+
+#: ../../editor_onboarding.md:9 af4253ba4430455bb650d2f4cb581162
+msgid ""
+"Have they reviewed or published in JOSS before? If not, you'll need to "
+"spend significantly more time explaining how the review process works."
+msgstr ""
+
+#: ../../editor_onboarding.md:10 367afd43cfd54e6c86cde5bae5877cdd
+msgid ""
+"Check on their research background (e.g., what tracks they might edit "
+"most actively in)."
+msgstr ""
+
+#: ../../editor_onboarding.md:11 dcfc47c7f9804d4f8b882ab744958e48
+msgid ""
+"Make sure to send them the [editorial "
+"guide](https://joss.readthedocs.io/en/latest/editing.html) to read before"
+" the call."
+msgstr ""
+
+#: ../../editor_onboarding.md:13 e284abf557264473b259da6e015f2cea
+msgid "The onboarding call"
+msgstr ""
+
+#: ../../editor_onboarding.md:15 26bc3820950d4500bc9e20f4c4414eb1
+msgid "**Preamble/introductions**"
+msgstr ""
+
+#: ../../editor_onboarding.md:17 0288d672dd644d869574fe8651ef8880
+msgid "Welcome! Thank them for their application to join the team."
+msgstr ""
+
+#: ../../editor_onboarding.md:18 fc4b238db8ee4f83be7ba4ca0bc59fb9
+msgid ""
+"Point out that this isn't an interview. Rather, this is an informational "
+"call designed to give the candidate the information they need to make an "
+"informed decision about editing at JOSS."
+msgstr ""
+
+#: ../../editor_onboarding.md:19 da6f67fa611c48c6bad424c28d3951a9
+msgid ""
+"90-day trial period/try out. Editor or JOSS editorial board can decide to"
+" part ways after that period."
+msgstr ""
+
+#: ../../editor_onboarding.md:20 0e10b197ceca4bfc86456fb0c1192d23
+msgid ""
+"No strict term limits. Some editors have been with us for 7+ years, "
+"others do 1-2 years. Most important thing is to be proactive with your "
+"editing responsibilities and communicating any issues with the EiCs."
+msgstr ""
+
+#: ../../editor_onboarding.md:21 d154b8c176bf47159aaddb9e58e4452c
+msgid "Confirm with them their level of familiarity with JOSS/our review process."
+msgstr ""
+
+#: ../../editor_onboarding.md:22 660c4e8cc8d042e08cedb31cff5d0dcb
+msgid ""
+"Point out that they *do not* need to make a decision on the call today. "
+"They are welcome to have a think about joining and get back to us."
+msgstr ""
+
+#: ../../editor_onboarding.md:24 ff266d9d359d4404b1f7d46e7bfa3f6e
+msgid "**Share your screen**"
+msgstr ""
+
+#: ../../editor_onboarding.md:26 90c995e80f744e3f85b69f1af85caae6
+msgid "Visit JOSS (https://joss.theoj.org)"
+msgstr ""
+
+#: ../../editor_onboarding.md:27 df997b30aea14f7bae260fb0f87e5a2b
+msgid ""
+"Pick a recently-published paper (you might want to identify this before "
+"the call one that shows off the review process well)."
+msgstr ""
+
+#: ../../editor_onboarding.md:28 e0bf12eb96994b469b6478049c9d70b0
+msgid "Show the paper on the JOSS site, and then go to the linked review issue."
+msgstr ""
+
+#: ../../editor_onboarding.md:29 c04aa708d2ba4de787763ba25b8460a8
+msgid ""
+"Explain that there are *two* issues per submission – the pre-review issue"
+" and the main review issue."
+msgstr ""
+
+#: ../../editor_onboarding.md:31 ebedb7d569f143b7901d1e5920d334ab
+msgid "**The pre-review issue**"
+msgstr ""
+
+#: ../../editor_onboarding.md:33 6c3464eb92a14c1ea6d4b264b68baaa7
+msgid ""
+"The 'meeting room for the paper'. Where author meets editor, and "
+"reviewers are identified."
+msgstr ""
+
+#: ../../editor_onboarding.md:34 43f5cee5fd4040fbb79f098fe9809d54
+msgid ""
+"Note that the EiC may have initiated a scope review. The editor should "
+"not start editing until this has completed. Also, editors are able to "
+"query the scope (as are reviewers) if they think the EiC should have (but"
+" didn't)."
+msgstr ""
+
+#: ../../editor_onboarding.md:35 411abf04587a4cbf8f75697715c489a9
+msgid "Walk them through what is happening in the pre-review issue..."
+msgstr ""
+
+#: ../../editor_onboarding.md:36 b737b32ada224c4bb1f3257819a037cf
+msgid ""
+"Editor is invited (likely with GitHub mention but also via email invite "
+"(`@editorialbot invite @editor as editor`))"
+msgstr ""
+
+#: ../../editor_onboarding.md:37 e7cb4bb86a9344e6b3c83a57b8295014
+msgid "Once editor accepts they start looking for reviewers."
+msgstr ""
+
+#: ../../editor_onboarding.md:39 2241d7556d9344b0bf3d888fbd589f75
+msgid "**Finding reviewers**"
+msgstr ""
+
+#: ../../editor_onboarding.md:41 bc39c6a124ce4ab9bb5966d25e08574f
+msgid "Explain that this is one of the more time-intensive aspects of editing."
+msgstr ""
+
+#: ../../editor_onboarding.md:42 4d11d78ab4224553b74d70cf8c81b1c9
+msgid ""
+"Explain where you can look for editors (your own professional network, "
+"asking the authors for recommendations, the [reviewers "
+"application](https://reviewers.joss.theoj.org/), similar papers "
+"identified by Editorialbot, )"
+msgstr ""
+
+#: ../../editor_onboarding.md:43 257f9d1b6ede475da45d8dfd2b8cd0e4
+msgid ""
+"Point out that we have a minimum of two reviewers, but if more than that "
+"accept (e.g., 3/4 then take them all – this gives you redundancy if one "
+"drops out)."
+msgstr ""
+
+#: ../../editor_onboarding.md:44 b9b7f5b236234980b8338708625b6c99
+msgid ""
+"Don't invite only one reviewer at a time! If you do this, it may take "
+"many weeks to find two reviewers who accept. Try 3/4/5 invites "
+"simultaneously."
+msgstr ""
+
+#: ../../editor_onboarding.md:45 958063b5e00d409986233f3c63a01288
+msgid ""
+"The [sample messages](sample_messages) section of the documentation has "
+"some example language you can use."
+msgstr ""
+
+#: ../../editor_onboarding.md:47 32dd245a660d4f8f9f9a6f0dd237a14b
+msgid "**The review**"
+msgstr ""
+
+#: ../../editor_onboarding.md:49 6e2a3f7b1656412dbb572f635fcf461c
+msgid "Once at least two reviewers are assigned, time to get going!"
+msgstr ""
+
+#: ../../editor_onboarding.md:50 5fba2497e6b1466a85ae9172fce563e0
+msgid "Encourage reviewers to complete their review in 4-6 weeks."
+msgstr ""
+
+#: ../../editor_onboarding.md:51 81a249a1d7ea458d86906e025a10c1ca
+msgid ""
+"Make sure to check in on the review – if reviewers haven't started after "
+"~1-2 weeks, time to remind them."
+msgstr ""
+
+#: ../../editor_onboarding.md:52 08f9e20221544c80be398b68741ca9f2
+msgid ""
+"Your role as editor is not to do the review yourself, rather, your job is"
+" to ensure that both reviewers give a good review and to facilitate "
+"discussion and consensus on what the author needs to do."
+msgstr ""
+
+#: ../../editor_onboarding.md:53 4a7a2460acb24ceeb3ffabd0f91b46fe
+msgid ""
+"Walk the editor through the various review artifacts: The checklist, "
+"comments/questions/discussion between reviewers and author, issues opened"
+" on the upstream repository (and cross-linked into the review thread)."
+msgstr ""
+
+#: ../../editor_onboarding.md:54 37291112d1d24315a1986185a1889f9b
+msgid ""
+"Point editors to the ['top tips'](editor_tips) section of our docs. Much "
+"of what makes an editor successful is regular check-ins on the review, "
+"and nudging people if nothing is happening."
+msgstr ""
+
+#: ../../editor_onboarding.md:55 81b8bcab7a7c4866a1ce5d80f36f21a0
+msgid "Do *not* let a review go multiple weeks without checking in."
+msgstr ""
+
+#: ../../editor_onboarding.md:57 55f437eb8c484edc8358b4b68812fe8b
+msgid "**Wrapping up the review**"
+msgstr ""
+
+#: ../../editor_onboarding.md:59 e24ad8981bcd4ea7a3ed82eabeb35cdf
+msgid ""
+"Once the review is wrapping up, show the candidate the checks that an "
+"editor should be doing (reading the paper, suggested edits, asking for an"
+" archive etc.)"
+msgstr ""
+
+#: ../../editor_onboarding.md:60 a7dc51a9e76d46dbbaf8382844910310
+msgid ""
+"Show the `recommend-accept` step which is the formal hand-off between "
+"editor and editor-in-chief."
+msgstr ""
+
+#: ../../editor_onboarding.md:61 cc1e0eb549fc462088805e50b4310680
+msgid ""
+"The [sample messages](sample_messages) section of the documentation has a"
+" checklist for the last steps of the review (for both authors and "
+"editors)."
+msgstr ""
+
+#: ../../editor_onboarding.md:64 de4909e22b204f90b674d316ada8efab
+msgid "**Show them the dashboard on the JOSS site**"
+msgstr ""
+
+#: ../../editor_onboarding.md:66 1646494e0e7f438fb5ae2ae411724336
+msgid ""
+"Point out that this means you *do not* need to stay on top of all of your"
+" notifications (the dashboard has the latest information)."
+msgstr ""
+
+#: ../../editor_onboarding.md:67 fd5cb0e8de564c4cb29ebd8f1c8af3df
+msgid ""
+"Highlight here that we ask editors to handle 8-12 submissions per year on"
+" average."
+msgstr ""
+
+#: ../../editor_onboarding.md:68 3583962d5d484e40a914d1e7686d4f6e
+msgid ""
+"...and that means 3-4 submissions on their desk at any one time (once "
+"they have completed their initial probationary period)."
+msgstr ""
+
+#: ../../editor_onboarding.md:69 4cf41efd823e4bbfa2379b5ea90ce9d9
+msgid ""
+"Show them the backlog for a track, and how they are welcome to pick "
+"papers from it (ideally oldest first)."
+msgstr ""
+
+#: ../../editor_onboarding.md:70 cc536af2918645c290f873f07dbfd5b7
+msgid ""
+"Show them their profile page, and how they can list their tracks there, "
+"and also what their availability is."
+msgstr ""
+
+#: ../../editor_onboarding.md:72 532406aae528432c8e6b8da2538281cf
+msgid "**Other important things to highlight**"
+msgstr ""
+
+#: ../../editor_onboarding.md:74 0d82dd40846f4a688a25ef91c634db8d
+msgid ""
+"Don't invite other editors as reviewers. We're all busy editing our own "
+"papers..."
+msgstr ""
+
+#: ../../editor_onboarding.md:75 2b19e938b20648679ccb8b70188f7c45
+msgid ""
+"Please be willing to edit outside of your specialisms. This helps JOSS "
+"run smoothly – often we don't have the 'ideal' editor for a submission "
+"and someone has to take it."
+msgstr ""
+
+#: ../../editor_onboarding.md:76 311d1b82d8e845f790edd906dc77e098
+msgid ""
+"Highlight that editors will have a buddy to work with for the first few "
+"months, and that it's very common for editors to ask questions in Slack "
+"(and people generally respond quickly)."
+msgstr ""
+
+#: ../../editor_onboarding.md:77 f8d7387c02164ea5b55945c48a7a6e25
+msgid ""
+"Scope reviews only work if editors vote! Please respond and vote on the "
+"weekly scope review email if you can. The process is private (authors "
+"don't know what editors are saying). Detailed comments are really helpful"
+" for the EiCs."
+msgstr ""
+
+#: ../../editor_onboarding.md:79 76170cd543ae4bc988d3e904381a1a35
+msgid "**Wrapping up**"
+msgstr ""
+
+#: ../../editor_onboarding.md:81 ec717aaa4f5c413a94e6b5246b09f47c
+msgid ""
+"Make sure you've highlighted everything in the ['top tips'](editor_tips) "
+"section of our docs."
+msgstr ""
+
+#: ../../editor_onboarding.md:82 ed7d3ee869a74d3ab0a208774debdcce
+msgid ""
+"Reinforce that this is a commitment, and thay regular attention to their "
+"submissions is absolutely critical (i.e., check in a couple of times per "
+"week)."
+msgstr ""
+
+#: ../../editor_onboarding.md:83 7f4f97f224a9454a89fcad728d2aec7c
+msgid ""
+"Ask if they would like to move forward or would like time to consider the"
+" opportunity."
+msgstr ""
+
+#: ../../editor_onboarding.md:84 1d4a5693fcf0457297ce32e038486299
+msgid ""
+"If they want to move forward, highlight they will receive a small number "
+"of invites: One to the JOSS editors GitHub team, a Slack invite, a Google"
+" Group invite, and an invite to the JOSS website to fill out their "
+"profile."
+msgstr ""
+
+#: ../../editor_onboarding.md:85 ad062cf91d9140008983e44436bf16bf
+msgid ""
+"If they are joining the team, make sure they mark themselves as "
+"unavailable in the [JOSS reviewers "
+"database](https://reviewers.joss.theoj.org/) (so they don't get asked to "
+"review any longer)."
+msgstr ""
+
+#: ../../editor_onboarding.md:86 959c06266b3340ccb404aa56a4515168
+msgid "Thank them again, and welcome them to the team."
+msgstr ""
+
+#: ../../editor_onboarding.md:88 57e5e7cc9d8c45a98704e42774733642
+msgid "**Communicate outcome to EiC**"
+msgstr ""
+
+#: ../../editor_onboarding.md:90 2695b240ae514e95b277e796e01d9d52
+msgid ""
+"Let the EiC know what the outcome was, and ask them to send out the "
+"invites to our various systems."
+msgstr ""
+
+#: ../../editor_onboarding.md:91 d3d7f5c61f004cd3831fc98199465ea9
+msgid "Work with EiC to identify onboarding buddy."
+msgstr ""
+
+#: ../../editor_onboarding.md:92 47c06ec3ec51411e85136587a501d84f
+msgid ""
+"Decide who is going to identify the first couple of papers for the editor"
+" to work on."
+msgstr ""
+
+#: ../../editor_onboarding.md:94 9103afd226aa4cfb93da986195af690d
+msgid "Editorial buddy"
+msgstr ""
+
+#: ../../editor_onboarding.md:96 52cc074f70f0452eb7aa5a54f58904e8
+msgid ""
+"New editors are assigned an editorial 'buddy' from the existing editorial"
+" team. The buddy is there to help the new editor onboard successfully and"
+" to provide a dedicated resource for any questions they might have but "
+"don't feel comfortable posting to the editor mailing list."
+msgstr ""
+
+#: ../../editor_onboarding.md:98 9b402229e4634e12a3be6084b380eb10
+msgid ""
+"Buddy assignments don't have a fixed term but generally require a "
+"commitment for 1-2 months."
+msgstr ""
+
+#: ../../editor_onboarding.md:100 c2e8c9ac253c48e08bf6919d135ec14d
+msgid "Some things you might need to do as a buddy for a new editor:"
+msgstr ""
+
+#: ../../editor_onboarding.md:102 93318044114a41c1a48256c92ba8839b
+msgid "Respond to questions via email or on GitHub review issues."
+msgstr ""
+
+#: ../../editor_onboarding.md:103 cf3e5a5a01464d21a0b380bb217202cf
+msgid ""
+"Check in with the new editor every couple of weeks if there hasn't been "
+"any other communication."
+msgstr ""
+
+#: ../../editor_onboarding.md:104 985001ec82aa4d67b2cb85a902d46531
+msgid "(Optionally) keep an eye on the new editor's submissions."
+msgstr ""
+
+#: ../../editor_onboarding.md:106 8b15cb26b49a482ab1161d587f7b4e85
+msgid "Managing notifications"
+msgstr ""
+
+#: ../../editor_onboarding.md:108 4b7b9807a9144dbba387399414759885
+msgid ""
+"Being on the JOSS editorial team means that there can be a _lot_ of "
+"notifications from GitHub if you don't take some proactive steps to "
+"minimize noise from the reviews repository."
+msgstr ""
+
+#: ../../editor_onboarding.md:110 4192d1ba00c44387b937cfe75bb00346
+msgid "Things you should do when joining the editorial team"
+msgstr ""
+
+#: ../../editor_onboarding.md:112 ff696e608e4a489abe1e1b1940566fc6
+msgid "**Curate your GitHub notifications experience**"
+msgstr ""
+
+#: ../../editor_onboarding.md:114 5651eddd6cc447a189ce01c753bd5263
+msgid ""
+"GitHub has extensive documentation on [managing "
+"notifications](https://help.github.com/en/articles/managing-your-"
+"notifications) which explains when and why different notifications are "
+"sent from a repository."
+msgstr ""
+
+#: ../../editor_onboarding.md:116 a51c81c5cf2f4c5b9d3678f6cfd63265
+msgid "**Set up email filters**"
+msgstr ""
+
+#: ../../editor_onboarding.md:118 aff07e303eb9460b9287e949edd244ec
+msgid ""
+"Email filters can be very useful for managing incoming email "
+"notifications, here are some recommended resources:"
+msgstr ""
+
+#: ../../editor_onboarding.md:120 b0784e8ba926473ab47e6b805ef7e761
+msgid ""
+"A GitHub blog post describing how to set up [email "
+"filters](https://github.blog/2017-07-18-managing-large-numbers-of-github-"
+"notifications/)."
+msgstr ""
+
+#: ../../editor_onboarding.md:122 3997825197d447a0b948aeaedd3cdc6c
+msgid "If you use Gmail:"
+msgstr ""
+
+#: ../../editor_onboarding.md:124 8e302db6f0ec4c139627255bd76d26e7
+msgid "https://gist.github.com/ldez/bd6e6401ad0855e6c0de6da19a8c50b5"
+msgstr ""
+
+#: ../../editor_onboarding.md:125 5b45a6e44a9d4546bb68495a5d6e8c53
+msgid "https://github.com/jessfraz/gmailfilters"
+msgstr ""
+
+#: ../../editor_onboarding.md:126 6fc0008f6d0f42ab89e74241d5c27c27
+msgid "https://hackernoon.com/how-to-never-miss-a-github-mention-fdd5a0f9ab6d"
+msgstr ""
+
+#: ../../editor_onboarding.md:128 dc6303ca879a468d810e323257f2ce35
+msgid "**Use a dedicated tool**"
+msgstr ""
+
+#: ../../editor_onboarding.md:130 a97e0e369ba64c18813e95ad318a2824
+msgid ""
+"For papers that you are already assigned to edit, the dedicated JOSS "
+"dashboard aggregates notifications associated with each paper. The "
+"dashboard is available at: "
+"`https://joss.theoj.org/dashboard/<yourgithubusername>`"
+msgstr ""
+
+#: ../../editor_onboarding.md:132 3337ea7412484660a8d38fad4340e16c
+msgid "Another tool you might want to try out is [Octobox](https://octobox.io/)."
+msgstr ""
+

--- a/docs/locale/pl/LC_MESSAGES/editor_tips.po
+++ b/docs/locale/pl/LC_MESSAGES/editor_tips.po
@@ -1,0 +1,143 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: pl\n"
+"Language-Team: pl <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../editor_tips.md:1 d749fc4d1210491180004f137656a576
+msgid "Top tips for JOSS editors"
+msgstr ""
+
+#: ../../editor_tips.md:3 fe01b068c66a4640b184ee34313798a8
+msgid "**Aim for reviewer redundancy**"
+msgstr ""
+
+#: ../../editor_tips.md:5 506d698bf9d74715b3e2a51baa97cb82
+msgid ""
+"If you have 3 people agree to review, take them up on their offer(s), "
+"that way if one person drops out, you'll have a backup and won't have to "
+"look for more reviewers. Also, when sending invites, try pinging a number"
+" of people at the same time rather than doing it one-by-one."
+msgstr ""
+
+#: ../../editor_tips.md:7 ba637b6b74fc45a5ad0802cba296d3b6
+msgid "**Email is a good backup**"
+msgstr ""
+
+#: ../../editor_tips.md:9 82b8d154d4ac4140b8ddca53676a282f
+msgid ""
+"Email is often the most reliable way of contacting people. Whether it's "
+"inviting reviewers, following up with reviewers or authors etc., if "
+"you've not heard back from someone on GitHub, try emailing them (their "
+"email is often available on their GitHub profile page)."
+msgstr ""
+
+#: ../../editor_tips.md:11 f6cb9d52f5ae488a8abb2ff29c8d32df
+msgid "**Default to over-communicating**"
+msgstr ""
+
+#: ../../editor_tips.md:13 6695c4e228e346d4a75e591262ae45cf
+msgid ""
+"When you take an action (even if it isn't on GitHub), share on the review"
+" thready what you're up to. For example, if you're looking for reviewers "
+"and are sending emails – leave a note on the review thread saying as "
+"much."
+msgstr ""
+
+#: ../../editor_tips.md:15 62e357fb51d3494499791cc65e29e31c
+msgid "**Use the JOSS Slack**"
+msgstr ""
+
+#: ../../editor_tips.md:17 2772614bb80c4087a5440566297059c8
+msgid ""
+"There's lots of historical knowledge in our Slack, and it's a great way "
+"to get questions answered."
+msgstr ""
+
+#: ../../editor_tips.md:19 efa88c0a4ded4ea8abe31c1351399c81
+msgid "**Ask reviewers to complete their review in 4-6 weeks**"
+msgstr ""
+
+#: ../../editor_tips.md:21 d77e168b384e4e0fbaf8d3f737851eea
+msgid ""
+"We aim for a total submission ... publication time of ~3 months. This "
+"means we ideally want reviewers to complete their review in 4-6 weeks "
+"(max)."
+msgstr ""
+
+#: ../../editor_tips.md:23 91ac07068efa4dcc9fd140f4dd07881a
+msgid "**Use saved replies on GitHub**"
+msgstr ""
+
+#: ../../editor_tips.md:25 66f9b3c7639c4d4c9be2e7e2a8b75f9e
+msgid ""
+"[Saved replies](https://docs.github.com/en/get-started/writing-on-github"
+"/working-with-saved-replies/using-saved-replies) on GitHub can be a huge "
+"productivity boost. Try making some using the example messages listed "
+"above."
+msgstr ""
+
+#: ../../editor_tips.md:27 08a7192f079847eaaad81d0d5681b1d4
+msgid "**Ping reviewers if they’ve not started after 2 weeks**"
+msgstr ""
+
+#: ../../editor_tips.md:29 78d6ae87e79744fe8295e3a4cdf254e1
+msgid ""
+"If a reviewer hasn't started within 1-2 weeks, you should probably give "
+"them a nudge. People often agree to review, and then forget about the "
+"review."
+msgstr ""
+
+#: ../../editor_tips.md:31 859a2e9877c4438ca943f94468d4a53b
+msgid "**Learn how to nudge gently, and often**"
+msgstr ""
+
+#: ../../editor_tips.md:33 2c1a7dbeb8c64edba0a8265789489cd4
+msgid ""
+"One of your jobs as the editor is to ensure the review keeps moving at a "
+"reasonable pace. If nothing has happened for a week or so, consider "
+"nudging the author or reviewers (depending upon who you're waiting for). "
+"A friendly _\"👋 reviewer, how are you getting along here\"_ can often be "
+"sufficient to get things moving again."
+msgstr ""
+
+#: ../../editor_tips.md:35 b1065cb4816f4cc08d9b63e4224432f0
+msgid "**Check in twice a week**"
+msgstr ""
+
+#: ../../editor_tips.md:37 effa9ac74ffc4db9bd03690bc60a1928
+msgid ""
+"Try to check in on your JOSS submissions twice per week, even if only for"
+" 5 minutes. Use your dashboard to stay on top of the current status of "
+"your submissions (i.e., who was the last person to comment on the "
+"thread)."
+msgstr ""
+
+#: ../../editor_tips.md:39 543a54fa561342b994523649f42b3ff4
+msgid "**Leave feedback on reviewers**"
+msgstr ""
+
+#: ../../editor_tips.md:41 6902b4e9f521488a900866b1592721cd
+msgid ""
+"Leave feedback on the [reviewers "
+"application](https://reviewers.joss.theoj.org/) at the end of the review."
+" This helps future editors when they're seeking out good reviewer "
+"candidates."
+msgstr ""
+

--- a/docs/locale/pl/LC_MESSAGES/editorial_bot.po
+++ b/docs/locale/pl/LC_MESSAGES/editorial_bot.po
@@ -1,0 +1,395 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: pl\n"
+"Language-Team: pl <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../editorial_bot.md:1 39acd70d3890461db4a421caea70b586
+msgid "Interacting with EditorialBot"
+msgstr ""
+
+#: ../../editorial_bot.md:3 6e5c118315d347549b4b783c80abe26f
+msgid ""
+"The Open Journals' editorial bot or `@editorialbot` on GitHub, is our "
+"editorial bot that interacts with authors, reviewers, and editors on JOSS"
+" reviews."
+msgstr ""
+
+#: ../../editorial_bot.md:5 034ec24930fa442282487029999399c2
+msgid ""
+"`@editorialbot` can do a bunch of different things. If you want to ask "
+"`@editorialbot` what it can do, simply type the following in a JOSS "
+"`review` or `pre-review` issue:"
+msgstr ""
+
+#: ../../editorial_bot.md:13 37c4358c69094920959adba7179a6576
+msgid ""
+"EditorialBot commands must be placed in the first line of a comment. "
+"Other text can be added after the first line with the command. Multiple "
+"commands are not allowed in the same comment, only the first one will be "
+"interpreted."
+msgstr ""
+
+#: ../../editorial_bot.md:16 79d66b5ff2a44ec58b6fe2582590f359
+msgid "Author and reviewers commands"
+msgstr ""
+
+#: ../../editorial_bot.md:18 722a20053ba74dd5bf80c265dcd7370e
+msgid ""
+"A subset of the EditorialBot commands are available to authors and "
+"reviewers:"
+msgstr ""
+
+#: ../../editorial_bot.md:20 3d4709ba4cc040d39be82497e5264a8f
+msgid "Compiling papers"
+msgstr ""
+
+#: ../../editorial_bot.md:22 329087aa872f4a2d86347f06dcd6f9df
+msgid ""
+"When a `pre-review` or `review` issue is opened, `@editorialbot` will try"
+" to compile the JOSS paper by looking for a `paper.md` file in the "
+"repository specified when the paper was submitted."
+msgstr ""
+
+#: ../../editorial_bot.md:24 5fe3cebe75d04022a072ef339b2909fe
+msgid ""
+"If it can't find the `paper.md` file it will say as much in the review "
+"issue. If it can't compile the paper (i.e. there's some kind of Pandoc "
+"error), it will try and report that error back in the thread too."
+msgstr ""
+
+#: ../../editorial_bot.md:27 beff48a007e444379df50e58937f3d27
+msgid ""
+"To compile the papers ``@editorialbot`` is running this `Docker image "
+"<https://github.com/openjournals/inara>`_."
+msgstr ""
+
+#: ../../editorial_bot.md:30 681cd9ecb4084a8aaa3d5a8f79c6f9e6
+msgid ""
+"Anyone can ask `@editorialbot` to compile the paper again (e.g. after a "
+"change has been made). To do this simply comment on the review thread as "
+"follows:"
+msgstr ""
+
+#: ../../editorial_bot.md:36 3f33e1ce9c8c4ac184f223dfba1a26d9
+msgid "Compiling papers from a specific branch"
+msgstr ""
+
+#: ../../editorial_bot.md:38 de44ff34a34848afb471e92e2b39db01
+msgid ""
+"By default, EditorialBot will look for papers in the branch set in the "
+"body of the issue (or in the default git branch if none is present). If "
+"you want to compile a paper from a specific branch (for instance: `my-"
+"custom-branch-name`), change that value with:"
+msgstr ""
+
+#: ../../editorial_bot.md:44 91b288f445cd45b6801f6ba4131e2737
+msgid "And then compile the paper normally:"
+msgstr ""
+
+#: ../../editorial_bot.md:50 5f048407817d418587b4069d5ae52baa
+msgid "Compiling preprint files"
+msgstr ""
+
+#: ../../editorial_bot.md:52 9218493b1e6c4a30b0f342357ed2e094
+msgid ""
+"If you need a generic paper file suitable for preprint servers (arXiv-"
+"like) you can use the following command that will generate a LaTeX file:"
+msgstr ""
+
+#: ../../editorial_bot.md:58 63abe318e90744bcabb914be85dbc8c8
+msgid "Finding reviewers"
+msgstr ""
+
+#: ../../editorial_bot.md:60 cb4985c235854d50a0b4632dfbafbee7
+msgid ""
+"Sometimes submitting authors suggest people the think might be "
+"appropriate to review their submission. If you want the link to the "
+"current list of JOSS reviewers, type the following in the review thread:"
+msgstr ""
+
+#: ../../editorial_bot.md:66 a53475cbbe5c4e829a5128eec29788eb
+msgid "Reviewers checklist command"
+msgstr ""
+
+#: ../../editorial_bot.md:68 59d7682aad184964b92f6e9e5b4e9e1f
+msgid ""
+"Once a user is assigned as reviewer and the review has started, the "
+"reviewer must type the following to get a review checklist:"
+msgstr ""
+
+#: ../../editorial_bot.md:74 b7c1bec8c7074b74b49214547c90b2ea
+msgid "Editorial commands"
+msgstr ""
+
+#: ../../editorial_bot.md:76 e8ee53cf551a428290fed02a51ca30dd
+msgid ""
+"Most of `@editorialbot`'s functionality can only be used by the journal "
+"editors."
+msgstr ""
+
+#: ../../editorial_bot.md:78 3649ad4afea04045888f03b418a67e49
+msgid "Assigning an editor"
+msgstr ""
+
+#: ../../editorial_bot.md:80 ccef8cbe57744489b3132de9e9bf0c4b
+msgid ""
+"Editors can either assign themselves or other editors as the editor of a "
+"submission as follows:"
+msgstr ""
+
+#: ../../editorial_bot.md:86 9f41cbfc147744f3a258c12f0b484fd5
+msgid "Inviting an editor"
+msgstr ""
+
+#: ../../editorial_bot.md:88 8459a863cecc41fdb46a1a6784a0b112
+msgid ""
+"EditorialBot can be used by EiCs to send email invites to registered "
+"editors as follows:"
+msgstr ""
+
+#: ../../editorial_bot.md:94 8efddf6295c04e1ba82440965ef33679
+msgid ""
+"This will send an automated email to the editor with a link to the GitHub"
+" `pre-review` issue."
+msgstr ""
+
+#: ../../editorial_bot.md:96 754bad1fbee2420482fbb9ab72b76cd1
+msgid "Adding and removing reviewers"
+msgstr ""
+
+#: ../../editorial_bot.md:98 926e3bce14ea48fc9b7259d6f1f455ac
+msgid "Reviewers should be assigned by using the following commands:"
+msgstr ""
+
+#: ../../editorial_bot.md:110 2689fcd6d2c64984a4d15988b0800a0d
+msgid "Starting the review"
+msgstr ""
+
+#: ../../editorial_bot.md:112 623edf03a5c644c2ad3585a866f58188
+msgid ""
+"Once the reviewer(s) and editor have been assigned in the `pre-review` "
+"issue, the editor starts the review with:"
+msgstr ""
+
+#: ../../editorial_bot.md:119 2962cbfb38a1482ca1cbb0d9ff40eb35
+msgid ""
+"If a reviewer recants their commitment or is unresponsive, editors can "
+"remove them with the command `@editorialbot remove @username from "
+"reviewers`. You can then delete that reviewer's checklist. You can also "
+"add new reviewers in the `REVIEW` issue with the command `@editorialbot "
+"add @username to reviewers`."
+msgstr ""
+
+#: ../../editorial_bot.md:122 7fd6f88a15de4d62a481cbf13d924336
+msgid "Reminding reviewers and authors"
+msgstr ""
+
+#: ../../editorial_bot.md:124 91f3ec6e1e9c4e61a87f4327e47c1114
+msgid ""
+"EditorialBot can remind authors and reviewers after a specified amount of"
+" time to return to the review issue. Reminders can only be set by "
+"editors, and only for REVIEW issues. For example:"
+msgstr ""
+
+#: ../../editorial_bot.md:142 53deec31cc8540399b9d6e5b36673991
+msgid ""
+"Most units of times are understood by EditorialBot e.g. "
+"`hour/hours/day/days/week/weeks`."
+msgstr ""
+
+#: ../../editorial_bot.md:145 160a106675bf4687a54aee81d86341b1
+msgid "Setting the software archive"
+msgstr ""
+
+#: ../../editorial_bot.md:147 8cde5b01e4d94b4dbfda848ec1a6f4e0
+msgid ""
+"When a submission is accepted, we ask that the authors to create an "
+"archive (on [Zenodo](https://zenodo.org/), "
+"[fig**share**](https://figshare.com/), or other) and post the archive DOI"
+" in the `REVIEW` issue. The editor should ask `@editorialbot` to add the "
+"archive to the issue as follows:"
+msgstr ""
+
+#: ../../editorial_bot.md:153 ddf0409112b744dca692a08eea0ce55d
+msgid "Changing the software version"
+msgstr ""
+
+#: ../../editorial_bot.md:155 d7163a45946e48398dfe080ea40bd5f0
+msgid ""
+"Sometimes the version of the software changes as a consequence of the "
+"review process. To update the version of the software do the following:"
+msgstr ""
+
+#: ../../editorial_bot.md:161 b8b4d78c6f264b8eb9f892c729c742ca
+msgid "Changing the git branch"
+msgstr ""
+
+#: ../../editorial_bot.md:163 a358f3205adb476caac745d1f609922c
+msgid ""
+"Sometimes the paper-md file is located in a topic branch. In order to "
+"have the PDF compiled from that branch it should be added to the issue. "
+"To update the branch value do the following (in the example, the name of "
+"the topic branch is _topic-branch-name_):"
+msgstr ""
+
+#: ../../editorial_bot.md:169 99cfd86ac4334d3a93a6fe6d5f468a0b
+msgid "Changing the repository"
+msgstr ""
+
+#: ../../editorial_bot.md:171 cc86ca0a157b4fba8180dec0b11e90f2
+msgid ""
+"Sometimes authors will move their software repository during the review. "
+"To update the value of the repository URL do the following:"
+msgstr ""
+
+#: ../../editorial_bot.md:178 55a044b6c92e4a6c9b2084a46ceef02c
+msgid "Check references"
+msgstr ""
+
+#: ../../editorial_bot.md:180 5b5719f0438e40a68b081b911b715d3a
+msgid ""
+"Editors can ask EditorialBot to check if the DOIs in the bib file are "
+"valid with the command:"
+msgstr ""
+
+#: ../../editorial_bot.md:187 3d85bd0c5ba54e51908722e5b1920804
+msgid ""
+"EditorialBot can verify that DOIs resolve, but cannot verify that the DOI"
+" associated with a paper is actually correct. In addition, DOI "
+"suggestions from EditorialBot are just that - i.e. they may not be "
+"correct."
+msgstr ""
+
+#: ../../editorial_bot.md:190 bcbc437df84e45e5ad79d999f957cc8e
+msgid "Repository checks"
+msgstr ""
+
+#: ../../editorial_bot.md:192 8727ffd998de498fb2c6e7de6051573a
+msgid ""
+"A series of checks can be run on the submitted repository with the "
+"command:"
+msgstr ""
+
+#: ../../editorial_bot.md:198 d5c1e29abff2449cac32014dd6116ec4
+msgid ""
+"EditorialBot will report back with an analysis of the source code and "
+"list authorship, contributions and file types information. EditorialBot "
+"will also label the issue with the top languages used in the repository, "
+"will count the number of words in the paper file, will look for an Open "
+"Source License and for a *Statement of need* section in the paper."
+msgstr ""
+
+#: ../../editorial_bot.md:200 0c6fbe9c4498459b83ec0b6951c8d470
+msgid "Post-review checklist"
+msgstr ""
+
+#: ../../editorial_bot.md:202 da7d497e843b46e59a81e65d3808a672
+msgid ""
+"Editors can get a checklist to remind all steps to do after the reviewers"
+" have finished their reviews and recommended the paper for acceptance:"
+msgstr ""
+
+#: ../../editorial_bot.md:208 0394e00296be44d5b93688847b8d13c5
+msgid "Flag a paper with query-scope"
+msgstr ""
+
+#: ../../editorial_bot.md:210 2e33d12745074fac95310cb1f8cd3b63
+msgid "Editors can flag a paper with query-scope with the command:"
+msgstr ""
+
+#: ../../editorial_bot.md:216 393ebbe4407b4ca0a0bdc945d22709d2
+msgid "Recommending a paper for acceptance"
+msgstr ""
+
+#: ../../editorial_bot.md:218 9bfe35851e6e450b8521b25cab769abe
+msgid ""
+"JOSS topic editors can recommend a paper for acceptance and ask for the "
+"final proofs to be created by EditorialBot with the following command:"
+msgstr ""
+
+#: ../../editorial_bot.md:224 18349f55da174b52b064ec5dcb3a04ab
+msgid ""
+"On issuing this command, EditorialBot will also check the references of "
+"the paper for any missing DOIs."
+msgstr ""
+
+#: ../../editorial_bot.md:227 f220421f146240b58642fb15e97d1782
+msgid "EiC-only commands"
+msgstr ""
+
+#: ../../editorial_bot.md:229 b274ce6a1fbe4e5c8a80fad4eaa00c12
+msgid "Only the JOSS editors-in-chief can accept, reject or withdraw papers."
+msgstr ""
+
+#: ../../editorial_bot.md:231 4d58a998d70e48e9b9dbc0b77f5fe48c
+msgid "Accepting a paper"
+msgstr ""
+
+#: ../../editorial_bot.md:233 a2e501ceaa9a486b903c55e39a9f27bd
+msgid ""
+"If everything looks good with the draft proofs from the `@editorialbot "
+"recommend acceptance` command, JOSS editors-in-chief can take the "
+"additional step of actually accepting the JOSS paper with the following "
+"command:"
+msgstr ""
+
+#: ../../editorial_bot.md:239 5ea840fce95540cea3e91e45ed2e42f8
+msgid ""
+"EditorialBot will accept the paper, assign it a DOI, deposit it and "
+"publish the paper."
+msgstr ""
+
+#: ../../editorial_bot.md:241 46d0d23563df44bdb17a9912edfc0c50
+msgid "Updating an already accepted paper"
+msgstr ""
+
+#: ../../editorial_bot.md:243 4e5a9ca95ae445dbbd0332c73ba5935b
+msgid ""
+"If the draft has been updated after a paper has been published, JOSS "
+"editors-in-chief can update the published info and PDF with the following"
+" command:"
+msgstr ""
+
+#: ../../editorial_bot.md:249 04866575ba564de58b51ae707d511c0a
+msgid "EditorialBot will update the published paper and re-deposit it."
+msgstr ""
+
+#: ../../editorial_bot.md:252 3036fdc2749f423591013b7a4a6725b6
+msgid "Rejecting a paper"
+msgstr ""
+
+#: ../../editorial_bot.md:254 1cb520f32bbe433eb78a87cedf1748cf
+msgid "JOSS editors-in-chief can reject a submission with the following command:"
+msgstr ""
+
+#: ../../editorial_bot.md:260 032b9e37e6494fe4aa2b29628f808f9b
+msgid "Withdrawing a paper"
+msgstr ""
+
+#: ../../editorial_bot.md:262 fc0a1690d4ec445596aaf5b5f2ac7723
+msgid ""
+"JOSS editors-in-chief can withdraw a submission with the following "
+"command:"
+msgstr ""
+
+#: ../../editorial_bot.md:268 5123958928554baeb31c1b3427955b7b
+msgid "The complete list of available commands"
+msgstr ""
+

--- a/docs/locale/pl/LC_MESSAGES/example_paper.po
+++ b/docs/locale/pl/LC_MESSAGES/example_paper.po
@@ -1,0 +1,55 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: pl\n"
+"Language-Team: pl <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../example_paper.md:1 8ca6579dcbc0405081c9234e3e25ddf9
+msgid "Example Paper"
+msgstr ""
+
+#: ../../example_paper.md:3 76c8bf09b0184b24810e7149e806adf0
+msgid ""
+"This example `paper.md` is adapted from _Gala: A Python package for "
+"galactic dynamics_ by Adrian M. Price-Whelan "
+"[http://doi.org/10.21105/joss.00388](http://doi.org/10.21105/joss.00388)."
+msgstr ""
+
+#: ../../example_paper.md:5 e6b48075e1114ec68c01114af4a4a757
+msgid ""
+"For a complete description of available options to describe author names "
+"[see here](author-names)."
+msgstr ""
+
+#: ../../example_paper.md:130 5f39e01834894da382cd056596155e04
+msgid "Example `paper.bib` file:"
+msgstr ""
+
+#: ../../example_paper.md:194 5bea5b8035d3406db5ea07d8efbff3c4
+msgid ""
+"Note that the paper begins by a metadata section (the enclosing --- lines"
+" are mandatory) and ends with a References heading, and the references "
+"are built automatically from the content in the `.bib` file. You should "
+"enter in-text citations in the paper body following correct [Markdown "
+"citation syntax](https://pandoc.org/MANUAL.html#extension-citations).  "
+"Also note that the references include full names of venues, e.g., "
+"journals and conferences, not abbreviations only understood in the "
+"context of a specific discipline."
+msgstr ""
+

--- a/docs/locale/pl/LC_MESSAGES/expectations.po
+++ b/docs/locale/pl/LC_MESSAGES/expectations.po
@@ -1,0 +1,173 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: pl\n"
+"Language-Team: pl <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../expectations.md:1 4c8612f8e66a48b494a730e3596c2063
+msgid "Expectations on JOSS editors"
+msgstr ""
+
+#: ../../expectations.md:3 0a07f881dd4f40f691a8af9001834a83
+msgid "Editorial load"
+msgstr ""
+
+#: ../../expectations.md:5 d2189641ac4f41f8b523f52a27043dff
+msgid ""
+"Our goal is for editors to handle between 3-4 submissions at any one "
+"time, and 8-12 submissions per year. During the trial period for editors "
+"(usually the first 90 days), we recommend new editors handle 1-2 "
+"submissions as they learn the JOSS editorial system and processes."
+msgstr ""
+
+#: ../../expectations.md:7 d17595ec867642bfa639f878662e2347
+msgid "Completing the trial period"
+msgstr ""
+
+#: ../../expectations.md:9 97492a5a6ec34c2580cba9bc426985ad
+msgid ""
+"JOSS has a 90-day trial period for new editors. At the end of the trial, "
+"the editor or JOSS editorial board can decide to part ways if either "
+"party determines editing for JOSS isn't a good fit for the editor. The "
+"most important traits the editorial board will be looking for with new "
+"editors are:"
+msgstr ""
+
+#: ../../expectations.md:11 caab6a9de39249d0af2b78753cb9447a
+msgid ""
+"Demonstrating professionalism in communications with authors, reviewers, "
+"and the wider editorial team."
+msgstr ""
+
+#: ../../expectations.md:12 36d289f2a08a402c864dc3d05c39051e
+msgid ""
+"Editorial responsibility, including [keeping up with their assigned "
+"submissions](#continued-attention-to-assigned-submissions)."
+msgstr ""
+
+#: ../../expectations.md:13 469696bcccdf43f985569eeefd85c7f2
+msgid ""
+"Encouraging good social (software community) practices. For example, "
+"thanking reviewers and making them feel like they are part of a team "
+"working together."
+msgstr ""
+
+#: ../../expectations.md:15 68060dfafa604f85a420dee7f417dd53
+msgid ""
+"If you're struggling with your editorial work, please let your buddy or "
+"an EiC know."
+msgstr ""
+
+#: ../../expectations.md:17 71f361156a5f442ab487707e693e9305
+msgid "Responding to editorial assignments"
+msgstr ""
+
+#: ../../expectations.md:19 7f904950b4314e0abbdff99c03a35775
+msgid ""
+"As documented above, usually, papers will be assigned to you by one of "
+"the TEiCs. We ask that editors do their best to respond in a timely "
+"fashion (~ 3 working days) to invites to edit a new submission."
+msgstr ""
+
+#: ../../expectations.md:21 861a33e26bf3481d8918b2f1a39cb670
+msgid "Continued attention to assigned submissions"
+msgstr ""
+
+#: ../../expectations.md:23 5c9cf961643b414a8c0759d3674c96b4
+msgid ""
+"As an editor, part of your role is to ensure that submissions you're "
+"responsible for are progressing smoothly through the editorial process. "
+"This means that:"
+msgstr ""
+
+#: ../../expectations.md:25 a3fe16f8e2094ea8a3be43e6f7625264
+msgid ""
+"During pre-review, and before reviewers have been identified, editors "
+"should be checking on their submissions twice per week to ensure "
+"reviewers are identified in a timely fashion."
+msgstr ""
+
+#: ../../expectations.md:26 104b72a966c94a8c8041ce1b4a4e9922
+msgid ""
+"During review, editors should check on their submissions once or twice "
+"per week (even for just a few minutes) to see if their input is required "
+"(e.g., if someone has asked a question that requires your input)."
+msgstr ""
+
+#: ../../expectations.md:28 509ff01f88764b589654025ead0d7107
+msgid ""
+"Your editorial dashboard (e.g. "
+"`https://joss.theoj.org/dashboard/youreditorname`) is the best place to "
+"check if there have been any updates to the papers you are editing."
+msgstr ""
+
+#: ../../expectations.md:30 7974f302790c43b38fe49a52acf17e44
+msgid "**If reviews go stale**"
+msgstr ""
+
+#: ../../expectations.md:32 1f2b12f8ff0f40f8ad2e1ed2376ecd82
+msgid ""
+"Sometimes reviews go quiet, either because a reviewer has failed to "
+"complete their review or an author has been slow to respond to a "
+"reviewer's feedback. **As the editor, we need you to prompt the author/or"
+" reviewer(s) to revisit the submission if there has been no response "
+"within 7-10 days unless there's a clear statement in the review thread "
+"that says an action is coming at a slightly later time, perhaps because a"
+" reviewer committed to a review by a certain date, or an author is making"
+" changes and says they will be done by a certain date.**"
+msgstr ""
+
+#: ../../expectations.md:34 6a6df7801ec74702aa36001f0787561f
+msgid ""
+"[EditorialBot has "
+"functionality](https://joss.readthedocs.io/en/latest/editorial_bot.html"
+"#reminding-reviewers-and-authors) to remind an author or review to return"
+" to a review at a certain point in the future. For example:"
+msgstr ""
+
+#: ../../expectations.md:40 9ef806aaf3114de4815903b063038340
+msgid "Out of office"
+msgstr ""
+
+#: ../../expectations.md:42 22b5920a8827483e87c893584ff63e86
+msgid ""
+"Sometimes we need time away from our editing duties at JOSS. If you're "
+"planning on being out of the office for more than two weeks, please let "
+"the JOSS editorial team know."
+msgstr ""
+
+#: ../../expectations.md:44 6796f6c4ca0944fdbf897e126f25a6f2
+msgid "Voting on papers flagged as potentially out of scope"
+msgstr ""
+
+#: ../../expectations.md:46 7fe0a02c7e70472d87e2cbea3e629f3d
+msgid ""
+"Once per week, an email is sent to all JOSS editors with a summary of the"
+" papers that are currently flagged as potentially out of scope. Editors "
+"are asked to review these submissions and vote on the JOSS website if "
+"they have an opinion about a submission."
+msgstr ""
+
+#: ../../expectations.md:49 f45c808931ce408c8b24362d20907faf
+msgid ""
+"Your input (vote) on submissions that are undergoing a scope review is "
+"incredibly valuable to the EiC team. Please try and vote early, and "
+"often!"
+msgstr ""
+

--- a/docs/locale/pl/LC_MESSAGES/index.po
+++ b/docs/locale/pl/LC_MESSAGES/index.po
@@ -1,0 +1,125 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: pl\n"
+"Language-Team: pl <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../index.rst:33
+msgid "Author Guides"
+msgstr ""
+
+#: ../../index.rst:42
+msgid "Reviewer Guides"
+msgstr ""
+
+#: ../../index.rst:50
+msgid "Editor Guides"
+msgstr ""
+
+#: ../../index.rst:60
+msgid "The Editorial Bot"
+msgstr ""
+
+#: ../../index.rst:66
+msgid "Developer Guides"
+msgstr ""
+
+#: ../../index.rst:2 0f9fd00d10994bde9487df77c173647c
+msgid "Journal of Open Source Software"
+msgstr ""
+
+#: ../../index.rst:4 b7f84e5ae46b4d7c9156aad67fb7cd0f
+msgid ""
+"The `Journal of Open Source Software <http://joss.theoj.org/>`_ (JOSS) is"
+" a developer friendly journal for research software packages."
+msgstr ""
+
+#: ../../index.rst:6 84ad65da2fbb4df4a39cf8defc685cf8
+msgid ""
+"JOSS is an academic journal (ISSN 2475-9066) with a formal peer-review "
+"process that is designed to *improve the quality of the software "
+"submitted*. Upon acceptance into JOSS, we mint a CrossRef DOI for your "
+"paper and we list it on the `JOSS website <http://joss.theoj.org/>`_."
+msgstr ""
+
+#: ../../index.rst:9 e44acbe63269418b90fa19eb9f3386a2
+msgid "About this site"
+msgstr ""
+
+#: ../../index.rst:11 1b295ccddd04446ca6ffd9d426fe18dd
+msgid ""
+"This site contains documentation for authors interested in submitting to "
+"JOSS, reviewers who have generously volunteered their time to review "
+"submissions, and editors who manage the JOSS editorial process."
+msgstr ""
+
+#: ../../index.rst:13 7bed16ea6e82428aa844436412867a22
+msgid "If you're interested in learning more about JOSS, you might want to read:"
+msgstr ""
+
+#: ../../index.rst:15 04b24557f26b44478abbf87be2c3f806
+msgid ""
+"`Our announcement blog post <http://www.arfon.org/announcing-the-journal-"
+"of-open-source-software>`_ describing some of the motivations for "
+"starting a new journal"
+msgstr ""
+
+#: ../../index.rst:16 56f0574fde3741419c77e3ded31340c4
+msgid ""
+"`The paper in Computing in Science and Engineering "
+"<https://doi.org/10.1109/MCSE.2018.03221930>`_ introducing JOSS"
+msgstr ""
+
+#: ../../index.rst:17 9d3759ade4a64885ae3954a27158631d
+msgid ""
+"`The paper in PeerJ CS <https://doi.org/10.7717/peerj-cs.147>`_ "
+"describing the first year of JOSS"
+msgstr ""
+
+#: ../../index.rst:18 fad5565d41484771ba10d89b2c5e3fbb
+msgid "The `about page <http://joss.theoj.org/about>`_ on the main JOSS site"
+msgstr ""
+
+#: ../../index.rst:21 22b4cf2291034a42bd88703454ed27a2
+msgid "Submitting a paper to JOSS"
+msgstr ""
+
+#: ../../index.rst:23 d79c0a72ff284f9dba237c4555df0303
+msgid ""
+"If you'd like to submit a paper to JOSS, please read the author "
+"submission guidelines in the :doc:`submitting` section."
+msgstr ""
+
+#: ../../index.rst:26 605a08afc01447dbb3f9ac1b93addf05
+msgid "Sponsors and affiliates"
+msgstr ""
+
+#: ../../index.rst:-1 9436c00eef0143748d00afeb40768f3b
+msgid "OSI & NumFOCUS"
+msgstr ""
+
+#: ../../index.rst:31 acf3af62f1724ef39d48d9109e26e4d6
+msgid ""
+"JOSS is a proud affiliate of the `Open Source Initiative "
+"<https://opensource.org/>`_. As such, we are committed to public support "
+"for open source software and the role OSI plays therein. In addition, "
+"Open Journals (the parent entity behind JOSS) is a `NumFOCUS-sponsored "
+"project <https://www.numfocus.org/project/open-journals>`_."
+msgstr ""
+

--- a/docs/locale/pl/LC_MESSAGES/installing.po
+++ b/docs/locale/pl/LC_MESSAGES/installing.po
@@ -1,0 +1,489 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: pl\n"
+"Language-Team: pl <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../installing.md:1 4f774171c24246e78329728517f8b9e7
+msgid "Installing the JOSS application"
+msgstr ""
+
+#: ../../installing.md:3 7c2d4ade22274352a9f442fae212c0c4
+msgid "Any Open Journal (JOSS, JOSE, etc.) can be considered in three parts:"
+msgstr ""
+
+#: ../../installing.md:5 e36bd80c5ce14615a804f4b4ba13cadf
+msgid "The website"
+msgstr ""
+
+#: ../../installing.md:6 a751dc18b8454069a019feca0b975ec1
+msgid "The Buffy gem to interface with GitHub"
+msgstr ""
+
+#: ../../installing.md:7 99d0865bd8244adc8104ef83a7094976
+msgid ""
+"Inara, a docker image to compile papers being used in GitHub actions and "
+"workflows"
+msgstr ""
+
+#: ../../installing.md:9 f3cb4da41c3641b793f534cbda979d72
+msgid "For JOSS, these correspond to the:"
+msgstr ""
+
+#: ../../installing.md:11 7706d290708e4215a0d1066c12ba8b70
+msgid "[JOSS](https://github.com/openjournals/joss),"
+msgstr ""
+
+#: ../../installing.md:12 9ce88ee192d74d75b21ff6c6473d9d57
+msgid "[Buffy](https://github.com/openjournals/buffy), and"
+msgstr ""
+
+#: ../../installing.md:13 18023f6691a24aed9f10eb211f20df23
+msgid "[Inara](https://github.com/openjournals/inara)"
+msgstr ""
+
+#: ../../installing.md:15 2af763723dec4b06a80b90108edc4a0a
+msgid "code bases."
+msgstr ""
+
+#: ../../installing.md:17 bfd72b4ceb2143f4a80dd5192fea6c84
+msgid "Setting up a local development environment"
+msgstr ""
+
+#: ../../installing.md:19 839f08a37e6643ddb15901d390c8db6a
+msgid ""
+"All Open Journals are coded in Ruby, with the website and Buffy developed"
+" as [Ruby on Rails](https://rubyonrails.org/inst) applications."
+msgstr ""
+
+#: ../../installing.md:23 448f1857fb7547b38869e65bece919a2
+msgid ""
+"If you'd like to develop these locally, you'll need a working Ruby on "
+"Rails development environment. For more information, please see [this "
+"official "
+"guide](https://guides.rubyonrails.org/getting_started.html#creating-a"
+"-new-rails-project-installing-rails)."
+msgstr ""
+
+#: ../../installing.md:28 6fceb023c1d140acb6aa84378b97a599
+msgid "Deploying your JOSS application"
+msgstr ""
+
+#: ../../installing.md:30 c36c4bc7d6b64237bb2041a5cea49030
+msgid ""
+"To deploy JOSS, you'll need a [Heroku "
+"account](https://signup.heroku.com/). We also recommend you gather the "
+"following information before deploying your application to Heroku:"
+msgstr ""
+
+#: ../../installing.md:34 bdd6ac4a32864b17a401073501a896ab
+msgid "A [public ORCID API](https://members.orcid.org/api/about-public-api) key"
+msgstr ""
+
+#: ../../installing.md:35 d3fea2ad0ad141f3823f465a1be8cb38
+msgid ""
+"A GitHub [Personal Access Token](https://docs.github.com/en/free-pro-"
+"team@latest/github/authenticating-to-github/creating-a-personal-access-"
+"token) for the automated account that users will interact with (e.g., "
+"`@editorialbot`, `@RoboNeuro`). In order to be able to send invitations "
+"to reviewers and collaborators, the automated GitHub account must be an "
+"admin of the organization the reviews take place at. And the Personal "
+"Access Token should include the `admin:org` scope."
+msgstr ""
+
+#: ../../installing.md:36 87d6be2a8ed349d2ae6ec252d618a94d
+msgid ""
+"An email address registered on a domain you control (i.e., not `gmail` or"
+" a related service)"
+msgstr ""
+
+#: ../../installing.md:39 ec245b6af1114e8c9c6b43dab184be7c
+msgid ""
+"Do not put these secrets directly into your code base! It is important "
+"that these keys are not under version control."
+msgstr ""
+
+#: ../../installing.md:42 6c24f4a22b9e4efda5ec5bf0a58d1c45
+msgid ""
+"There are different ways to make sure your application has access to "
+"these keys, depending on whether your code is being developed locally or "
+"on Heroku. Locally, you can store these locally in a .env file. The "
+".gitignore in JOSS is already set to ignore this file type."
+msgstr ""
+
+#: ../../installing.md:47 ac957a56a2f0488584b50444d074c0a4
+msgid ""
+"On Heroku, they will be config variables that you can set either with the"
+" Heroku CLI or directly on your application's dashboard. See [this guide "
+"from Heroku](https://devcenter.heroku.com/articles/config-vars#managing-"
+"config-vars) for more information."
+msgstr ""
+
+#: ../../installing.md:51 33ae259eb2884b89832f63790b710bbc
+msgid ""
+"Assuming you [have forked the JOSS GitHub "
+"repository](https://docs.github.com/en/free-pro-team@latest/github"
+"/getting-started-with-github/fork-a-repo) to your account, you can "
+"[configure Heroku as a git "
+"remote](https://devcenter.heroku.com/articles/git#prerequisites-install-"
+"git-and-the-heroku-cli) for your code. This makes it easy to keep your "
+"Heroku deployment in sync with your local development copy."
+msgstr ""
+
+#: ../../installing.md:56 7a74914499304caeb5aeebaf2ad12225
+msgid ""
+"On the JOSS Heroku deployment, you'll need to provision several [add-"
+"ons](https://elements.heroku.com/addons). Specifically, you'll need:"
+msgstr ""
+
+#: ../../installing.md:59 63e1a5bdf03947dbaf70911e67516b7a
+msgid "[Elasticsearch add-on](https://elements.heroku.com/addons/bonsai)"
+msgstr ""
+
+#: ../../installing.md:60 4db8faf5399342ea8bda26e2d590c72d
+msgid "[PostgreSQL add-on](https://elements.heroku.com/addons/heroku-postgresql)"
+msgstr ""
+
+#: ../../installing.md:61 125450c630f04cbdb696309f6cbae800
+msgid "[Scheduler add-on](https://devcenter.heroku.com/articles/scheduler)"
+msgstr ""
+
+#: ../../installing.md:63 f6c31a27438a4e27a8f4650f5a3764d6
+msgid ""
+"For the scheduler add-on, you'll need to designate which tasks it should "
+"run and when. These can be found in the `lib/tasks` folder, and involve "
+"things such as sending out weekly reminder emails to editors. Each task "
+"should be scheduled as a separate job; for example, `rake "
+"send_weekly_emails`."
+msgstr ""
+
+#: ../../installing.md:67 480effe493c745e49a6a46f680482be9
+msgid ""
+"You can also optionally configure the following add-ons (or simply set "
+"their secret keys in your config variables):"
+msgstr ""
+
+#: ../../installing.md:69 18bf6583b4ca4b5aa704859cb3bc8e50
+msgid ""
+"[SendGrid add-on](https://elements.heroku.com/addons/sendgrid) for "
+"sending emails"
+msgstr ""
+
+#: ../../installing.md:70 1ef8f6a531a540d0aae9ba991194e388
+msgid ""
+"[Honeybadger add-on](https://elements.heroku.com/addons/honeybadger) for "
+"error reporting"
+msgstr ""
+
+#: ../../installing.md:72 28a4c573c67b4182903e04d891c3c231
+msgid ""
+"Once you've pushed your application to Heroku and provisioned the "
+"appropriate add-ons, you're ready to update your config with the "
+"appropriate secrets. For a list of the expected secret key names, see the"
+" `app.json` file."
+msgstr ""
+
+#: ../../installing.md:77 6fd5c894e54f4bf185d27a7df1c5d9b5
+msgid ""
+"One \"gotcha\" when provisioning the Bonsai add-on is that it may only "
+"set the `BONSAI_URL` variable. Make sure that there is also an "
+"`ELASTICSEARCH_URL` which is set to the same address."
+msgstr ""
+
+#: ../../installing.md:81 a8d49a25ce6d466fb77c9eab1ac84315
+msgid ""
+"We will not cover Portico, as this requires that your application is a "
+"part of the `openjournals` organization. If you do not already have "
+"access to these keys, you can simply ignore them for now."
+msgstr ""
+
+#: ../../installing.md:85 9b8bd242eaa24872bf8f8a3b562fc579
+msgid ""
+"One secret key we have not covered thus far is `BOT_SECRET`. This is "
+"because it is not one that you obtain from a provide, but a secret key "
+"that you set yourself. We recommend using something like a random SHA1 "
+"string."
+msgstr ""
+
+#: ../../installing.md:90 a07f1080dac54cf69dfa63db432a6e7f
+msgid ""
+"It is important to remember this key, as you will need it when deploying "
+"your Buffy application."
+msgstr ""
+
+#: ../../installing.md:94 be0e73d9129b47a19c2ba229db91cff4
+msgid ""
+"After pushing your application to Heroku, provisioning the appropriate "
+"add-ons, and confirming that your config variables are set correctly, you"
+" should make sure that your username is registered as an admin on the "
+"application."
+msgstr ""
+
+#: ../../installing.md:98 51ac835ee244430d9f362bca2db59b58
+msgid ""
+"You can do this on a local Rails console, by logging in and setting the "
+"boolean field 'admin' on your user ID to True. If you'd prefer to do this"
+" on the Heroku deployment, make sure you've logged into the application. "
+"Then you can directly modify this attribute in the deployments Postgres "
+"database using SQL. For more information on accessing your application's "
+"Postgres database, see [the official "
+"docs](https://devcenter.heroku.com/articles/heroku-postgresql#pg-psql)."
+msgstr ""
+
+#: ../../installing.md:105 17b2ffdb4fc64475811b954d7af4a67a
+msgid "Making modifications to launch your own site"
+msgstr ""
+
+#: ../../installing.md:107 373595fdd5fe46fca658718f3acffad9
+msgid ""
+"Some times you may not want to launch an exact copy of JOSS, but a "
+"modified version. This can be especially useful if you're planning to "
+"spin up your own platform based on the Open Journals framework. "
+"[NeuroLibre](https://neurolibre.org/) is one such example use-case."
+msgstr ""
+
+#: ../../installing.md:112 8fcfc2f6b93e4c2091b2aadd1e8e4fcb
+msgid "Modifying your site configuration"
+msgstr ""
+
+#: ../../installing.md:114 6624ff396d3442e8bcfcf00ce6f7b875
+msgid ""
+"In this case, there are several important variables to be aware of and "
+"modify. Most of these are accessible in the `config` folder."
+msgstr ""
+
+#: ../../installing.md:117 9b4c51ceb34744afa07f805c2870c9f5
+msgid ""
+"First, there are three files which provide settings for your Rails "
+"application in different development contexts:"
+msgstr ""
+
+#: ../../installing.md:119 ../../installing.md:210
+#: 0da0106839214cc2b157be7c6d8feba7 fbdd0ac095944c7ca292eed10fe87092
+msgid "`settings-test.yml`"
+msgstr ""
+
+#: ../../installing.md:120 abd2fc35958a48c6bb958b53fc7a9671
+msgid "`settings-development.yml`"
+msgstr ""
+
+#: ../../installing.md:121 ../../installing.md:211
+#: 3f8bc2da9f75411ba083909f20b54964 ddc8e9cab50b4d1891e2c624589f5742
+msgid "`settings-production.yml`"
+msgstr ""
+
+#: ../../installing.md:123 b9c68715d55148e984be13fa178f4f19
+msgid ""
+"These each contain site-specific variables that should be modified if you"
+" are building off of the Open Journals framework."
+msgstr ""
+
+#: ../../installing.md:125 06b78fe89e454f599cdd523294c88eb8
+msgid ""
+"Next, you'll need to modify the `repository.yml` file. This file lists "
+"the GitHub repository where you expect papers to be published, as well as"
+" the editor team ID. For your GitHub organization, make sure you have "
+"created and populated a team called `editors`. Then, you can check its ID"
+" number as detailed in [this guide](https://fabian-"
+"kostadinov.github.io/2015/01/16/how-to-find-a-github-team-id). In "
+"`config` you should also modify the `orcid.yml` file to list your site as"
+" the production site."
+msgstr ""
+
+#: ../../installing.md:132 f13db8cf9e4644519ad56b82189a306c
+msgid ""
+"Finally, you'll need to set up a [GitHub "
+"webhook](https://docs.github.com/en/free-pro-team@latest/developers"
+"/webhooks-and-events/about-webhooks) for reviews repository. This should "
+"be a repository that you have write access to, where you expect most of "
+"the reviewer-author interaction to occur. For JOSS, this corresponds to "
+"the `openjournals/joss-reviews` GitHub repository."
+msgstr ""
+
+#: ../../installing.md:137 ../../installing.md:221
+#: a64d98ae21c24483915d4efc526de7da b45fc86903bb4d34bfd57621ee5cdcb3
+msgid ""
+"In this GitHub repository's settings, you can add a new webhook with the "
+"following configuration:"
+msgstr ""
+
+#: ../../installing.md:140 686a1bffb5e8446e8fa8ee9309d8824f
+msgid ""
+"Set the `Payload` URL to the `/dispatch` hook for your Heroku application"
+" URL. For example, https://neurolibre.herokuapp.com/dispatch"
+msgstr ""
+
+#: ../../installing.md:142 ../../installing.md:226
+#: 17a6db41035949f990e4d948f27424b7 4ddd63b0f6f643d5bd2b2016f6c7302b
+msgid "Set the `Content type` to `application/json`"
+msgstr ""
+
+#: ../../installing.md:143 ../../installing.md:227
+#: 9052e8d56f124cc78e097c27c7faaf98 ddb732f428924b0f96f1a7d69ba9ace3
+msgid ""
+"Set the secret to a high-entropy, random string as detailed in the "
+"[GitHub docs](https://docs.github.com/en/free-pro-team@latest/developers"
+"/webhooks-and-events/securing-your-webhooks#setting-your-secret-token)"
+msgstr ""
+
+#: ../../installing.md:144 ../../installing.md:228
+#: bd18d6eff9bc4c31bfeec584d7dcc8a1 da172741ab3a4d9997f25854ae69a198
+msgid "Set the webhook to deliver `all events`"
+msgstr ""
+
+#: ../../installing.md:146 bf68263770984fa38c91aa9285ef7a95
+msgid "Updating your application database"
+msgstr ""
+
+#: ../../installing.md:148 c5dc60327d3a414bb3b1f1af4cb4c62d
+msgid ""
+"Optionally, you can edit `seeds.rb`, a file in the `db` folder. \"DB\" is"
+" short for \"database,\" and this file _seeds_ the database with "
+"information about your editorial team. You can edit the file `seeds.rb` "
+"to remove any individuals who are not editors in your organization. This "
+"can be especially useful if you will be creating the database multiple "
+"times during development; for example, if you add in testing information "
+"that you'd later like to remove."
+msgstr ""
+
+#: ../../installing.md:154 23a7defba63e4d8199dce4c3e802a467
+msgid ""
+"You can reinitialize the database from your Heroku CLI using the "
+"following commands:"
+msgstr ""
+
+#: ../../installing.md:163 f2a8d9e5a8dc4ea39b7332bf84f9f6a8
+msgid "Modifying your site contents"
+msgstr ""
+
+#: ../../installing.md:165 67ffa2e9bc1848aa94aedb082bcadc90
+msgid ""
+"You can modify site content by updating files in the `app` and `docs` "
+"folders. For example, in `app/views/notifications` you can change the "
+"text for any emails that will be sent by your application."
+msgstr ""
+
+#: ../../installing.md:168 6a3bc644aed24f6bae19fccc6c80dd3b
+msgid ""
+"Note that files which end in `.html.erb` are treated as HTML files, and "
+"typical HTML formatting applies. You can set the HTML styling by "
+"modifying the Sass files for your application, located in "
+"`app/assets/stylesheets`."
+msgstr ""
+
+#: ../../installing.md:172 e4f19b8d33d545b08a4c919c3c618f28
+msgid ""
+"There are currently a few hard-coded variables in the application which "
+"you will also need to update. Note that these are mostly under "
+"`lib/tasks`. For example, in `stats.rake`, the reviewer sheet ID is hard-"
+"coded on line 37. You should update this to point to your own spreadsheet"
+" where you maintain a list of eligible reviewers."
+msgstr ""
+
+#: ../../installing.md:177 4b836fad75bf48daab9d5c1186b8e1d7
+msgid ""
+"In the same folder, `utils.rake` is currently hard-coded to alternate "
+"assignments of editor-in-chief based on weeks. You should modify this to "
+"either set a single editor-in-chief, or design your own scheme of "
+"alternating between members of your editorial board."
+msgstr ""
+
+#: ../../installing.md:181 b46f9ccf2df2437c91125f29645854df
+msgid "Deploying your Buffy Application"
+msgstr ""
+
+#: ../../installing.md:183 dcf8823d458446aea1fd61c3feb6bd42
+msgid ""
+"Buffy can also be deployed on Heroku. Note that &mdash; for full "
+"functionality &mdash; Buffy must be deployed on [Hobby "
+"dynos](https://devcenter.heroku.com/articles/dyno-types), rather than "
+"free dynos. Hobby dynos allow the Buffy application to run continuously, "
+"without falling asleep after 30 minutes of inactivity; this means that "
+"Buffy can respond to activity on GitHub at any time. Buffy specifically "
+"requires two Hobby dynos: one for the `web` service and one for the "
+"`worker` service."
+msgstr ""
+
+#: ../../installing.md:189 e812a9316c9f4959bd0298c4f43f169e
+msgid ""
+"For a complete step-by-step guide on installing and deploying Buffy, you "
+"can read the [Buffy documentation](https://buffy.readthedocs.io)."
+msgstr ""
+
+#: ../../installing.md:191 5f41ed6042284220a7bece9e43285b4f
+msgid ""
+"As before, once you've pushed your application to Heroku and provisioned "
+"the appropriate add-ons, you're ready to update your config with the "
+"appropriate secrets."
+msgstr ""
+
+#: ../../installing.md:194 622adbea9d8042649356223ef54f3b8c
+msgid ""
+"Specifically, the `JOSS_API_KEY`env var in Heroku should match the "
+"`BOT_SECRET` key that you created in your JOSS deployment."
+msgstr ""
+
+#: ../../installing.md:196 0d0ed34fb17649c3bb25bca81c145fe1
+msgid "Modifying your Buffy deployment"
+msgstr ""
+
+#: ../../installing.md:198 e0cd470cefb04da38734b7e246d48347
+msgid ""
+"Some times you may not want to launch an exact copy of the Buffy, but a "
+"modified version. This can be especially useful if you're planning to "
+"spin up your own platform based on the Open Journals framework. "
+"[rOpenSci-review-bot](https://github.com/ropensci-review-bot) and "
+"[Scoobies](https://github.com/scoobies) are examples of use-cases."
+msgstr ""
+
+#: ../../installing.md:203 54fb2e41380b4eccac2346c55ca57dd5
+msgid "Modifying your Buffy configuration"
+msgstr ""
+
+#: ../../installing.md:205 40dea617bd104bd0af00184cfe6ab720
+msgid ""
+"Similar to the JOSS deployment described above, the Buffy configuration "
+"is controlled through a series of YAML files included in the `config/` "
+"folder. Each of these files provide relevant configuration for a "
+"different development context. Specifically, two files are defined:"
+msgstr ""
+
+#: ../../installing.md:213 305e5b23bc2f4934b642d9605e7c0fcf
+msgid ""
+"which can be used to define testing and production environment variables,"
+" respectively."
+msgstr ""
+
+#: ../../installing.md:215 bee5692828314f52a82ee40bdf8a6250
+msgid ""
+"Finally, you'll need to set up a [GitHub "
+"webhook](https://docs.github.com/en/free-pro-team@latest/developers"
+"/webhooks-and-events/about-webhooks) for your reviews repository. As a "
+"reminder, this should be a repository that you have write access to. For "
+"JOSS, this corresponds to the `openjournals/joss-reviews` GitHub "
+"repository. **This is in addition to the webhook you previously created "
+"for the JOSS deployment, although it points to the same repository.**"
+msgstr ""
+
+#: ../../installing.md:224 e8b69180551748bf8a4a59d38e5d66de
+msgid ""
+"Set the `Payload` URL to the `/dispatch` hook for your Heroku application"
+" URL. For example, https://roboneuro.herokuapp.com/dispatch"
+msgstr ""
+

--- a/docs/locale/pl/LC_MESSAGES/paper.po
+++ b/docs/locale/pl/LC_MESSAGES/paper.po
@@ -1,0 +1,827 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: pl\n"
+"Language-Team: pl <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../paper.md:1 fa2014b0271a4a5dbcbdda71c3aea87f
+msgid "JOSS Paper Format"
+msgstr ""
+
+#: ../../paper.md:3 f435876e6c764e9c9a03c779beed7e5b
+msgid ""
+"Submitted articles must use Markdown and must provide a metadata section "
+"at the beginning of the article. Format metadata using YAML, a human-"
+"friendly data serialization language (The Official YAML Web Site, 2022). "
+"The information provided is included in the title and sidebar of the "
+"generated PDF."
+msgstr ""
+
+#: ../../paper.md:7 7f84aa3d14974a3783e82f225be7098a
+msgid "What should my paper contain?"
+msgstr ""
+
+#: ../../paper.md:10 bd929e02502549e9a986519beae8433d
+msgid ""
+"Begin your paper with a summary of the high-level functionality of your "
+"software for a non-specialist reader. Avoid jargon in this section."
+msgstr ""
+
+#: ../../paper.md:13 a86e5255e8de428093396370a3b63b72
+msgid ""
+"JOSS welcomes submissions from broadly diverse research areas. For this "
+"reason, we require that authors include in the paper some sentences that "
+"explain the software functionality and domain of use to a non-specialist "
+"reader. We also require that authors explain the research applications of"
+" the software. The paper should be between 250-1000 words. Authors "
+"submitting papers significantly longer than 1000 words may be asked to "
+"reduce the length of their paper."
+msgstr ""
+
+#: ../../paper.md:15 a2d5b50f11ec4ecaa8eb0a2e8e7184ad
+msgid "Your paper should include:"
+msgstr ""
+
+#: ../../paper.md:17 61fbc3484cd64b4388c3040e5179ede5
+msgid ""
+"A list of the authors of the software and their affiliations, using the "
+"correct format (see the example below)."
+msgstr ""
+
+#: ../../paper.md:18 b1150af4d7104633b3c06f1e13becdfb
+msgid ""
+"A summary describing the high-level functionality and purpose of the "
+"software for a diverse, *non-specialist audience*."
+msgstr ""
+
+#: ../../paper.md:19 ba5c62e4670c4c719b7bd39f28a0b338
+msgid ""
+"A *Statement of need* section that clearly illustrates the research "
+"purpose of the software and places it in the context of related work."
+msgstr ""
+
+#: ../../paper.md:20 9ca2a7e3312f451f86540f3bd34690f7
+msgid ""
+"A list of key references, including to other software addressing related "
+"needs. Note that the references should include full names of venues, "
+"e.g., journals and conferences, not abbreviations only understood in the "
+"context of a specific discipline."
+msgstr ""
+
+#: ../../paper.md:21 e5ebb30afd284a04a47caa540482d06e
+msgid ""
+"Mention (if applicable) a representative set of past or ongoing research "
+"projects using the software and recent scholarly publications enabled by "
+"it."
+msgstr ""
+
+#: ../../paper.md:22 2dec64a1a8a0420392dde5aa4e08f6f3
+msgid "Acknowledgement of any financial support."
+msgstr ""
+
+#: ../../paper.md:24 e876f741ede4426dbb62cf04d87acb5d
+msgid ""
+"As this short list shows, JOSS papers are only expected to contain a "
+"limited set of metadata (see example below), a Statement of need, "
+"Summary, Acknowledgements, and References sections. You can look at an "
+"[example accepted paper](example_paper). Given this format, a \"full "
+"length\" paper is not permitted, and software documentation such as API "
+"(Application Programming Interface) functionality should not be in the "
+"paper and instead should be outlined in the software documentation."
+msgstr ""
+
+#: ../../paper.md:27 ae2e048ffe834cf4b3068e48f886218c
+msgid ""
+"Your paper will be reviewed by two or more reviewers in a public GitHub "
+"issue. Take a look at the [review checklist](review_checklist) and  "
+"[review criteria](review_criteria) to better understand how your "
+"submission will be reviewed."
+msgstr ""
+
+#: ../../paper.md:30 cf85cd7d312145b6aba381d9888ac880
+msgid "Article metadata"
+msgstr ""
+
+#: ../../paper.md:33 7d59faef660b4b528d2b32c5f2574fb9
+msgid "Names"
+msgstr ""
+
+#: ../../paper.md:35 dd8ac44e573f475baa9166905eb83753
+msgid ""
+"Providing an author name is straight-forward: just set the `name` "
+"attribute. However, sometimes more control over the name is required."
+msgstr ""
+
+#: ../../paper.md:37 e5b4e44952cb429b974dbf8832df605b
+msgid "Name parts"
+msgstr ""
+
+#: ../../paper.md:39 67f20378d0c1421e8cb269c7c5c13159
+msgid ""
+"There are many ways to describe the parts of names; we support the "
+"following:"
+msgstr ""
+
+#: ../../paper.md:41 c869635f3e8d4a8e8570dd1806c41c96
+msgid "given names,"
+msgstr ""
+
+#: ../../paper.md:42 eb79984c537545d4be61899db1cfa065
+msgid "surname,"
+msgstr ""
+
+#: ../../paper.md:43 458fa74370974a149dc426d1c52405b1
+msgid "dropping particle,"
+msgstr ""
+
+#: ../../paper.md:44 93fc4ebe42e241ebbc0bd529c139f850
+msgid "non-dropping particle,"
+msgstr ""
+
+#: ../../paper.md:45 cba35b5262cb42bf94509372e0c977d1
+msgid "and suffix."
+msgstr ""
+
+#: ../../paper.md:47 60637395091f49aca67416f5605b5e6a
+msgid ""
+"We use a heuristic to parse names into these components. This parsing may"
+" produce the wrong result, in which case it is necessary to provide the "
+"relevant parts explicitly."
+msgstr ""
+
+#: ../../paper.md:49 f9412ec745274eca9be22b9cfc58390d
+msgid "The respective field names are"
+msgstr ""
+
+#: ../../paper.md:51 8b09eeceb8774b26a7a1accc275559db
+msgid "`given-names` (aliases: `given`, `first`, `firstname`)"
+msgstr ""
+
+#: ../../paper.md:52 047b49c2a7dd445a9c0d6a470c7b6bd3
+msgid "`surname` (aliases: `family`)"
+msgstr ""
+
+#: ../../paper.md:53 1399da8321a54c02ae4a16a764a7d9a6
+msgid "`suffix`"
+msgstr ""
+
+#: ../../paper.md:55 60a965723562460ab4ca4f3f4f26d66e
+msgid ""
+"The full display name will be constructed from these parts, unless the "
+"`name` attribute is given as well."
+msgstr ""
+
+#: ../../paper.md:57 e804dcbbe16d4b9194c8930c8b68fb71
+msgid "Particles"
+msgstr ""
+
+#: ../../paper.md:59 ecb8132848a04bab9788f7afd3cf0042
+msgid ""
+"It's usually enough to place particles like \"van\", \"von\", \"della\", "
+"etc. at the end of the given name or at the beginning of the surname, "
+"depending on the details of how the name is used."
+msgstr ""
+
+#: ../../paper.md:61 d21693e5142848d7a4cfd4058fe70d63
+msgid "`dropping-particle`"
+msgstr ""
+
+#: ../../paper.md:62 aa96722b312a4049bba3cb53b2c630f8
+msgid "`non-dropping-particle`"
+msgstr ""
+
+#: ../../paper.md:64 507def513a2c43a2bece07343c752ab2
+msgid "Literal names"
+msgstr ""
+
+#: ../../paper.md:66 114e5fd3f40a442d95c7282a0245a03d
+msgid ""
+"The automatic construction of the full name from parts is geared towards "
+"common Western names. It may therefore be necessary sometimes to provide "
+"the display name explicitly. This is possible by setting the `literal` "
+"field, e.g., `literal: Tachibana Taki`. This feature should only be used "
+"as a last resort. <!-- e.g., `literal: 宮水 三葉`. -->"
+msgstr ""
+
+#: ../../paper.md:68 2ece940089ea482693daa17ea2e389d0
+msgid "Example"
+msgstr ""
+
+#: ../../paper.md:87 0cdb10d51b2140a99d7d5cb4c2945264
+msgid "The name parts can also be collected under the author's `name`:"
+msgstr ""
+
+#: ../../paper.md:102 95cc4e2a1ef44eaaabb11b0249feb0da
+msgid "Internal references"
+msgstr ""
+
+#: ../../paper.md:104 4c14f1598b3f46f581e2a82e8abed510
+msgid ""
+"The goal of Open Journals is to provide authors with a seamless and "
+"pleasant writing experience. Since Markdown has no default mechanism to "
+"handle document internal references, known as “cross-references”, Open "
+"Journals supports a limited set of LaTex commands. In brief, elements "
+"that were marked with `\\label` and can be referenced with `\\ref` and "
+"`\\autoref`."
+msgstr ""
+
+#: ../../paper.md:112 b44070bda6a54e9c9b1de36173ede776
+msgid "Tables and figures"
+msgstr ""
+
+#: ../../paper.md:114 5880b4e4a8d54c2eaa2da191b4672bc8
+msgid ""
+"Tables and figures can be referenced if they are given a *label* in the "
+"caption. In pure Markdown, this can be done by adding an empty span "
+"`[]{label=\"floatlabel\"}` to the caption. LaTeX syntax is supported as "
+"well: `\\label{floatlabel}`."
+msgstr ""
+
+#: ../../paper.md:116 36b4c9eb2f014c8c8057252d016d38f8
+msgid ""
+"Link to a float element, i.e., a table or figure, with "
+"`\\ref{identifier}` or `\\autoref{identifier}`, where `identifier` must "
+"be defined in the float's caption. The former command results in just the"
+" float's number, while the latter inserts the type and number of the "
+"referenced float. E.g., in this document `\\autoref{proglangs}` yields "
+"\"\\autoref{proglangs}\", while `\\ref{proglangs}` gives "
+"\"\\ref{proglangs}\"."
+msgstr ""
+
+#: ../../paper.md:118 00f1a8c2974e4aa0a3d6de2134ecf323
+msgid ""
+": Comparison of programming languages used in the publishing tool. "
+"[]{label=\"proglangs\"}"
+msgstr ""
+
+#: ../../paper.md:126 6a6b07ce53a8441a8b7ab8ff293711a9
+msgid "Equations"
+msgstr ""
+
+#: ../../paper.md:128 39ad38abe7b2404abd476712b7fe20b5
+msgid ""
+"Cross-references to equations work similarly to those for floating "
+"elements. The difference is that, since captions are not supported for "
+"equations, the label must be included in the equation:"
+msgstr ""
+
+#: ../../paper.md:132 e2b44dcea679454fba346acc19bab564
+msgid ""
+"Referencing, however, is identical, with `\\autoref{eq:fermat}` resulting"
+" in \"\\autoref{eq:fermat}\"."
+msgstr ""
+
+#: ../../paper.md:134 cccf1e00213b47bbb562d831ef502339
+msgid "$$a^n + b^n = c^n \\label{eq:fermat}$$"
+msgstr ""
+
+#: ../../paper.md:136 0611b18dbc83421481f814a7a19e705a
+msgid ""
+"Authors who do not wish to include the label directly in the formula can "
+"use a Markdown span to add the label:"
+msgstr ""
+
+#: ../../paper.md:140 2a3bd0ce271840299c567e14657556b5
+msgid "Markdown"
+msgstr ""
+
+#: ../../paper.md:141 57aff3425b2041198fa569a3efa32452
+msgid ""
+"Markdown is a lightweight markup language used frequently in software "
+"development and online environments. Based on email conventions, it was "
+"developed in 2004 by John Gruber and Aaron Swartz."
+msgstr ""
+
+#: ../../paper.md:143 6297d980245f4f8996aa247167a4fc7c
+msgid "Inline markup"
+msgstr ""
+
+#: ../../paper.md:145 d8f21d85db4d425d8a0f4b1e38da0fda
+msgid ""
+"The markup in Markdown should be semantic, not presentations. The table "
+"below has some basic examples."
+msgstr ""
+
+#: ../../paper.md:26 d3df3328c4b64fc79997a1eb9b5aba15
+msgid "Markup"
+msgstr ""
+
+#: ../../paper.md:26 71e31d5f64224918affd375f45966558
+msgid "Markdown example"
+msgstr ""
+
+#: ../../paper.md:26 2dc916e2562649c7a74cf6c3aeac0874
+msgid "Rendered output"
+msgstr ""
+
+#: ../../paper.md:26 19cc622ca4494b8a9fa55b3a4388c2aa
+msgid "emphasis"
+msgstr ""
+
+#: ../../paper.md:26 a948a0a3802946478e2ff67ec0447655
+msgid "`*this*`"
+msgstr ""
+
+#: ../../paper.md:26 c58033ec56614927859e5e062d0bd345
+msgid "*this*"
+msgstr ""
+
+#: ../../paper.md:26 3e6cf5b487fb4a2689d8ac32c0788ca1
+msgid "strong emphasis"
+msgstr ""
+
+#: ../../paper.md:26 87febb945a3a4114ac4e4d8bbff65234
+msgid "`**that**`"
+msgstr ""
+
+#: ../../paper.md:26 a1765c48f9bb4e5883a902d91aa67278
+msgid "**that**"
+msgstr ""
+
+#: ../../paper.md:26 2ee0f00be1de4d638e605814fa02365f
+msgid "strikeout"
+msgstr ""
+
+#: ../../paper.md:26 885cb945571c4bb19bffa030446ca598
+msgid "`~~not this~~`"
+msgstr ""
+
+#: ../../paper.md:26 6fc0a89828d44669ac25de645a01f13a
+msgid "~~not this~~"
+msgstr ""
+
+#: ../../paper.md:26 385f870923b842eeabdda8c2244b885b
+msgid "subscript"
+msgstr ""
+
+#: ../../paper.md:26 a800ad356de940f8b902cf81915b4bd7
+msgid "`H~2~O`"
+msgstr ""
+
+#: ../../paper.md:26 03cf79ed62ad4410a5620c9515580c52
+msgid "H{sub}`2`O"
+msgstr ""
+
+#: ../../paper.md:26 d72212de80a44aab8408b46657caa9fe
+msgid "superscript"
+msgstr ""
+
+#: ../../paper.md:26 abd55b2a79af49728e32f3cba1d37811
+msgid "`Ca^2+^`"
+msgstr ""
+
+#: ../../paper.md:26 edef998bf9924bb19218abf4b07260e5
+msgid "Ca{sup}`2+`"
+msgstr ""
+
+#: ../../paper.md:26 2d13cc92c79d4f96afb59bd17f76a9f2
+msgid "underline"
+msgstr ""
+
+#: ../../paper.md:26 c6f3cde067ba4082906c6c064f7074f4
+msgid "`[underline]{.ul}`"
+msgstr ""
+
+#: ../../paper.md:26 7b4509b5bd7345888756987c4a8be939
+msgid "[underline]{.ul}"
+msgstr ""
+
+#: ../../paper.md:26 65162614eaac4acc96a0a3071cb8a3db
+msgid "small caps"
+msgstr ""
+
+#: ../../paper.md:26 91530edf3cb845caacc1e535364ca03e
+msgid "`[Small Caps]{.sc}`"
+msgstr ""
+
+#: ../../paper.md:26 45ab80e8677a43899fd1b35f6e7a8203
+msgid "[Small Caps]{.sc}"
+msgstr ""
+
+#: ../../paper.md:26 be91f863a4e8472cbf1e661551378429
+msgid "inline code"
+msgstr ""
+
+#: ../../paper.md:26 35992e1d02f746c1a80deaed97a40045
+msgid "`` `return 23` ``"
+msgstr ""
+
+#: ../../paper.md:26 50a8e17eb7444ab6b6a9d3a3386d3acd
+msgid "`return 23`"
+msgstr ""
+
+#: ../../paper.md:159 0d3c74f2e23a46929da8ff4443dc3f24
+msgid "Links"
+msgstr ""
+
+#: ../../paper.md:161 dc93319bdbfe4c8fbda1e72409ac8e1d
+msgid ""
+"Link syntax is `[link description](targetURL)`. E.g., this link to the "
+"[Journal of Open Source Software](https://joss.theoj.org/) is written as "
+"\\ `[Journal of Open Source Software](https://joss.theoj.org/)`."
+msgstr ""
+
+#: ../../paper.md:164 a46e19b9f7424c4ebc18a97071b16854
+msgid ""
+"Open Journal publications are not limited by the constraints of print "
+"publications. We encourage authors to use hyperlinks for websites and "
+"other external resources. However, the standard scientific practice of "
+"citing the relevant publications should be followed regardless."
+msgstr ""
+
+#: ../../paper.md:166 e7673ea4de8c41e5b647187597cf4438
+msgid "Grid Tables"
+msgstr ""
+
+#: ../../paper.md:168 a6f5f6ad8afb4076aef3a6a26e42bf3f
+msgid ""
+"Grid tables are made up of special characters which form the rows and "
+"columns, and also change table and style variables."
+msgstr ""
+
+#: ../../paper.md:170 d5ce43c9effb4504928b003a114ed47b
+msgid ""
+"Complex information can be conveyed by using the following features not "
+"found in other table styles:"
+msgstr ""
+
+#: ../../paper.md:172 18e1a75a972749a888862eb73b6182e5
+msgid "spanning columns"
+msgstr ""
+
+#: ../../paper.md:173 885f47fb518a4f8db6004b4680b63532
+msgid "adding footers"
+msgstr ""
+
+#: ../../paper.md:174 b3b4738e305047ca8c576bda1044e5d8
+msgid "using intra-cellular body elements"
+msgstr ""
+
+#: ../../paper.md:175 765a10f0d6ea48449a45f8bb917bc042
+msgid "creating multi-row headers"
+msgstr ""
+
+#: ../../paper.md:177 637517af24604afca5f59c7db1b5f470
+msgid ""
+"Grid table syntax uses the characters \"-\", \"=\", \"|\", and \"+\" to "
+"represent the table outline:"
+msgstr ""
+
+#: ../../paper.md:179 86751efbcd76472aa01f232810e33bea
+msgid "Hyphens (-) separate horizontal rows."
+msgstr ""
+
+#: ../../paper.md:180 caccc6e900e440ddac1d5e0ed3bd6593
+msgid ""
+"Equals signs (=) produce a header when used to create the row under the "
+"header text."
+msgstr ""
+
+#: ../../paper.md:181 c453086fc1754cfbb07b7e8fe800df08
+msgid ""
+"Equals signs (=) create a footer when used to enclose the last row of the"
+" table."
+msgstr ""
+
+#: ../../paper.md:182 97201779586f43f78b6083f89aabf9c3
+msgid "Vertical bars (|) separate columns and also adjusts the depth of a row."
+msgstr ""
+
+#: ../../paper.md:183 eda6f86cd1864a5885c9133f4df32357
+msgid "Plus signs (+) indicates a juncture between horizontal and parallel lines."
+msgstr ""
+
+#: ../../paper.md:185 cfbc0c2781684349b6b42e3e77b9f394
+msgid ""
+"Note: Inserting a colon (:) at the boundaries of the separator line after"
+" the header will change text alignment. If there is no header, insert "
+"colons into the top line."
+msgstr ""
+
+#: ../../paper.md:187 e7d4ac076a6e4b24bf520f1e30ea99b2
+msgid "Sample grid table:"
+msgstr ""
+
+#: ../../paper.md:204 68e153d4ff5b43538ab81db30e236a5b
+msgid "Figures and Images"
+msgstr ""
+
+#: ../../paper.md:206 d3dd4a2dc0064607b123dbed87a838df
+msgid ""
+"To create a figure, a captioned image must appear by itself in a "
+"paragraph. The Markdown syntax for a figure is a link, preceded by an "
+"exclamation point (!) and a description.   Example:   `![This description"
+" will be the figure caption](path/to/image.png)`"
+msgstr ""
+
+#: ../../paper.md:210 25374bd786624c4c8dd131cbd7ba12c9
+msgid ""
+"In order to create a figure rather than an image, there must be a "
+"description included and the figure syntax must be the only element in "
+"the paragraph, i.e., it must be surrounded by blank lines."
+msgstr ""
+
+#: ../../paper.md:212 afe902d108f54b1b8c09d40f691776eb
+msgid ""
+"Images that are larger than the text area are scaled to fit the page. You"
+" can give images an explicit height and/or width, e.g. when adding an "
+"image as part of a paragraph. The Markdown `![Nyan cat](nyan-"
+"cat.png){height=\"9pt\"}` includes the image saved as `nyan-cat.png` "
+"while scaling it to a height of 9 pt."
+msgstr ""
+
+#: ../../paper.md:214 d781dc3c1e0e4ec88d36b614f55f1d4a
+msgid "Citations"
+msgstr ""
+
+#: ../../paper.md:216 a308b28c59314248bcad2d66a5f81828
+msgid ""
+"Bibliographic data should be collected in a file `paper.bib`; it should "
+"be formatted in the BibLaTeX format, although plain BibTeX is acceptable "
+"as well. All major citation managers offer to export these formats."
+msgstr ""
+
+#: ../../paper.md:218 68879f46c083445189cd2ec5f2e24677
+msgid ""
+"Cite a bibliography entry by referencing its identifier: `[@upper1974]` "
+"will create the reference \"(Upper 1974)\". Omit the brackets when "
+"referring to the author as part of a sentence: \"For a case study on "
+"writers block, see Upper (1974).\" Please refer to the [pandoc "
+"manual](https://pandoc.org/MANUAL#extension-citations) for additional "
+"features, including page locators, prefixes, suffixes, and suppression of"
+" author names in citations."
+msgstr ""
+
+#: ../../paper.md:226 9ced5108486944279bbadf6acd752d6d
+msgid "The full citation will display as"
+msgstr ""
+
+#: ../../paper.md:228 b58d3000ebc14f6ea205d83d02d97ffe
+msgid ""
+"Upper, D. 1974. \"The Unsuccessful Self-Treatment of a Case of "
+"\\\"Writer's Block\\\".\" *Journal of Applied Behavior Analysis* 7 (3): "
+"497. <https://doi.org/10.1901/jaba.1974.7-497a>."
+msgstr ""
+
+#: ../../paper.md:232 83bffdb66e8c469e891be7c79776e24c
+msgid "Mathematical Formulæ"
+msgstr ""
+
+#: ../../paper.md:234 88f755b42e5f4f70ad0886fb02178d06
+msgid ""
+"Mark equations and other math content with dollar signs ($). Use a single"
+" dollar sign ($) for math that will appear directly within the text. Use "
+"two dollar signs ($$) when the formula is to be presented centered and on"
+" a separate line, in \"display\" style. The formula itself must be given "
+"using TeX syntax."
+msgstr ""
+
+#: ../../paper.md:236 c57d9b2d35344152b639f4665a30e1c0
+msgid ""
+"To give some examples: When discussing a variable *x* or a short formula "
+"like"
+msgstr ""
+
+#: ../../paper.md:238 84a73b2d6e43464498f0945bc8cb6d9f
+msgid "\\sin \\frac{\\pi}{2}"
+msgstr ""
+
+#: ../../paper.md:242 dea1c388f0544db69339d9736ec000b5
+msgid "we would write $x$ and"
+msgstr ""
+
+#: ../../paper.md:246 a97b8654f0da4367a248b0aebf7dbd58
+msgid ""
+"respectively. However, for more complex formulæ, display style is more "
+"appropriate. Writing"
+msgstr ""
+
+#: ../../paper.md:250 0f0329c771f44cb6a6efaafd1ad78646
+msgid "will give us"
+msgstr ""
+
+#: ../../paper.md:252 918f159918e6425cba03454fee55c46e
+msgid "$$\\int_{-\\infty}^{+\\infty} e^{-x^2} \\, dx = \\sqrt{\\pi}$$"
+msgstr ""
+
+#: ../../paper.md:254 ../../paper.md:272 200c575fa9724d6191d0ac3601ce1657
+#: 654239a09caa439db25316f6f862e3ed
+msgid "Footnotes"
+msgstr ""
+
+#: ../../paper.md:256 50bee0b418a74fd0b1553da10571d333
+msgid ""
+"Syntax for footnotes centers around the \"caret\" character `^`. The "
+"symbol is also used as a delimiter for superscript text and thereby "
+"mirrors the superscript numbers used to mark a footnote in the final "
+"text."
+msgstr ""
+
+#: ../../paper.md:265 b78a90e3ad884ad89029584ca691d168
+msgid "The above example results in the following output:"
+msgstr ""
+
+#: ../../paper.md:269 adf6b36b98e74cde95d2ae621d9d8cb4
+msgid ""
+"Articles are published under a Creative Commons license [#f1]_. Software "
+"should use an OSI-approved license."
+msgstr ""
+
+#: ../../paper.md:273 c2d72dc731f9452cb4eba7528bf9f3b3
+msgid "An open license that allows reuse."
+msgstr ""
+
+#: ../../paper.md:277 d8cecaaf776f437f8a3d75f4c3c4fe8f
+msgid ""
+"Note: numbers do not have to be sequential, they will be reordered "
+"automatically in the publishing step. In fact, the identifier of a note "
+"can be any sequence of characters, like `[^marker]`, but may not contain "
+"whitespace characters."
+msgstr ""
+
+#: ../../paper.md:280 b0b34a44b50f43c0b4f2dc2f7fb0da1f
+msgid "Blocks"
+msgstr ""
+
+#: ../../paper.md:282 b056c0cf16644fe7ab3c59aa8b23cd76
+msgid "The larger components of a document are called \"blocks\"."
+msgstr ""
+
+#: ../../paper.md:284 205d779737564263b3301c258d94a892
+msgid "Headings"
+msgstr ""
+
+#: ../../paper.md:286 7d07abf30db64a60a587faeaeb53ffff
+msgid ""
+"Headings are added with `#` followed by a space, where each additional "
+"`#` demotes the heading to a level lower in the hierarchy:"
+msgstr ""
+
+#: ../../paper.md:296 03bca033beee433d96a81737d3adcbf9
+msgid ""
+"Please start headings on the first level. The maximum supported level is "
+"5, but paper authors are encouraged to limit themselves to headings of "
+"the first two or three levels."
+msgstr ""
+
+#: ../../paper.md:298 545dbaf2d690400bb80f400e9a5db1d1
+msgid "Deeper nesting"
+msgstr ""
+
+#: ../../paper.md:300 6fc28f3a87ad460ab3c89394b150fad9
+msgid ""
+"Fourth- and fifth-level subsections – like this one and the following "
+"heading – are supported by the system; however, their use is discouraged."
+" Use lists instead of fourth- and fifth-level headings."
+msgstr ""
+
+#: ../../paper.md:303 907b61bed238496d8d774a7c4933d893
+msgid "Lists"
+msgstr ""
+
+#: ../../paper.md:305 34fbfc819c714c67a5e7e83e95af6289
+msgid ""
+"Bullet lists and numbered lists, a.k.a. enumerations, offer an additional"
+" method to present sequential and hierarchical information."
+msgstr ""
+
+#: ../../paper.md:314 e117581200c145db9836ca8670bafa45
+msgid "apples"
+msgstr ""
+
+#: ../../paper.md:315 df8b5cb323ee435cb354c118514ab0d5
+msgid "citrus fruits"
+msgstr ""
+
+#: ../../paper.md:316 b1e18a0e189646efb99c1048c7ca2ffb
+msgid "lemons"
+msgstr ""
+
+#: ../../paper.md:317 f63fd2fea04d4b2fa4cfc6d0e0e2bb4a
+msgid "oranges"
+msgstr ""
+
+#: ../../paper.md:319 d3c61a750d9c4f33b662bc3e6f39b2b6
+msgid ""
+"Enumerations start with the number of the first item. Using the the first"
+" two [laws of "
+"thermodynamics](https://en.wikipedia.org/wiki/Laws_of_thermodynamics) as "
+"example,"
+msgstr ""
+
+#: ../../paper.md:330 06cb1a1c2ed24fa8b6a14b4772b3c397
+msgid "Rendered:"
+msgstr ""
+
+#: ../../paper.md:332 2cf710ad67ae4c2ba56d655cc91662ed
+msgid ""
+"If two systems are each in thermal equilibrium with a third, they are "
+"also in thermal equilibrium with each other."
+msgstr ""
+
+#: ../../paper.md:333 af3e0769ebf54102be5e436699193ced
+msgid ""
+"In a process without transfer of matter, the change in internal energy, "
+"$\\Delta U$, of a thermodynamic system is equal to the energy gained as "
+"heat, $Q$, less the thermodynamic work, $W$, done by the system on its "
+"surroundings. $$\\Delta U = Q - W$$"
+msgstr ""
+
+#: ../../paper.md:336 e7942e2a2aed45a083f4736213905b84
+msgid "Checking that your paper compiles"
+msgstr ""
+
+#: ../../paper.md:338 87276e2613d946699125e8ff7e56341d
+msgid ""
+"JOSS uses Pandoc to compile papers from their Markdown form into a PDF. "
+"There are a few different ways you can test that your paper is going to "
+"compile properly for JOSS:"
+msgstr ""
+
+#: ../../paper.md:340 278486451bea43619f324ad6bab10fde
+msgid "GitHub Action"
+msgstr ""
+
+#: ../../paper.md:342 b6d499cea66f4dd7b73a26b06d2d13ee
+msgid ""
+"If you're using GitHub for your repository, you can use the [Open "
+"Journals GitHub Action](https://github.com/marketplace/actions/open-"
+"journals-pdf-generator) to automatically compile your paper each time you"
+" update your repository."
+msgstr ""
+
+#: ../../paper.md:344 e75e90a3f7794e239a964024a9b46db3
+msgid ""
+"The PDF is available via the Actions tab in your project and click on the"
+" latest workflow run. The zip archive file (including the `paper.pdf`) is"
+" listed in the run's Artifacts section."
+msgstr ""
+
+#: ../../paper.md:346 2ad09cdbb09f44bd93356b2a61bbbb80
+msgid "Docker"
+msgstr ""
+
+#: ../../paper.md:348 dffc31688cae44f08b93b3b9bc3b6b68
+msgid ""
+"If you have Docker installed on your local machine, you can use the same "
+"Docker Image to compile a draft of your paper locally. In the example "
+"below, the `paper.md` file is in the `paper` directory. Upon successful "
+"execution of the command, the `paper.pdf` file will be created in the "
+"same location as the `paper.md` file:"
+msgstr ""
+
+#: ../../paper.md:358 033a33ebf2ba4473907162b56a9c9f4a
+msgid "Locally"
+msgstr ""
+
+#: ../../paper.md:360 10a19a9058f842bba680a0cab71b851e
+msgid ""
+"The materials for the `inara` container image above are themselves open "
+"source and available in [its own "
+"repository](https://github.com/openjournals/inara). You can clone that "
+"repository and run the `inara` script locally with `make` after "
+"installing the necessary dependencies, which can be inferred from the "
+"[`Dockerfile`](https://github.com/openjournals/inara/blob/main/Dockerfile)."
+msgstr ""
+
+#: ../../paper.md:362 61413520e58d44b3b72760315e5aa7c5
+msgid "Behind the scenes"
+msgstr ""
+
+#: ../../paper.md:364 b0935bca284342188f389d7ab25691a2
+msgid ""
+"Readers may wonder about the reasons behind some of the choices made for "
+"paper writing. Most often, the decisions were driven by radical "
+"pragmatism. For example, Markdown is not only nearly ubiquitous in the "
+"realms of software, but it can also be converted into many different "
+"output formats. The archiving standard for scientific articles is JATS, "
+"and the most popular publishing format is PDF. Open Journals has built "
+"its pipeline based on [pandoc](https://pandoc.org), a universal document "
+"converter that can produce both of these publishing formats as well as "
+"many more."
+msgstr ""
+
+#: ../../paper.md:366 c49bc21e23344cb59e03d9194ac0e11d
+msgid ""
+"A common method for PDF generation is to go via LaTeX. However, support "
+"for tagging -- a requirement for accessible PDFs -- is not readily "
+"available for LaTeX. The current method used ConTeXt, to produce tagged "
+"PDF/A-3."
+msgstr ""
+

--- a/docs/locale/pl/LC_MESSAGES/policies.po
+++ b/docs/locale/pl/LC_MESSAGES/policies.po
@@ -1,0 +1,86 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: pl\n"
+"Language-Team: pl <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../policies.md:1 05bd176d1b3d4a84b95c1e98561974a7
+msgid "JOSS Policies"
+msgstr ""
+
+#: ../../policies.md:3 1a24f03bf77c44e5bc89d17ecd904804
+msgid "Animal research policy"
+msgstr ""
+
+#: ../../policies.md:5 a29e58a0a21447f1a28925c36a80f353
+msgid ""
+"In the exceptional case a JOSS submission contains original data on "
+"animal research, the corresponding author must confirm that the data was "
+"collected in accordance with the latest guidelines and applicable "
+"regulations. The manuscript must include complete reporting of the data, "
+"including the ways that the study was approved and relevant details of "
+"the sample. Authors are required to report either the "
+"[ARRIVE](https://arriveguidelines.org/) or "
+"[PREPARE](https://doi.org/10.1177/0023677217724823) guidelines for animal"
+" research in the submission."
+msgstr ""
+
+#: ../../policies.md:7 41e6fe0485154930a4a4630831b36898
+msgid ""
+"We recommend that authors replace, reduce, and refine animal research as "
+"promoted by the [N3RS](https://www.nc3rs.org.uk/)."
+msgstr ""
+
+#: ../../policies.md:9 0a44ed6a60e84552b1810e6aad1aa183
+msgid "Data sharing policy"
+msgstr ""
+
+#: ../../policies.md:11 6f14b42a55d34bb783de81296f134597
+msgid ""
+"If any original data analysis results are provided within the submitted "
+"work, such results have to be entirely reproducible by reviewers, "
+"including accessing the data."
+msgstr ""
+
+#: ../../policies.md:13 bfde40c520e74ffc9264824de2104fe9
+msgid ""
+"Submissions are, by definition, contained within one or multiple "
+"repositories, which we require authors to archive before we accept the "
+"submission. Any data contained within the software is made available "
+"accordingly."
+msgstr ""
+
+#: ../../policies.md:16 32119166412c467e927ba9c349404d68
+msgid "Human participants research policy"
+msgstr ""
+
+#: ../../policies.md:18 527c91102a9f44639f5edc8632fc3b59
+msgid ""
+"In the exceptional case a JOSS submission contains original data on human"
+" participants, the study must have been performed in accordance with the "
+"[Declaration of Helsinki](https://www.wma.net/policies-post/wma-"
+"declaration-of-helsinki-ethical-principles-for-medical-research-"
+"involving-human-subjects/). The manuscript must contain all relevant "
+"information regarding ethics approval, including but not limited to the "
+"responsible ethics committee and reference number. This also applies to "
+"ethics exemptions. Informed consent must be collected from all human "
+"research participants, and authors are required to state whether this "
+"occurred in the manuscript."
+msgstr ""
+

--- a/docs/locale/pl/LC_MESSAGES/review_checklist.po
+++ b/docs/locale/pl/LC_MESSAGES/review_checklist.po
@@ -1,0 +1,200 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: pl\n"
+"Language-Team: pl <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../review_checklist.md:1 66a6c65f275d44cbb2bf2b7d90818c3a
+msgid "Review checklist"
+msgstr ""
+
+#: ../../review_checklist.md:3 ab33d256eec14d68a92c5df919eb7ea3
+msgid ""
+"JOSS reviews are checklist-driven. That is, there is a checklist for each"
+" JOSS reviewer to work through when completing their review. A JOSS "
+"review is generally considered incomplete until the reviewer has checked "
+"off all of their checkboxes."
+msgstr ""
+
+#: ../../review_checklist.md:5 bdb4fdb8aa7d4521b7d8fb3ed024ad92
+msgid ""
+"Below is an example of the review checklist for the [Yellowbrick JOSS "
+"submission](https://github.com/openjournals/joss-reviews/issues/1075)."
+msgstr ""
+
+#: ../../review_checklist.md:9 ac29b31942e64e75a81f234148534d4e
+msgid ""
+"Note this section of our documentation only describes the JOSS review "
+"checklist. Authors and reviewers should consult the [review "
+"criteria](review_criteria) to better understand how these checklist items"
+" should be interpreted."
+msgstr ""
+
+#: ../../review_checklist.md:11 a5b9ebdb2c224bccb418db97543955fd
+msgid "Conflict of interest"
+msgstr ""
+
+#: ../../review_checklist.md:13 d9e6d5eef2514de981668ed987f0fa41
+msgid ""
+"I confirm that I have read the [JOSS conflict of interest "
+"policy](reviewer_guidelines.md#joss-conflict-of-interest-policy) and "
+"that: I have no COIs with reviewing this work or that any perceived COIs "
+"have been waived by JOSS for the purpose of this review."
+msgstr ""
+
+#: ../../review_checklist.md:15 b756fc2a709942baac7158306b73e675
+msgid "Code of Conduct"
+msgstr ""
+
+#: ../../review_checklist.md:17 f565cf05471743518d47a4dcde002be2
+msgid ""
+"I confirm that I read and will adhere to the [JOSS code of "
+"conduct](https://joss.theoj.org/about#code_of_conduct)."
+msgstr ""
+
+#: ../../review_checklist.md:19 a8b74cd44e3545d4964f0d2d28ee4928
+msgid "General checks"
+msgstr ""
+
+#: ../../review_checklist.md:21 47a2f9a832c14548be1b915bfa9aa4d1
+msgid ""
+"**Repository:** Is the source code for this software available at the <a "
+"target=\"_blank\" "
+"href=\"https://github.com/DistrictDataLabs/yellowbrick\">repository "
+"url</a>?"
+msgstr ""
+
+#: ../../review_checklist.md:22 0c35535cc6fe469188caf674344b3ba5
+msgid ""
+"**License:** Does the repository contain a plain-text LICENSE file with "
+"the contents of an [OSI "
+"approved](https://opensource.org/licenses/alphabetical) software license?"
+msgstr ""
+
+#: ../../review_checklist.md:23 62ebe9bb575643c29322218589461dbe
+msgid ""
+"**Contribution and authorship:** Has the submitting author made major "
+"contributions to the software? Does the full list of paper authors seem "
+"appropriate and complete?"
+msgstr ""
+
+#: ../../review_checklist.md:25 d697e71dad8a472c8821084c9a69704a
+msgid "Functionality"
+msgstr ""
+
+#: ../../review_checklist.md:27 043f354cc3634e31a57f6c02c4f98df4
+msgid ""
+"**Installation:** Does installation proceed as outlined in the "
+"documentation?"
+msgstr ""
+
+#: ../../review_checklist.md:28 40f63352e5fd4566abfab33af3e21c3f
+msgid ""
+"**Functionality:** Have the functional claims of the software been "
+"confirmed?"
+msgstr ""
+
+#: ../../review_checklist.md:29 4887147c31084be681cadd1d7c031f0a
+msgid ""
+"**Performance:** If there are any performance claims of the software, "
+"have they been confirmed? (If there are no claims, please check off this "
+"item.)"
+msgstr ""
+
+#: ../../review_checklist.md:31 040ce75ed5d34bfe84921ed499be6aa5
+msgid "Documentation"
+msgstr ""
+
+#: ../../review_checklist.md:33 ce980eb02c1a4bb6ba7c51f7ce7c2b03
+msgid ""
+"**A statement of need:** Do the authors clearly state what problems the "
+"software is designed to solve and who the target audience is?"
+msgstr ""
+
+#: ../../review_checklist.md:34 4b0a6f9b8a4d4f98b32efd462a30cb38
+msgid ""
+"**Installation instructions:** Is there a clearly-stated list of "
+"dependencies? Ideally these should be handled with an automated package "
+"management solution."
+msgstr ""
+
+#: ../../review_checklist.md:35 804ce952933a4ea2be9a7333cc78e95b
+msgid ""
+"**Example usage:** Do the authors include examples of how to use the "
+"software (ideally to solve real-world analysis problems)."
+msgstr ""
+
+#: ../../review_checklist.md:36 d7652d9182a848fbaff430778b15723a
+msgid ""
+"**Functionality documentation:** Is the core functionality of the "
+"software documented to a satisfactory level (e.g., API method "
+"documentation)?"
+msgstr ""
+
+#: ../../review_checklist.md:37 1690d7664c00418c9c66f3f5127fc584
+msgid ""
+"**Automated tests:** Are there automated tests or manual steps described "
+"so that the functionality of the software can be verified?"
+msgstr ""
+
+#: ../../review_checklist.md:38 be6c547613474995be785253c9ebbcfd
+msgid ""
+"**Community guidelines:** Are there clear guidelines for third parties "
+"wishing to 1) Contribute to the software 2) Report issues or problems "
+"with the software 3) Seek support"
+msgstr ""
+
+#: ../../review_checklist.md:40 ab745636d12945438b7d66d2deb64534
+msgid "Software paper"
+msgstr ""
+
+#: ../../review_checklist.md:42 61634e5a367b4123a26fd3005e19af68
+msgid ""
+"**Summary:** Has a clear description of the high-level functionality and "
+"purpose of the software for a diverse, non-specialist audience been "
+"provided?"
+msgstr ""
+
+#: ../../review_checklist.md:43 6b1c201f0b624ac5815b79eb1c119945
+msgid ""
+"**A statement of need:** Does the paper have a section titled 'Statement "
+"of need' that clearly states what problems the software is designed to "
+"solve, who the target audience is, and its relation to other work?"
+msgstr ""
+
+#: ../../review_checklist.md:44 918b339399514b9da9e93fdfa1ec098a
+msgid ""
+"**State of the field:** Do the authors describe how this software "
+"compares to other commonly-used packages?"
+msgstr ""
+
+#: ../../review_checklist.md:45 c767f227017641bb92d17fa4aadba03a
+msgid ""
+"**Quality of writing:** Is the paper well written (i.e., it does not "
+"require editing for structure, language, or writing quality)?"
+msgstr ""
+
+#: ../../review_checklist.md:46 281e3f89b1e24882a2f4a38d01c89fa7
+msgid ""
+"**References:** Is the list of references complete, and is everything "
+"cited appropriately that should be cited (e.g., papers, datasets, "
+"software)? Do references in the text use the proper [citation syntax]( "
+"https://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html#citation_syntax)?"
+msgstr ""
+

--- a/docs/locale/pl/LC_MESSAGES/review_criteria.po
+++ b/docs/locale/pl/LC_MESSAGES/review_criteria.po
@@ -1,0 +1,389 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: pl\n"
+"Language-Team: pl <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../review_criteria.md:1 a3ae2504cdaa47aeaa3da0fb14ab5a56
+msgid "Review criteria"
+msgstr ""
+
+#: ../../review_criteria.md:3 c49b5ecb47a84a32b6f5b3ee3715d525
+msgid "The JOSS paper"
+msgstr ""
+
+#: ../../review_criteria.md:5 93a2222f76c943dd84499681ef06115a
+msgid ""
+"As outlined in the [submission guidelines provided to authors](paper.md"
+"#what-should-my-paper-contain), the JOSS paper (the compiled PDF "
+"associated with this submission) should only include:"
+msgstr ""
+
+#: ../../review_criteria.md:7 1f4d9cc91cd84aaa9bb019fe4dba0dc8
+msgid "A list of the authors of the software and their affiliations."
+msgstr ""
+
+#: ../../review_criteria.md:8 c1fc8ff600484d3dab42a4daa19a5536
+msgid ""
+"A summary describing the high-level functionality and purpose of the "
+"software for a diverse, non-specialist audience."
+msgstr ""
+
+#: ../../review_criteria.md:9 aba52248ddba49299ca26939f4a55724
+msgid "A clear statement of need that illustrates the purpose of the software."
+msgstr ""
+
+#: ../../review_criteria.md:10 5432e875314441b08dadb882791eb795
+msgid ""
+"A description of how this software compares to other commonly-used "
+"packages in this research area."
+msgstr ""
+
+#: ../../review_criteria.md:11 290b1f2a97d344c491ef92b86b97498c
+msgid ""
+"Mentions (if applicable) of any ongoing research projects using the "
+"software or recent scholarly publications enabled by it."
+msgstr ""
+
+#: ../../review_criteria.md:12 862c8f7394104c96ac6b7900f1014999
+msgid "A list of key references including a link to the software archive."
+msgstr ""
+
+#: ../../review_criteria.md:15 d387e6729d58447da57400ea805b9ddc
+msgid ""
+"Note the paper *should not* include software documentation such as API "
+"(Application Programming Interface) functionality, as this should be "
+"outlined in the software documentation."
+msgstr ""
+
+#: ../../review_criteria.md:18 c3c635e88b274a3086ddda3ad4b1e176
+msgid "Review items"
+msgstr ""
+
+#: ../../review_criteria.md:21 c677627ec8a34ec7a23f7c58e5c70b10
+msgid ""
+"Note, if you've not yet been involved in a JOSS review, you can see an "
+"example JOSS review checklist [here](review_checklist)."
+msgstr ""
+
+#: ../../review_criteria.md:24 066ba8aa557d4a598cea9d5f302fe406
+msgid "Software license"
+msgstr ""
+
+#: ../../review_criteria.md:26 29bfcd0a730a42a6b230d4ab11897725
+msgid ""
+"There should be an [OSI "
+"approved](https://opensource.org/licenses/alphabetical) license included "
+"in the repository. Common licenses such as those listed on "
+"[choosealicense.com](https://choosealicense.com) are preferred. Note "
+"there should be an actual license file present in the repository not just"
+" a reference to the license."
+msgstr ""
+
+#: ../../review_criteria.md:28 c6803cd60a494344846c83ad030e05e9
+msgid ""
+"**Acceptable:** A plain-text LICENSE or COPYING file with the contents of"
+" an OSI approved license<br />             **Not acceptable:** A phrase "
+"such as 'MIT license' in a README file"
+msgstr ""
+
+#: ../../review_criteria.md:31 04833d2d9e924b539b619745a7a9cd0d
+msgid "Substantial scholarly effort"
+msgstr ""
+
+#: ../../review_criteria.md:33 30bac5e4746e4f448ac0115fb7e272a1
+msgid ""
+"Reviewers should verify that the software represents substantial "
+"scholarly effort. As a rule of thumb, JOSS' minimum allowable "
+"contribution should represent **not less than** three months of work for "
+"an individual. Signals of effort may include:"
+msgstr ""
+
+#: ../../review_criteria.md:35 7477cde373f0429480d60affc9bd8f25
+msgid ""
+"Age of software (is this a well-established software project) / length of"
+" commit history."
+msgstr ""
+
+#: ../../review_criteria.md:36 0cf8268b8f464abf9c8c17f76fadc30a
+msgid "Number of commits."
+msgstr ""
+
+#: ../../review_criteria.md:37 c674174db0f24c299a27e7def881586a
+msgid "Number of authors."
+msgstr ""
+
+#: ../../review_criteria.md:38 a40a69e54f2347069f5f48bce39d053a
+msgid ""
+"Lines of code (LOC): These statistics are usually reported by "
+"EditorialBot in the `pre-review` issue thread."
+msgstr ""
+
+#: ../../review_criteria.md:39 824bad6c28e34daf8cc2af69e6834cc0
+msgid "Whether the software has already been cited in academic papers."
+msgstr ""
+
+#: ../../review_criteria.md:40 9cac14af8bd34ff9b14aca3dadb45d9c
+msgid ""
+"Whether the software is sufficiently useful that it is _likely to be "
+"cited_ by other researchers working in this domain."
+msgstr ""
+
+#: ../../review_criteria.md:42 c7e64a5ebbe54d2f8df4184127bbefc8
+msgid ""
+"These guidelines are not meant to be strictly prescriptive. Recently "
+"released software may not have been around long enough to gather "
+"citations in academic literature. While some authors contribute openly "
+"and accrue a long and rich commit history before submitting, others may "
+"upload their software to GitHub shortly before submitting their JOSS "
+"paper.  Reviewers should rely on their expert understanding of their "
+"domain to judge whether the software is of broad interest (_likely to be "
+"cited by other researchers_) or more narrowly focused around the needs of"
+" an individual researcher or lab."
+msgstr ""
+
+#: ../../review_criteria.md:45 14e061e917a34d84bd1b45fbd683c521
+msgid ""
+"The decision on scholarly effort is ultimately one made by JOSS editors. "
+"Reviewers are asked to flag submissions of questionable scope during the "
+"review process so that the editor can bring this to the attention of the "
+"JOSS editorial team."
+msgstr ""
+
+#: ../../review_criteria.md:48 bc63b89e20f54816b2c6fa2bd7631a72
+msgid "Documentation"
+msgstr ""
+
+#: ../../review_criteria.md:50 762d838e2b6342e2aa20e552cff0281c
+msgid ""
+"There should be sufficient documentation for you, the reviewer to "
+"understand the core functionality of the software under review. A high-"
+"level overview of this documentation should be included in a `README` "
+"file (or equivalent). There should be:"
+msgstr ""
+
+#: ../../review_criteria.md:52 cdbfad5d318f495ca77ff18e66a48c26
+msgid "A statement of need"
+msgstr ""
+
+#: ../../review_criteria.md:54 b64bdb4ac55d45f281f55d3a240ce249
+msgid ""
+"The authors should clearly state what problems the software is designed "
+"to solve, who the target audience is, and its relation to other work."
+msgstr ""
+
+#: ../../review_criteria.md:56 b94ecbcfa45a42c7a68caca936983ff2
+msgid "Installation instructions"
+msgstr ""
+
+#: ../../review_criteria.md:58 04c1fd41940943a0b240a2426431c51d
+msgid ""
+"Software dependencies should be clearly documented and their installation"
+" handled by an automated procedure. Where possible, software installation"
+" should be managed with a package manager. However, this criterion "
+"depends upon the maturity and availability of software packaging and "
+"distribution in the programming language being used. For example, Python "
+"packages should be `pip install`able, and have adopted [packaging "
+"conventions](https://packaging.python.org), while Fortran submissions "
+"with a Makefile may be sufficient."
+msgstr ""
+
+#: ../../review_criteria.md:60 423ec8bc924d45e3a8a68f1a52ba46ad
+msgid ""
+"**Good:** The software is simple to install, and follows established "
+"distribution and dependency management approaches for the language being "
+"used<br /> **OK:** A list of dependencies to install, together with some "
+"kind of script to handle their installation (e.g., a Makefile)<br /> "
+"**Bad (not acceptable):** Dependencies are unclear, and/or installation "
+"process lacks automation"
+msgstr ""
+
+#: ../../review_criteria.md:64 99c4a218ff0b475d8fb1519284276fd9
+msgid "Example usage"
+msgstr ""
+
+#: ../../review_criteria.md:66 93205fb027ac4d7ab35b410f0128cb4a
+msgid ""
+"The authors should include examples of how to use the software (ideally "
+"to solve real-world analysis problems)."
+msgstr ""
+
+#: ../../review_criteria.md:68 cf0cd14d290d47439729b5d22edfd9e2
+msgid "API documentation"
+msgstr ""
+
+#: ../../review_criteria.md:70 742f31db489740669c3b2daeeef92d17
+msgid ""
+"Reviewers should check that the software API is documented to a suitable "
+"level."
+msgstr ""
+
+#: ../../review_criteria.md:72 bb9dd3804e264b9888e5628d92711333
+msgid ""
+"**Good:** All functions/methods are documented including example inputs "
+"and outputs<br /> **OK:** Core API functionality is documented<br /> "
+"**Bad (not acceptable):** API is undocumented"
+msgstr ""
+
+#: ../../review_criteria.md:77 7ca53aa3538c4b46a4332b7cfe5c2195
+msgid ""
+"The decision on API documentation is left largely to the discretion of "
+"the reviewer and their experience of evaluating the software."
+msgstr ""
+
+#: ../../review_criteria.md:80 4f72d30f771d4d7f8a552288047c7258
+msgid "Community guidelines"
+msgstr ""
+
+#: ../../review_criteria.md:82 366133c9c36a4406a00140fdff344f46
+msgid "There should be clear guidelines for third-parties wishing to:"
+msgstr ""
+
+#: ../../review_criteria.md:84 3cfd6451af164fd8acc6792d2319d05a
+msgid "Contribute to the software"
+msgstr ""
+
+#: ../../review_criteria.md:85 387acec0c9134ec99118b0a4a0b7de4e
+msgid "Report issues or problems with the software"
+msgstr ""
+
+#: ../../review_criteria.md:86 e862f9edf72a4cd6869dab2578a0ddf4
+msgid "Seek support"
+msgstr ""
+
+#: ../../review_criteria.md:88 ac41672935d7481fb21fcd597a34fb5d
+msgid "Functionality"
+msgstr ""
+
+#: ../../review_criteria.md:90 ec0fd30c7a7e4f36bfc8b38410305be9
+msgid ""
+"Reviewers are expected to install the software they are reviewing and to "
+"verify the core functionality of the software."
+msgstr ""
+
+#: ../../review_criteria.md:92 f090de964a8c43e0a8c990ee6d4800da
+msgid "Tests"
+msgstr ""
+
+#: ../../review_criteria.md:94 e65f9d63fb1a48d08d5ce15aa49f9735
+msgid ""
+"Authors are strongly encouraged to include an automated test suite "
+"covering the core functionality of their software."
+msgstr ""
+
+#: ../../review_criteria.md:96 089c873fc04040bfb2ee1834edf23802
+msgid ""
+"**Good:** An automated test suite hooked up to continuous integration "
+"(GitHub Actions, Circle CI, or similar)<br /> **OK:** Documented manual "
+"steps that can be followed to objectively check the expected "
+"functionality of the software (e.g., a sample input file to assert "
+"behavior)<br /> **Bad (not acceptable):** No way for you, the reviewer, "
+"to objectively assess whether the software works"
+msgstr ""
+
+#: ../../review_criteria.md:100 ebb1b4031d094c5594972efd0a2a835b
+msgid "Other considerations"
+msgstr ""
+
+#: ../../review_criteria.md:102 86cfff0974ac429bb5f3b5a0ffcc5761
+msgid "Authorship"
+msgstr ""
+
+#: ../../review_criteria.md:104 fb9888066a4044ffbf7d1021d1ab3fa4
+msgid ""
+"As part of the review process, you are asked to check whether the "
+"submitting author has made a 'substantial contribution' to the submitted "
+"software (as determined by the commit history) and to check that 'the "
+"full list of paper authors seems appropriate and complete?'"
+msgstr ""
+
+#: ../../review_criteria.md:106 a1199fe7c5144a11a60643dd829bfe6d
+msgid ""
+"As discussed in the [submission guidelines for "
+"authors](submitting.md#authorship), authorship is a complex topic with "
+"different practices in different communities.  Ultimately, the authors "
+"themselves are responsible for deciding which contributions are "
+"sufficient for co-authorship, although JOSS policy is that purely "
+"financial contributions are not considered sufficient. Your job as a "
+"reviewer is to check that the list of authors appears reasonable, and if "
+"it's not obviously complete/correct, to raise this as a question during "
+"the review."
+msgstr ""
+
+#: ../../review_criteria.md:108 2a98da4cffce4906ab6de24f09322c25
+msgid "An important note about 'novel' software and citations of relevant work"
+msgstr ""
+
+#: ../../review_criteria.md:110 525c4a7e843147fe99eddcd11fff5fbe
+msgid ""
+"Submissions that implement solutions already solved in other software "
+"packages are accepted into JOSS provided that they meet the criteria "
+"listed above and cite prior similar work. Reviewers should point out "
+"relevant published work which is not yet cited."
+msgstr ""
+
+#: ../../review_criteria.md:112 3f8680b3074b45cd8c9d73cb69ffb1cb
+msgid "What happens if the software I'm reviewing doesn't meet the JOSS criteria?"
+msgstr ""
+
+#: ../../review_criteria.md:114 0f4ae26b8fa2418393f9280bfde27152
+msgid ""
+"We ask that reviewers grade submissions in one of three categories: 1) "
+"Accept 2) Minor Revisions 3) Major Revisions. Unlike some journals we do "
+"not reject outright submissions requiring major revisions - we're more "
+"than happy to give the author as long as they need to make these "
+"modifications/improvements."
+msgstr ""
+
+#: ../../review_criteria.md:116 2d3fb95950504a8f9805e879737a7f0d
+msgid ""
+"What about submissions that rely upon proprietary languages/development "
+"environments?"
+msgstr ""
+
+#: ../../review_criteria.md:118 28a5400b4e234c6f8656ae98057b751f
+msgid ""
+"As outlined in our author guidelines, submissions that rely upon a "
+"proprietary/closed source language or development environment are "
+"acceptable provided that they meet the other submission requirements and "
+"that you, the reviewer, are able to install the software & verify the "
+"functionality of the submission as required by our reviewer guidelines."
+msgstr ""
+
+#: ../../review_criteria.md:120 9d2bcdbbff5a40e68ed6cfb4a3f30852
+msgid ""
+"If an open source or free variant of the programming language exists, "
+"feel free to encourage the submitting author to consider making their "
+"software compatible with the open source/free variant."
+msgstr ""
+
+#: ../../review_criteria.md:122 b48c8ad73ef84644ab7f489a5335dd18
+msgid "Where can the repository be hosted?"
+msgstr ""
+
+#: ../../review_criteria.md:124 239c57cd8c514639a01b029768e59a6e
+msgid ""
+"Repositories must be hosted at a location that allows outside users to "
+"freely open issues and propose code changes, such as GitHub, GitLab, "
+"Bitbucket, etc. Submissions will not be accepted if the repository is "
+"hosted at a location where accounts must be manually approved (or paid "
+"for), regardless of if this approval is done by the owners of the "
+"repository or some other entity."
+msgstr ""
+

--- a/docs/locale/pl/LC_MESSAGES/reviewer_guidelines.po
+++ b/docs/locale/pl/LC_MESSAGES/reviewer_guidelines.po
@@ -1,0 +1,130 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: pl\n"
+"Language-Team: pl <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../reviewer_guidelines.md:1 a419474b5d484081ac03bf756dc47be2
+msgid "Reviewing for JOSS"
+msgstr ""
+
+#: ../../reviewer_guidelines.md:3 6f0fdd54d4174b4595d47c2b51ca3d61
+msgid ""
+"Firstly, thank you so much for agreeing to review for the Journal of Open"
+" Source Software (JOSS), we're delighted to have your help. This document"
+" is designed to outline our editorial guidelines and help you understand "
+"our requirements for accepting a submission into the JOSS. Our review "
+"process is based on a tried-and-tested approach of the [rOpenSci "
+"collaboration](http://ropensci.org/blog/2016/03/28/software-review)."
+msgstr ""
+
+#: ../../reviewer_guidelines.md:5 d5e8babfd2064983aa963d6a55fe50fa
+msgid "Guiding principles"
+msgstr ""
+
+#: ../../reviewer_guidelines.md:7 e9542046504d4ac8a187bd3008f57960
+msgid ""
+"We like to think of JOSS as a 'developer friendly' journal. That is, if "
+"the submitting authors have followed best practices (have documentation, "
+"tests, continuous integration, and a license) then their review should be"
+" rapid."
+msgstr ""
+
+#: ../../reviewer_guidelines.md:9 c4a4f8320cda4a24885dcce346f51047
+msgid ""
+"For those submissions that don't quite meet the bar, please try to give "
+"clear feedback on how authors could improve their submission. A key goal "
+"of JOSS is to raise the quality of research software generally and you "
+"(the experienced reviewer) are well placed to give this feedback."
+msgstr ""
+
+#: ../../reviewer_guidelines.md:11 c0da10831e7e434abf4b8a055a939ea5
+msgid ""
+"A JOSS review involves checking submissions against a checklist of "
+"essential software features and details in the submitted paper. This "
+"should be objective, not subjective; it should be based on the materials "
+"in the submission as perceived without distortion by personal feelings, "
+"prejudices, or interpretations."
+msgstr ""
+
+#: ../../reviewer_guidelines.md:13 f8fcae6e6d2149468bfe9f42b965a85d
+msgid ""
+"We encourage reviewers to file issues against the submitted repository's "
+"issue tracker. **When you have completed your review, please leave a "
+"comment in the review issue saying so.**"
+msgstr ""
+
+#: ../../reviewer_guidelines.md:15 1e6f2e4fec2d44178087bb2565ae4b21
+msgid ""
+"You can include in your review links to any new issues that you the "
+"reviewer believe to be impeding the acceptance of the repository. "
+"(Similarly, if the submitted repository is a GitHub repository, "
+"mentioning the review issue URL in the submitted repository's issue "
+"tracker will create a mention in the review issue's history.)"
+msgstr ""
+
+#: ../../reviewer_guidelines.md:17 efc7dd0cb2b94f26bc26af6c2c612cb5
+msgid "JOSS Conflict of Interest Policy"
+msgstr ""
+
+#: ../../reviewer_guidelines.md:19 579958bd5d754abea42dacc3dfbb13be
+msgid ""
+"The definition of a conflict of Interest in peer review is a circumstance"
+" that makes you \"unable to make an impartial scientific judgment or "
+"evaluation.\" ([PNAS Conflict of Interest "
+"Policy](http://www.pnas.org/site/authors/coi.xhtml)). JOSS is concerned "
+"with avoiding any actual conflicts of interest, and being sufficiently "
+"transparent that we avoid the appearance of conflicts of interest as "
+"well."
+msgstr ""
+
+#: ../../reviewer_guidelines.md:21 2bcd98fbb8054a0493f210435d102957
+msgid ""
+"As a reviewer (or editor), COIs are your present or previous association "
+"with any authors of a submission: recent (past four years) collaborators "
+"in funded research or work that is published; and lifetime for the family"
+" members, business partners, and thesis student/advisor or mentor. In "
+"addition, your recent (past year) association with the same organization "
+"of a submitter is a COI, for example, being employed at the same "
+"institution."
+msgstr ""
+
+#: ../../reviewer_guidelines.md:23 3e219416fb1b41f6be1daed87f710feb
+msgid ""
+"If you have a conflict of interest with a submission, you should disclose"
+" the specific reason to the submissions' editor (or to an EiC if you are "
+"an editor, or to the other EiCs if you are an EiC). This may lead to you "
+"not being able to review or edit the submission, but some conflicts may "
+"be recorded and then waived, and if you think you are able to make an "
+"impartial assessment of the work, you should request that the conflict be"
+" waived. For example, if you and a submitter were two of 2000 authors of "
+"a high energy physics paper but did not actually collaborate. Or if you "
+"and a submitter worked together 6 years ago, but due to delays in the "
+"publishing industry, a paper from that collaboration with both of you as "
+"authors was published 2 years ago. Or if you and a submitter are both "
+"employed by the same very large organization but in different units "
+"without any knowledge of each other."
+msgstr ""
+
+#: ../../reviewer_guidelines.md:25 20b6775665854597b7c9a1e07e37d175
+msgid ""
+"Declaring actual, perceived, and potential conflicts of interest is "
+"required under professional ethics. If in doubt: ask the editors."
+msgstr ""
+

--- a/docs/locale/pl/LC_MESSAGES/sample_messages.po
+++ b/docs/locale/pl/LC_MESSAGES/sample_messages.po
@@ -1,0 +1,54 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: pl\n"
+"Language-Team: pl <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../sample_messages.md:1 cef95ca5eb52466087ac6592b8313bc2
+msgid "Sample messages for authors and reviewers"
+msgstr ""
+
+#: ../../sample_messages.md:3 4cc65d85532a4849b89d03bd9f2df182
+msgid "Sample email to potential reviewers"
+msgstr ""
+
+#: ../../sample_messages.md:38 75d2d7121efb4d739fc9ccee78cd9590
+msgid "Query scope of submission"
+msgstr ""
+
+#: ../../sample_messages.md:50 b1bf7b7a0f1a4a308ace2cc4ae649d71
+msgid "GitHub invite to potential reviewers"
+msgstr ""
+
+#: ../../sample_messages.md:56 88bea41bab0f4aa68bd78b43f506f193
+msgid "Message to reviewers at the start of a review"
+msgstr ""
+
+#: ../../sample_messages.md:76 2fed1a4176bd444f8e00e87dd5bb5521
+msgid "Message to authors at the end of a review"
+msgstr ""
+
+#: ../../sample_messages.md:88 c726398e48664dbc97293c9d76bd2ed6
+msgid "Rejection due to out of scope/failing substantial scholarly effort test"
+msgstr ""
+
+#: ../../sample_messages.md:90 1813d0630c2b491e816e004cf1e16d04
+msgid "(Note that rejections are handled by EiCs and not individual editors)."
+msgstr ""
+

--- a/docs/locale/pl/LC_MESSAGES/submitting.po
+++ b/docs/locale/pl/LC_MESSAGES/submitting.po
@@ -1,0 +1,528 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: pl\n"
+"Language-Team: pl <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../submitting.md:1 71cbc32ad5bf43439a801a3bd72ab616
+msgid "Submitting a paper to JOSS"
+msgstr ""
+
+#: ../../submitting.md:3 ce6cc30f0f5742389088b8ca91bf4cea
+msgid ""
+"If you've already developed a fully featured research code, released it "
+"under an [OSI-approved license](https://opensource.org/licenses), and "
+"written good documentation and tests, then we expect that it should take "
+"perhaps an hour or two to prepare and submit your paper to JOSS. But "
+"please read these instructions carefully for a streamlined submission."
+msgstr ""
+
+#: ../../submitting.md:6 be732c65a672404fb848550294f9dd33
+msgid "Submission requirements"
+msgstr ""
+
+#: ../../submitting.md:8 fd0c74f034f8459bbc39cd47a2179404
+msgid ""
+"The software must be open source as per the [OSI "
+"definition](https://opensource.org/osd)."
+msgstr ""
+
+#: ../../submitting.md:9 177b6f6b577848b081b1b3a885a0fc34
+msgid ""
+"The software must be hosted at a location where users can open issues and"
+" propose code changes without manual approval of (or payment for) "
+"accounts."
+msgstr ""
+
+#: ../../submitting.md:10 81033d1871ec4a14a360bd8427c4061e
+msgid "The software must have an **obvious** research application."
+msgstr ""
+
+#: ../../submitting.md:11 e2fa627d3e534e168ccd394e8e1aa99b
+msgid ""
+"You must be a major contributor to the software you are submitting, and "
+"have a GitHub account to participate in the review process."
+msgstr ""
+
+#: ../../submitting.md:12 9eb67b83630b41558fdab6b507408a07
+msgid ""
+"Your paper must not focus on new research results accomplished with the "
+"software."
+msgstr ""
+
+#: ../../submitting.md:13 7a7b9c123a364cec93888316cee67854
+msgid ""
+"Your paper (`paper.md` and BibTeX files, plus any figures) must be hosted"
+" in a Git-based repository together with your software."
+msgstr ""
+
+#: ../../submitting.md:14 1966b52d0e7942228fe11f836d43911e
+msgid ""
+"The paper may be in a short-lived branch which is never merged with the "
+"default, although if you do this, make sure this branch is _created_ from"
+" the default so that it also includes the source code of your submission."
+msgstr ""
+
+#: ../../submitting.md:16 4522f942cd214907949aae02b4c51bb0
+msgid "In addition, the software associated with your submission must:"
+msgstr ""
+
+#: ../../submitting.md:18 7f9d57e5b3f941b496a57903370962f1
+msgid "Be stored in a repository that can be cloned without registration."
+msgstr ""
+
+#: ../../submitting.md:19 195c2e675de44629a06315c28b1c3942
+msgid "Be stored in a repository that is browsable online without registration."
+msgstr ""
+
+#: ../../submitting.md:20 92aafa33002e4bab93d1636798edac83
+msgid "Have an issue tracker that is readable without registration."
+msgstr ""
+
+#: ../../submitting.md:21 481c9906fc414102850fd47d4387a1d5
+msgid "Permit individuals to create issues/file tickets against your repository."
+msgstr ""
+
+#: ../../submitting.md:23 30106fab445b4df49a92acc026401e20
+msgid "What we mean by research software"
+msgstr ""
+
+#: ../../submitting.md:25 c90e60057d834a2494df62e9d7687a23
+msgid ""
+"JOSS publishes articles about research software. This definition includes"
+" software that: solves complex modeling problems in a scientific context "
+"(physics, mathematics, biology, medicine, social science, neuroscience, "
+"engineering); supports the functioning of research instruments or the "
+"execution of research experiments; extracts knowledge from large data "
+"sets; offers a mathematical library, or similar. While useful for many "
+"areas of research, pre-trained machine learning models and notebooks are "
+"not in-scope for JOSS."
+msgstr ""
+
+#: ../../submitting.md:27 ae9ca5bd94884dd8bd0327ed4cbfcee9
+msgid "Substantial scholarly effort"
+msgstr ""
+
+#: ../../submitting.md:29 4df6f96e766b4979b64a65dd02ee1d04
+msgid ""
+"JOSS publishes articles about software that represent substantial "
+"scholarly effort on the part of the authors. Your software should be a "
+"significant contribution to the available open source software that "
+"either enables some new research challenges to be addressed or makes "
+"addressing research challenges significantly better (e.g., faster, "
+"easier, simpler)."
+msgstr ""
+
+#: ../../submitting.md:31 6e18cc918f19432faf5ccbedff57edfb
+msgid ""
+"As a rule of thumb, JOSS' minimum allowable contribution should represent"
+" **not less than** three months of work for an individual. Some factors "
+"that may be considered by editors and reviewers when judging effort "
+"include:"
+msgstr ""
+
+#: ../../submitting.md:33 9b107a1e586d4d9bb3435aa25c7b078a
+msgid ""
+"Age of software (is this a well-established software project) / length of"
+" commit history."
+msgstr ""
+
+#: ../../submitting.md:34 7ec26d3e19fa408a813b80a864297808
+msgid "Number of commits."
+msgstr ""
+
+#: ../../submitting.md:35 44355accc3ff464d88a9b0993cf9fad2
+msgid "Number of authors."
+msgstr ""
+
+#: ../../submitting.md:36 5a295caed8b0403ca4c94f914ab90722
+msgid ""
+"Total lines of code (LOC). Submissions under 1000 LOC will usually be "
+"flagged, those under 300 LOC will be desk rejected."
+msgstr ""
+
+#: ../../submitting.md:37 8da115eebe0147d1810885380da53882
+msgid "Whether the software has already been cited in academic papers."
+msgstr ""
+
+#: ../../submitting.md:38 3c7ffb04490d4e70b2deede95f59a3ea
+msgid ""
+"Whether the software is sufficiently useful that it is _likely to be "
+"cited_ by your peer group."
+msgstr ""
+
+#: ../../submitting.md:40 ca3f0849aa9c49a7827756a6b0279698
+msgid ""
+"In addition, JOSS requires that software should be feature-complete "
+"(i.e., no half-baked solutions), packaged appropriately according to "
+"common community standards for the programming language being used (e.g.,"
+" [Python](https://packaging.python.org), "
+"[R](https://r-pkgs.org/index.html)), and designed for maintainable "
+"extension (not one-off modifications of existing tools). \"Minor "
+"utility\" packages, including \"thin\" API clients, and single-function "
+"packages are not acceptable."
+msgstr ""
+
+#: ../../submitting.md:42 05900ce680f74068b3d2b2234e835913
+msgid "A note on web-based software"
+msgstr ""
+
+#: ../../submitting.md:44 0fa3a80b5753418eb40586ad94d41213
+#, python-format
+msgid ""
+"Many web-based research tools are out of scope for JOSS due to a lack of "
+"modularity and challenges testing and maintaining the code. Web-based "
+"tools may be considered 'in scope' for JOSS, provided that they meet one "
+"or both of the following criteria: 1) they are are built around and "
+"expose a 'core library' through a web-based experience (e.g., "
+"R/[Shiny](https://www.rstudio.com/products/shiny/) applications) or 2) "
+"the web application demonstrates a high-level of rigor with respect to "
+"domain modeling and testing (e.g., adopts and implements a design pattern"
+" such as "
+"[MVC](https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93controller)"
+" using a framework such as [Django](https://www.djangoproject.com/))."
+msgstr ""
+
+#: ../../submitting.md:46 a7a177222c5a4338af4683c9e830e978
+msgid ""
+"Similar to other categories of submission to JOSS, it's essential that "
+"any web-based tool can be tested easily by reviewers locally (i.e., on "
+"their local machine)."
+msgstr ""
+
+#: ../../submitting.md:48 e062985b56ee4940a02dafc8d0110f03
+msgid "Co-publication of science, methods, and software"
+msgstr ""
+
+#: ../../submitting.md:50 7463266f25d24104b732b5cc847b5739
+msgid ""
+"Sometimes authors prepare a JOSS publication alongside a contribution "
+"describing a science application, details of algorithm development, "
+"and/or methods assessment. In this circumstance, JOSS considers "
+"submissions for which the implementation of the software itself reflects "
+"a substantial scientific effort. This may be represented by the design of"
+" the software, the implementation of the algorithms, creation of "
+"tutorials, or any other aspect of the software. We ask that authors "
+"indicate whether related publications (published, in review, or nearing "
+"submission) exist as part of submitting to JOSS."
+msgstr ""
+
+#: ../../submitting.md:52 980ec3e752254675a5fcbba6fe1d427f
+msgid "Other venues for reviewing and publishing software packages"
+msgstr ""
+
+#: ../../submitting.md:54 885a143d4e9e4b068ccc4368d41e1fc0
+msgid ""
+"Authors wishing to publish software deemed out of scope for JOSS have a "
+"few options available to them:"
+msgstr ""
+
+#: ../../submitting.md:56 43ba4588359841f0933b8f80396d0a3d
+msgid ""
+"Follow [GitHub's guide](https://guides.github.com/activities/citable-"
+"code/) on how to create a permanent archive and DOI for your software. "
+"This DOI can then be used by others to cite your work."
+msgstr ""
+
+#: ../../submitting.md:57 0c1921b7858540afbed5f145221c4e4c
+msgid ""
+"Enquire whether your software might be considered by communities such as "
+"[rOpenSci](https://ropensci.org) and [pyOpenSci](https://pyopensci.org)."
+msgstr ""
+
+#: ../../submitting.md:59 4201ae50bb354bcabc952a4933fbaffd
+msgid "Should I write my own software or contribute to an existing package?"
+msgstr ""
+
+#: ../../submitting.md:61 c295535022b642cfb470639de383178a
+msgid ""
+"While we are happy to review submissions in standalone repositories, we "
+"also review submissions that are significant contributions made to "
+"existing packages. It is often better to have an integrated library or "
+"package of methods than a large number of single-method packages."
+msgstr ""
+
+#: ../../submitting.md:63 0201c8f9c91d490ab4e4f5574774e250
+msgid "Policies"
+msgstr ""
+
+#: ../../submitting.md:65 aa37ca3febd7418cb10d12b2b82ea741
+msgid ""
+"**Disclosure:** All authors must disclose any potential conflicts of "
+"interest related to the research in their manuscript, including "
+"financial, personal, or professional relationships that may affect their "
+"objectivity. This includes any financial relationships, such as "
+"employment, consultancies, honoraria, stock ownership, or other financial"
+" interests that may be relevant to the research."
+msgstr ""
+
+#: ../../submitting.md:67 7da66e89310a4a368f5e5d13db4598c4
+msgid ""
+"**Acknowledgement:** Authors should acknowledge all sources of financial "
+"support for the work and include a statement indicating whether or not "
+"the sponsor had any involvement in it."
+msgstr ""
+
+#: ../../submitting.md:69 676858145ce44bd88f2d1acc8e00303e
+msgid ""
+"**Review process:** Editors and reviewers must be informed of any "
+"potential conflicts of interest before reviewing the manuscript to ensure"
+" unbiased evaluation of the research."
+msgstr ""
+
+#: ../../submitting.md:71 e17ce766ddf54a99a34152e02f590de6
+msgid ""
+"**Compliance:** Authors who fail to comply with the COI policy may have "
+"their manuscript rejected or retracted if a conflict is discovered after "
+"publication."
+msgstr ""
+
+#: ../../submitting.md:73 f082af420013469ea87e5e47602ede5b
+msgid ""
+"**Review and Update:** This COI policy will be reviewed and updated "
+"regularly to ensure it remains relevant and effective."
+msgstr ""
+
+#: ../../submitting.md:75 1b6123be3aa9458ca1abe472bfc6a73a
+msgid "Conflict of Interest policy for authors"
+msgstr ""
+
+#: ../../submitting.md:77 dfe5a74b60e840fab111d4a239be2092
+msgid ""
+"An author conflict of interest (COI) arises when an author has financial,"
+" personal, or other interests that may influence their research or the "
+"interpretation of its results. In order to maintain the integrity of the "
+"work published in JOSS, we require that authors disclose any potential "
+"conflicts of interest at submission time."
+msgstr ""
+
+#: ../../submitting.md:79 eae21d8642ae4e06893e671d7e50b8a8
+msgid "Preprint Policy"
+msgstr ""
+
+#: ../../submitting.md:81 d34627f972a0467195f060a48e97035f
+msgid ""
+"Authors are welcome to submit their papers to a preprint server "
+"([arXiv](https://arxiv.org/), [bioRxiv](https://www.biorxiv.org/), "
+"[SocArXiv](https://socopen.org/), [PsyArXiv](https://psyarxiv.com/) etc.)"
+" at any point before, during, or after the submission and review process."
+msgstr ""
+
+#: ../../submitting.md:83 d7139daf4aee486cb97d6ce667ee7f03
+msgid ""
+"Submission to a preprint server is _not_ considered a previous "
+"publication."
+msgstr ""
+
+#: ../../submitting.md:85 dd31368d70844c2ba70ddf4e0fc3aa1b
+msgid "Authorship"
+msgstr ""
+
+#: ../../submitting.md:87 080b12bc710e4465b136748026764e6b
+msgid ""
+"Purely financial (such as being named on an award) and organizational "
+"(such as general supervision of a research group) contributions are not "
+"considered sufficient for co-authorship of JOSS submissions, but active "
+"project direction and other forms of non-code contributions are. The "
+"authors themselves assume responsibility for deciding who should be "
+"credited with co-authorship, and co-authors must always agree to be "
+"listed. In addition, co-authors agree to be accountable for all aspects "
+"of the work, and to notify JOSS if any retraction or correction of "
+"mistakes are needed after publication."
+msgstr ""
+
+#: ../../submitting.md:89 155e841452dc4a03a996f9cad264c0fe
+msgid "Submissions using proprietary languages/development environments"
+msgstr ""
+
+#: ../../submitting.md:91 2da8c3a5108b445886c4fd0fa14f1706
+msgid ""
+"We strongly prefer software that doesn't rely upon proprietary (paid for)"
+" development environments/programming languages. However, provided _your "
+"submission meets our requirements_ (including having a valid open source "
+"license) then we will consider your submission for review. Should your "
+"submission be accepted for review, we may ask you, the submitting author,"
+" to help us find reviewers who already have the required development "
+"environment installed."
+msgstr ""
+
+#: ../../submitting.md:93 3a154b0142da47ef977734c5cae46c2f
+msgid "Submission Process"
+msgstr ""
+
+#: ../../submitting.md:95 aedcc91a3841485683a22414ecccae2f
+msgid "Before you submit, you should:"
+msgstr ""
+
+#: ../../submitting.md:97 5ec969a179bb454c8c059c7ba7e35f1b
+msgid ""
+"Make your software available in an open repository (GitHub, Bitbucket, "
+"etc.) and include an [OSI approved open source "
+"license](https://opensource.org/licenses)."
+msgstr ""
+
+#: ../../submitting.md:98 9f5479a2846e4f2dada98e900de5d858
+msgid ""
+"Make sure that the software complies with the [JOSS review "
+"criteria](review_criteria). In particular, your software should be full-"
+"featured, well-documented, and contain procedures (such as automated "
+"tests) for checking correctness."
+msgstr ""
+
+#: ../../submitting.md:99 b18084fdb5764ba38ab6bfb4f7829dd9
+msgid ""
+"Write a short paper in Markdown format using `paper.md` as file name, "
+"including a title, summary, author names, affiliations, and key "
+"references. See our [example paper](example_paper) to follow the correct "
+"format."
+msgstr ""
+
+#: ../../submitting.md:100 f91d9e13cd814e0e9aceb3888e5ee21d
+msgid ""
+"(Optional) create a metadata file describing your software and include it"
+" in your repository. We provide [a "
+"script](https://gist.github.com/arfon/478b2ed49e11f984d6fb) that "
+"automates the generation of this metadata."
+msgstr ""
+
+#: ../../submitting.md:102 a075ecd3fbca4896b053977cb2c441fa
+msgid "Submitting your paper"
+msgstr ""
+
+#: ../../submitting.md:104 7129a25f2dfb445da6465a68a9d5cb73
+msgid "Submission is as simple as:"
+msgstr ""
+
+#: ../../submitting.md:106 7616900c2ae54bf1aa3d7266b05129ff
+msgid "Filling in the [short submission form](http://joss.theoj.org/papers/new)"
+msgstr ""
+
+#: ../../submitting.md:107 a99c4e5802ea4f85bc8826256000daf1
+msgid ""
+"Waiting for the managing editor to start a pre-review issue over in the "
+"JOSS reviews repository: https://github.com/openjournals/joss-reviews"
+msgstr ""
+
+#: ../../submitting.md:109 3586343bfb9d4d36b0500ffbe6476716
+msgid "No submission fees"
+msgstr ""
+
+#: ../../submitting.md:111 fa914426586e4013a9774d2a273fa493
+msgid ""
+"There are no fees for submitting or publishing in JOSS. You can read more"
+" about our [cost and sustainability "
+"model](http://joss.theoj.org/about#costs)."
+msgstr ""
+
+#: ../../submitting.md:113 1890cf9ebb07463d855f2321ef97a341
+msgid "Review Process"
+msgstr ""
+
+#: ../../submitting.md:115 fad65e22fa3d4763a8364dc654735ed6
+msgid "After submission:"
+msgstr ""
+
+#: ../../submitting.md:117 7ef0f9d383394a039c02d02bccb37d7e
+msgid ""
+"An Associate Editor-in-Chief will carry out an initial check of your "
+"submission, and proceed to assign a handling editor."
+msgstr ""
+
+#: ../../submitting.md:118 b69093aef0544b7d986ab71eed8ecaf9
+msgid ""
+"The handling editor will assign two or more JOSS reviewers, and the "
+"review will be carried out in the [JOSS reviews "
+"repository](https://github.com/openjournals/joss-reviews)."
+msgstr ""
+
+#: ../../submitting.md:119 a124181eeaf14a21b56ee720011fcd6d
+msgid ""
+"Authors will respond to reviewer-raised issues (if any are raised) on the"
+" submission repository's issue tracker. Reviewer and editor "
+"contributions, like any other contributions, should be acknowledged in "
+"the repository."
+msgstr ""
+
+#: ../../submitting.md:120 42ce72f09737477f9734c8b21f653b97
+msgid ""
+"**JOSS reviews are iterative and conversational in nature.** Reviewers "
+"are encouraged to post comments/questions/suggestions in the review "
+"thread as they arise, and authors are expected to respond in a timely "
+"fashion."
+msgstr ""
+
+#: ../../submitting.md:121 ee84f73437f44e5b84c8d81a97a6fd18
+msgid ""
+"Authors and reviewers are asked to be patient when waiting for a response"
+" from an editor. Please allow a week for an editor to respond to a "
+"question before prompting them for further action."
+msgstr ""
+
+#: ../../submitting.md:122 5c004698eab4486798f76d010ab7555d
+msgid ""
+"Upon successful completion of the review, authors will make a tagged "
+"release of the software, and deposit a copy of the repository with a "
+"data-archiving service such as [Zenodo](https://zenodo.org/) or "
+"[figshare](https://figshare.com/), get a DOI for the archive, and update "
+"the review issue thread with the version number and DOI."
+msgstr ""
+
+#: ../../submitting.md:123 e9a1850c91664d9d82885b19f94c08c5
+msgid ""
+"After we assign a DOI for your accepted JOSS paper, its metadata is "
+"deposited with CrossRef and listed on the JOSS website."
+msgstr ""
+
+#: ../../submitting.md:124 f4726f1773f44fd5beed4c2e8d04a5ca
+msgid ""
+"The review issue will be closed, and automatic posts from [@JOSS_TheOJ at"
+" Twitter](https://twitter.com/JOSS_TheOJ) and [@JOSS at "
+"Mastodon](https://fosstodon.org/@joss) will announce it!"
+msgstr ""
+
+#: ../../submitting.md:126 ac2cccc96054481e9da17a5f7ab487a5
+msgid ""
+"If you want to learn more details about the review process, take a look "
+"at the [reviewer guidelines](reviewer_guidelines)."
+msgstr ""
+
+#: ../../submitting.md:128 918c5067728d42d0a81dbe095682832a
+msgid "Confidential requests"
+msgstr ""
+
+#: ../../submitting.md:130 04fed9904c5d40b4a5cf50ab9f708a60
+msgid ""
+"Please write admin@theoj.org with confidential matters such as retraction"
+" requests, report of misconduct, and retroactive author name changes."
+msgstr ""
+
+#: ../../submitting.md:132 c57a3a1aee824bd98b028fa7d25c43e9
+msgid ""
+"In the event of a name change request, the DOI will remain unchanged, and"
+" the paper will be updated without the publication of a correction "
+"notice. Please note that because JOSS submissions are managed publicly, "
+"updates to papers are visible in the public record (e.g., in the [JOSS "
+"papers repository](https://github.com/openjournals/joss-papers) commit "
+"history)."
+msgstr ""
+
+#: ../../submitting.md:134 d4ed5f2a5fe842b191c5708f33bf7e89
+msgid "JOSS will also update Crossref metadata."
+msgstr ""
+

--- a/docs/locale/pl/LC_MESSAGES/translating.po
+++ b/docs/locale/pl/LC_MESSAGES/translating.po
@@ -1,0 +1,125 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 13:00-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: pl\n"
+"Language-Team: pl <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../translating.md:1 dc0404984ec141be90f2c0ab0b08952e
+msgid "Contributing to Translation"
+msgstr ""
+
+#: ../../translating.md:3 436d651294454374ad5e679c4d227a60
+msgid ""
+"These docs and the main journal website welcome corrections or "
+"translations into additional languages."
+msgstr ""
+
+#: ../../translating.md:6 61edeeb8b3d4438a88d83dcbbf9a28f6
+msgid ""
+"Both are available in the same repository "
+"[openjournals/joss](https://github.com/openjournals/joss) with slightly "
+"different contributor workflows:"
+msgstr ""
+
+#: ../../translating.md:9 646240381af84c869dd9dcfd5910e4d3
+msgid "Python Docs"
+msgstr ""
+
+#: ../../translating.md:11 1bc1a234c2da449a90e5f6d7d1da7bfa
+msgid ""
+"The documents in the `docs` directory (this site) are built with `sphinx`"
+" and internationalized with `sphinx-intl`. These translations use "
+"standard `gettext`-style `.pot` and `.po` files."
+msgstr ""
+
+#: ../../translating.md:15 67377f2b156543c193d7089c35864d73
+msgid ""
+"The `.pot` files are generated from the source pages on each update and "
+"not versioned, and the translations are contained within `.po` files in "
+"the `locale` directory. A CI action ensures that any change to the "
+"english source text is reflected in the generated `.po` files."
+msgstr ""
+
+#: ../../translating.md:20 a71c1369388a4a9fa5f4359e8bcd71c9
+msgid "Adding a new language"
+msgstr ""
+
+#: ../../translating.md:22 b2f7d9c4ff87411a98ce8c5ea6aba22d
+msgid ""
+"Install the requirements, ideally in a virtual environment:  `python -m "
+"pip install -r requirements.txt`"
+msgstr ""
+
+#: ../../translating.md:24 6ec9f8d4512648af8911082fab6e2d3e
+msgid ""
+"Add a new "
+"[ISO-639](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes) "
+"code to the `languages` list in `conf.py`"
+msgstr ""
+
+#: ../../translating.md:26 1e4917f5f5df46ca84277ea8969c87d5
+msgid ""
+"Run `make i18n` (which just calls `update_i18n.py`) to generate the `.po`"
+" files"
+msgstr ""
+
+#: ../../translating.md:27 609caf2c695e4f9599080559bb527f57
+msgid ""
+"Open a PR with the empty `.po` files - the maintainers of the site will "
+"have to add the new language as a [readthedocs "
+"project](https://docs.readthedocs.io/en/stable/localization.html"
+"#projects-with-multiple-translations), so this early PR gives them time "
+"to get that ready by the time the translation is relatively complete"
+msgstr ""
+
+#: ../../translating.md:30 17bcfc9e6a5d467484b9bf6298ae6cb1
+msgid "Work on the translations in the `.po` files!"
+msgstr ""
+
+#: ../../translating.md:32 48c06b282fec40638c03fa2746b75734
+msgid "Translating"
+msgstr ""
+
+#: ../../translating.md:34 a1b5330df5c4410f851a8f295c0b8034
+msgid ""
+"You can run the `sphinx-intl stat` command to get a sense of what files "
+"need the most work:"
+msgstr ""
+
+#: ../../translating.md:37 77325337d66047aa995749393e3bbae9
+msgid "From `docs`:"
+msgstr ""
+
+#: ../../translating.md:59 7cd4308945884faea16c3fa9d1dd6d56
+msgid ""
+"See the [pyopensci `TRANSLATING.md` guide in the `python-package-"
+"guide`](https://github.com/pyOpenSci/python-package-"
+"guide/blob/main/TRANSLATING.md) for further instructions!"
+msgstr ""
+
+#: ../../translating.md:62 fac172f90d63435cbf1dd8ff06adecb0
+msgid ""
+"After you are finished, run `make i18n` again to reformat your strings to"
+" fit the standard style that the CI will check for."
+msgstr ""
+
+#: ../../translating.md:65 1ad35b647a5845208e9d30cbe5168562
+msgid "JOSS Website"
+msgstr ""
+

--- a/docs/locale/pl/LC_MESSAGES/venv.po
+++ b/docs/locale/pl/LC_MESSAGES/venv.po
@@ -1,0 +1,904 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Open Journals
+# This file is distributed under the same license as the JOSS package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: JOSS \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-26 12:44-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: pl\n"
+"Language-Team: pl <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../venv/lib/python3.11/site-packages/MarkupSafe-2.1.5.dist-info/LICENSE.rst:1
+#: 4b04f57e9705450b9306605acd594245
+msgid "Copyright 2010 Pallets"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/MarkupSafe-2.1.5.dist-info/LICENSE.rst:3
+#: ../../venv/lib/python3.11/site-packages/click-8.1.7.dist-info/LICENSE.rst:3
+#: ../../venv/lib/python3.11/site-packages/idna-3.8.dist-info/LICENSE.md:6
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:10
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:44
+#: 1c4ecad3a0424d278d60922719a1bd17 52fbaf4189b2418891a406cc66dfea0b
+#: bfb06a8d236443628369f31abfe6c5a5 c44159ded9ac490fbf34569fb4b5e505
+#: dc0fa4a1b4994b5990003a4f8be3018e
+msgid ""
+"Redistribution and use in source and binary forms, with or without "
+"modification, are permitted provided that the following conditions are "
+"met:"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/MarkupSafe-2.1.5.dist-info/LICENSE.rst:7
+#: ../../venv/lib/python3.11/site-packages/alabaster-0.7.16.dist-info/LICENSE.rst:12
+#: ../../venv/lib/python3.11/site-packages/click-8.1.7.dist-info/LICENSE.rst:7
+#: ../../venv/lib/python3.11/site-packages/idna-3.8.dist-info/LICENSE.md:10
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:14
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:48
+#: 0a8e3445bb9045aaa841f636280c29e9 50113402d53346e8b923c2791161f01e
+#: 6d0e378e76a44454a0b8e54e701b4696 99979e2633bb42d6a30709742d964325
+#: f0f15fee79ed4b40ae793c9a39b91bf0 fa525a2654e74ef38a3627c05034bffe
+msgid ""
+"Redistributions of source code must retain the above copyright notice, "
+"this list of conditions and the following disclaimer."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/MarkupSafe-2.1.5.dist-info/LICENSE.rst:10
+#: ../../venv/lib/python3.11/site-packages/alabaster-0.7.16.dist-info/LICENSE.rst:15
+#: ../../venv/lib/python3.11/site-packages/click-8.1.7.dist-info/LICENSE.rst:10
+#: ../../venv/lib/python3.11/site-packages/idna-3.8.dist-info/LICENSE.md:13
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:17
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:50
+#: 0031803d4c2d4c2ca18f449baefa0288 02124d671c794341906e400a07da7441
+#: 09b72535bd7a4abca7204af33a35ec0d 224b40621fba4ad5b474748d7844882b
+#: 9dc8f8e5362441f29805a535a6c346be c62e1ce755f84d55aa0895f42813eceb
+msgid ""
+"Redistributions in binary form must reproduce the above copyright notice,"
+" this list of conditions and the following disclaimer in the "
+"documentation and/or other materials provided with the distribution."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/MarkupSafe-2.1.5.dist-info/LICENSE.rst:14
+#: ../../venv/lib/python3.11/site-packages/click-8.1.7.dist-info/LICENSE.rst:14
+#: ../../venv/lib/python3.11/site-packages/idna-3.8.dist-info/LICENSE.md:17
+#: 4de8e3ea9944403e868dfe5117f95570 a7e7f1a47d64472998a37ca0df813f2c
+#: ba2cd4afb9e140dc90a0fed6a5642677
+msgid ""
+"Neither the name of the copyright holder nor the names of its "
+"contributors may be used to endorse or promote products derived from this"
+" software without specific prior written permission."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/MarkupSafe-2.1.5.dist-info/LICENSE.rst:18
+#: ../../venv/lib/python3.11/site-packages/click-8.1.7.dist-info/LICENSE.rst:18
+#: ../../venv/lib/python3.11/site-packages/idna-3.8.dist-info/LICENSE.md:21
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:21
+#: 714609d72fe247c8ad7729ac1f599b1f b8eacd94e15b4a6199fe0065a84e1cc7
+#: c3270b0b2f504737aef0391ae710c590 f0f3f4fb89af44b08e1db0d4d9e3c2e8
+msgid ""
+"THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS "
+"IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED "
+"TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A "
+"PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER"
+" OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,"
+" EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, "
+"PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR "
+"PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF "
+"LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING "
+"NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS "
+"SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/alabaster-0.7.16.dist-info/LICENSE.rst:1
+#: dfcb151fc3914bdd8ec2a51b56633fbf
+msgid "Copyright (c) 2020 Jeff Forcier."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/alabaster-0.7.16.dist-info/LICENSE.rst:3
+#: bef43b50d4ac4d0d8a49beddecaad047
+msgid ""
+"Based on original work copyright (c) 2011 Kenneth Reitz and copyright (c)"
+" 2010 Armin Ronacher."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/alabaster-0.7.16.dist-info/LICENSE.rst:6
+#: 565f5758f467498abf005b476600b18a
+msgid "Some rights reserved."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/alabaster-0.7.16.dist-info/LICENSE.rst:8
+#: 5c13cb064db14e03b7874927cb3567a2
+msgid ""
+"Redistribution and use in source and binary forms of the theme, with or "
+"without modification, are permitted provided that the following "
+"conditions are met:"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/alabaster-0.7.16.dist-info/LICENSE.rst:20
+#: a0cc506593fb41bdb6af104b963f3a1a
+msgid ""
+"The names of the contributors may not be used to endorse or promote "
+"products derived from this software without specific prior written "
+"permission."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/alabaster-0.7.16.dist-info/LICENSE.rst:24
+#: c75de0dede354a8ba06bcf63b2049444
+msgid ""
+"THIS THEME IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS "
+"IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED "
+"TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A "
+"PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER "
+"OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, "
+"EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, "
+"PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR "
+"PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF "
+"LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING "
+"NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS THEME,"
+" EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/click-8.1.7.dist-info/LICENSE.rst:1
+#: 77270f4e7f2a4a4da5fe29bfaa4a3688
+msgid "Copyright 2014 Pallets"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/idna-3.8.dist-info/LICENSE.md:1
+#: 12a5eef7249e48d5a9d9ad59ccf233af
+msgid "BSD 3-Clause License"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/idna-3.8.dist-info/LICENSE.md:3
+#: de0055e0f911416fa5f584514d6240ba
+msgid "Copyright (c) 2013-2024, Kim Davies and contributors. All rights reserved."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/imagesize-1.4.1.dist-info/LICENSE.rst:2
+#: 6dd5458610ed4e9cba29810165da96ce
+msgid "The MIT License (MIT)"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/imagesize-1.4.1.dist-info/LICENSE.rst:4
+#: 9f00b96eb75f4a049843504e6bd8eb4a
+msgid "Copyright © 2016 Yoshiki Shibukawa"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/imagesize-1.4.1.dist-info/LICENSE.rst:6
+#: 1852768a207148e8a640eb1acc076ab7
+msgid ""
+"Permission is hereby granted, free of charge, to any person obtaining a "
+"copy of this software and associated documentation files (the "
+"“Software”), to deal in the Software without restriction, including "
+"without limitation the rights to use, copy, modify, merge, publish, "
+"distribute, sublicense, and/or sell copies of the Software, and to permit"
+" persons to whom the Software is furnished to do so, subject to the "
+"following conditions:"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/imagesize-1.4.1.dist-info/LICENSE.rst:12
+#: c58be8ee3c8f473f813bde5daeafa536
+msgid ""
+"The above copyright notice and this permission notice shall be included "
+"in all copies or substantial portions of the Software."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/imagesize-1.4.1.dist-info/LICENSE.rst:15
+#: bcc0103fc9e548e89f1d6b5bc7c98b31
+msgid ""
+"THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS "
+"OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF "
+"MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN"
+" NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,"
+" DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR "
+"OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE"
+" USE OR OTHER DEALINGS IN THE SOFTWARE."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:1
+#: e49e03c1886844259db71a8b0da9789b
+msgid "markdown-it-container"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:3
+#: a88b013cb1a14120b1d5a9ecea4ce9e8
+msgid ""
+"[![Build Status](https://img.shields.io/travis/markdown-it/markdown-it-"
+"container/master.svg?style=flat)](https://travis-ci.org/markdown-it"
+"/markdown-it-container) [![NPM version](https://img.shields.io/npm/v"
+"/markdown-it-container.svg?style=flat)](https://www.npmjs.org/package"
+"/markdown-it-container) [![Coverage "
+"Status](https://img.shields.io/coveralls/markdown-it/markdown-it-"
+"container/master.svg?style=flat)](https://coveralls.io/r/markdown-it"
+"/markdown-it-container?branch=master)"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:3
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:3
+#: 643fb1c2331c444d9eebcd59b0d84541 cbb138ffd079476e9fe9d321fc8140c3
+msgid "Build Status"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:3
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:3
+#: 445043497ac446d5b5d8faaae13e055c fb3a1e66cb544d44a6830d3373fee4b1
+msgid "NPM version"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:3
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:3
+#: 675a06e31cd54cb4af1320b991125f4a 72f10afff03e4b4794fd68d69afcd9d2
+msgid "Coverage Status"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:7
+#: 8be808a359e54b2492064927350fba55
+msgid ""
+"Plugin for creating block-level custom containers for [markdown-"
+"it](https://github.com/markdown-it/markdown-it) markdown parser."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:9
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:9
+#: 631b149484d24e069016c7c1532d2d2a b767f0ca917a44de82f46da9e24e96e0
+msgid "__v2.+ requires `markdown-it` v5.+, see changelog.__"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:11
+#: 223eb6d266f64663862ff0cdef64a2d6
+msgid "With this plugin you can create block containers like:"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:19
+#: 140f37968c6544cab5bdbfb02d68faaf
+msgid ""
+".... and specify how they should be rendered. If no renderer defined, "
+"`<div>` with container name class will be created:"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:28
+#: 60fd44e6161d42c597c5cc42d2eed050
+msgid ""
+"Markup is the same as for [fenced code "
+"blocks](http://spec.commonmark.org/0.18/#fenced-code-blocks). Difference "
+"is, that marker use another character and content is rendered as markdown"
+" markup."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:32
+#: 1ceac555acc142ee8eeacaefafaa3f59
+msgid "Installation"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:34
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:16
+#: 86896043684e479dbd1adef4bcac2d7d b8e71f9c76714680aeb2932862327ceb
+msgid "node.js, browser:"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:42
+#: 7b65b1f4c2724172bb8c7b295b2e4020
+msgid "API"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:49
+#: e5471c7e42184b81b02e665a8a581796
+msgid "Params:"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:51
+#: 4e3326221502434b86c72ef95b41eb1c
+msgid "__name__ - container name (mandatory)"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:52
+#: 8ed63f922bec4da6b4f8bf2c4f25744f
+msgid "__options:__"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:53
+#: 8ae43dd5876a4aa6b280d2c4a1136da5
+msgid ""
+"__validate__ - optional, function to validate tail after opening marker, "
+"should return `true` on success."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:55
+#: 92c1d59d17d54ababefbb54659ad6e55
+msgid "__render__ - optional, renderer function for opening/closing tokens."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:56
+#: dc129b03265c4b358f333b46c657e072
+msgid "__marker__ - optional (`:`), character to use in delimiter."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:59
+#: bdf4b7ccb1674f76b933dec24378a70b
+msgid "Example"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:93
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:36
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:1
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:133
+#: 267559600a324daf8006b181564ce566 a79d787bc551494d9ca6a05f14b8e305
+#: df86e1c582764592b97e877a242c6754 e734876cb52e46e7b6a3bac331c58bda
+msgid "License"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/container/README.md:95
+#: 0869b2da52404f49aa98f1bd9f537651
+msgid ""
+"[MIT](https://github.com/markdown-it/markdown-it-"
+"container/blob/master/LICENSE)"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:1
+#: cc74ddf7f726442a85770d6a72aeb251
+msgid "markdown-it-deflist"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:3
+#: 31b33cfff4184aaf9f43a3e90efe371d
+msgid ""
+"[![Build Status](https://img.shields.io/travis/markdown-it/markdown-it-"
+"deflist/master.svg?style=flat)](https://travis-ci.org/markdown-it"
+"/markdown-it-deflist) [![NPM version](https://img.shields.io/npm/v"
+"/markdown-it-deflist.svg?style=flat)](https://www.npmjs.org/package"
+"/markdown-it-deflist) [![Coverage "
+"Status](https://img.shields.io/coveralls/markdown-it/markdown-it-"
+"deflist/master.svg?style=flat)](https://coveralls.io/r/markdown-it"
+"/markdown-it-deflist?branch=master)"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:7
+#: 7d21759f971b4214afcfa828d381248f
+msgid ""
+"Definition list (`<dl>`) tag plugin for [markdown-it](https://github.com"
+"/markdown-it/markdown-it) markdown parser."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:11
+#: 987f97e09dc54604953d756f606dcb80
+msgid ""
+"Syntax is based on [pandoc definition "
+"lists](http://johnmacfarlane.net/pandoc/README.html#definition-lists)."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:14
+#: ed30c3a0e7ac4ac8bb5bc6b3ef717acc
+msgid "Install"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:23
+#: 5b56c9e9862040c4a3021651b5d92687
+msgid "Use"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:32
+#: 32291d893f79454e80caa070b39edd1d
+msgid ""
+"_Differences in browser._ If you load script directly into the page, "
+"without package system, module will add itself globally as "
+"`window.markdownitDeflist`."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/deflist/README.md:38
+#: 41fce509e63049ac8424e184b06b5109
+msgid ""
+"[MIT](https://github.com/markdown-it/markdown-it-"
+"deflist/blob/master/LICENSE)"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:1
+#: e057db94d78a4d14ad08b3011dfbc477
+msgid ""
+"[![License](https://img.shields.io/github/license/goessner/markdown-it-"
+"texmath.svg)](https://github.com/goessner/markdown-it-"
+"texmath/blob/master/licence.txt) [![npm](https://img.shields.io/npm/v"
+"/markdown-it-texmath.svg)](https://www.npmjs.com/package/markdown-it-"
+"texmath) [![npm](https://img.shields.io/npm/dt/markdown-it-"
+"texmath.svg)](https://www.npmjs.com/package/markdown-it-texmath)"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:1
+#: 74576af3ad9a4ee39bfe44e316de5fb1 c4872ca8b32c4a4790ab0597faf8a8a6
+msgid "npm"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:5
+#: 157e5a3dd0264571916e500b8de44002
+msgid "markdown-it-texmath"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:7
+#: 309e16f425964b159a4ba307590e184f
+msgid ""
+"Add TeX math equations to your Markdown documents rendered by [markdown-"
+"it](https://github.com/markdown-it/markdown-it) parser. "
+"[KaTeX](https://github.com/Khan/KaTeX) is used as a fast math renderer."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:9
+#: f8a4e94757f2422187c6435994cf7371
+msgid "Features"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:10
+#: 4f9f5dd8bf7f4854b4e5638e412ee282
+msgid ""
+"Simplify the process of authoring markdown documents containing math "
+"formulas. This extension is a comfortable tool for scientists, engineers "
+"and students with markdown as their first choice document format."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:13
+#: b0aa32493be546e58e566fc4747d46dd
+msgid "Macro support"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:14
+#: c00e2c3e083f4388bc7037ba1498dd18
+msgid "Simple formula numbering"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:15
+#: 695beb0db9c34573b5938bca9ee90e4f
+msgid "Inline math with tables, lists and blockquote."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:16
+#: be57ab220b7540888023ab3059f71bc7
+msgid "User setting delimiters:"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:17
+#: a30604d94dce451daafcdb5bc890d3ac
+msgid "`'dollars'` (default)"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:18
+#: 6f0461a9f63345c09a4d0178947dbb68
+msgid "inline: `$...$`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:19
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:35
+#: 12142a76d44d4ce5a16c4d5a158a9637 dc1b9cbd2f82487891503c0bafeda846
+msgid "display: `$$...$$`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:20
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:36
+#: 7e3c7d4b5bd54953bbdbd63bc6d7d2b5 f877016f55b7445ba30eabbe42b70592
+msgid "display + equation number: `$$...$$ (1)`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:21
+#: b8672b73a3354b7da686ae497556ff0e
+msgid "`'brackets'`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:22
+#: 75b30e1f2b0b4e3d986b1cd299422178
+msgid "inline: `\\(...\\)`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:23
+#: 1fb03d476a78432fb6df765247a9756d
+msgid "display: `\\[...\\]`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:24
+#: 83ef05ce21aa4e2d85d4d6e6ae9792d0
+msgid "display + equation number: `\\[...\\] (1)`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:25
+#: fe4d88fc08214241881129b5809e626d
+msgid "`'gitlab'`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:26
+#: d3abb6d66da44a79922e6d4e6c591cfe
+msgid "inline: ``$`...`$``"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:27
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:31
+#: 27a059ce708a4188a0bb041a725a3a20 cb0b71fa64334a71ad45ae199735edf8
+msgid "display: `` ```math ... ``` ``"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:28
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:32
+#: 3fde380aaa3945098eb8c7d3f1ca0fee eb7c543e030d4bc8ae1363703dc98995
+msgid "display + equation number: `` ```math ... ``` (1)``"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:29
+#: 17b547696b3a49ffb84ca24d282958c9
+msgid "`'julia'`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:30
+#: a537a5dc24534cb890e59dd3b1812a7e
+msgid "inline: `$...$`  or ``` ``...`` ```"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:33
+#: d36e5471714647f9ab6d1fbb7fa35cae
+msgid "`'kramdown'`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:34
+#: 15f31bf2467f42298aa5f8c26c6e586e
+msgid "inline: ``$$...$$``"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:38
+#: 94fed257197541c0bf7e9f8fb6d18733
+msgid "Show me"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:40
+#: e874f0a1930b4a5b8113d67bbca00bfd
+msgid ""
+"View a [test table](https://goessner.github.io/markdown-it-"
+"texmath/index.html)."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:42
+#: aa9577bc494a4effadf83ecc4027026b
+msgid ""
+"[try it out ...](https://goessner.github.io/markdown-it-texmath/markdown-"
+"it-texmath-demo.html)"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:44
+#: aee8284928ba4f8eb1632e3a2c551fa6
+msgid "Use with `node.js`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:46
+#: bb77829871ba4620b31bed6d2e78816b
+msgid ""
+"Install the extension. Verify having `markdown-it` and `katex` already "
+"installed ."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:50
+#: 23a36619cd544731943d0b39c03abbbf
+msgid "Use it with JavaScript."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:59
+#: 7cc8519d35664f64aecb71811907b28e
+msgid "Use in Browser"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:83
+#: b92a92ced9ef40d8b39e21ad0e8e2c27
+msgid "CDN"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:85
+#: bf5f80a2ccca4fb2930d7aac38f18edc
+msgid "Use following links for `texmath.js` and `texmath.css`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:86
+#: d4a48801bb9f4a3994af4674142e785b
+msgid "`https://gitcdn.xyz/cdn/goessner/markdown-it-texmath/master/texmath.js`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:87
+#: f80a34376a374cca938d70c30c25fb51
+msgid "`https://gitcdn.xyz/cdn/goessner/markdown-it-texmath/master/texmath.css`"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:89
+#: 31a28aa4a3e94a5996ebc74e4193808f
+msgid "Dependencies"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:91
+#: 9848d2d73f914656b6c171d05b7d8bb3
+msgid ""
+"[`markdown-it`](https://github.com/markdown-it/markdown-it): Markdown "
+"parser done right. Fast and easy to extend."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:92
+#: fa7ced3164cb48e49bdd4932a9a4f39d
+msgid ""
+"[`katex`](https://github.com/Khan/KaTeX): This is where credits for fast "
+"rendering TeX math in HTML go to."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:94
+#: 9efc2dd198d6436f94d82e29f6a01ddd
+msgid "ToDo"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:96
+#: 496b6811181140d1b87b046e281ee0c9
+msgid "nothing yet"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:98
+#: 5d717d64ba734c43a58128212dd36e0a
+msgid "FAQ"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:100
+#: 061ba8572ca048d190a69f157744524a
+msgid "__`markdown-it-texmath` with React Native does not work, why ?__"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:101
+#: 77e5944397a7463e9a73036487698715
+msgid ""
+"`markdown-it-texmath` is using regular expressions with `y` [(sticky) "
+"property](https://developer.mozilla.org/en-"
+"US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/sticky) and cannot"
+" avoid this. The use of the `y` flag in regular expressions means the "
+"plugin is not compatible with React Native (which as of now doesn't "
+"support it and throws an error `Invalid flags supplied to RegExp "
+"constructor`)."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:103
+#: cbe91ac47621429e94e3d2b7dd2835e0
+msgid "CHANGELOG"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:105
+#: cf019dffbb1a4b0e86c9d6f3bf053cec
+msgid "[0.6.0] on October 04, 2019"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:106
+#: 05490a0fff214b72ba3e1924fe73ec4f
+msgid ""
+"Add support for [Julia "
+"Markdown](https://docs.julialang.org/en/v1/stdlib/Markdown/) on "
+"[request](https://github.com/goessner/markdown-it-texmath/issues/15)."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:108
+#: 2093987c7b3b411bb5f6247aa287c147
+msgid "[0.5.5] on February 07, 2019"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:109
+#: 5269b5c18ce241d1a255e3ab2c68baef
+msgid ""
+"Remove [rendering bug with brackets "
+"delimiters](https://github.com/goessner/markdown-it-texmath/issues/9)."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:111
+#: 6aaf8d7a4e064bb3b98a5edae720fe8c
+msgid "[0.5.4] on January 20, 2019"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:112
+#: 75fabae3db7343879034b56ae4299a77
+msgid ""
+"Remove pathological [bug within "
+"blockquotes](https://github.com/goessner/mdmath/issues/50)."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:114
+#: 7f4b1fc7dc8045f8988333ff58e8f07c
+msgid "[0.5.3] on November 11, 2018"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:115
+#: b39e4ea4dad641178b78ff31ce51b458
+msgid ""
+"Add support for Tex macros (https://katex.org/docs/supported.html#macros)"
+" ."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:116
+#: 3c4d1c6e691e405a8410a3bf5d567a62
+msgid ""
+"Bug with [brackets delimiters](https://github.com/goessner/markdown-it-"
+"texmath/issues/9) ."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:118
+#: 715aaf957c2f45f68aa18fb6adcecae1
+msgid "[0.5.2] on September 07, 2018"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:119
+#: 1c21dcd8158e4b7380335032f8488823
+msgid "Add support for [Kramdown](https://kramdown.gettalong.org/) ."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:121
+#: 8c40cb3b696d400581aafbffe01a2863
+msgid "[0.5.0] on August 15, 2018"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:122
+#: b0703ac4821f4ec6ab431d8b4ff0c713
+msgid ""
+"Fatal blockquote bug investigated. Implemented workaround to vscode bug, "
+"which has finally gone with vscode 1.26.0 ."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:124
+#: 07f70dde3d0b49d7bf4b46e7b43fc60c
+msgid "[0.4.6] on January 05, 2018"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:125
+#: 2ccc50aeca474fd3ab8fd4414e678598
+msgid "Escaped underscore bug removed."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:127
+#: 59f4f020ddb7424fa3fa5d217b9457b9
+msgid "[0.4.5] on November 06, 2017"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:128
+#: 681997521a854dc4bdc39d2eaa888c34
+msgid "Backslash bug removed."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:130
+#: 531fd1ab52274de3801dc5911ee09ad2
+msgid "[0.4.4] on September 27, 2017"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:131
+#: 31968e82ca544532bec7bc26ef8ed9f9
+msgid ""
+"Modifying the `block` mode regular expression with `gitlab` delimiters, "
+"so removing the `newline` bug."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:135
+#: 52c2b744570047b3b3a075714536978d
+msgid "`markdown-it-texmath` is licensed under the [MIT License](./license.txt)"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/mdit_py_plugins/texmath/README.md:137
+#: 89bc025154c44499bf25fd4a6621ba0d
+msgid "© [Stefan Gössner](https://github.com/goessner)"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:2
+#: e2034c149edf4233ba2d239de2bc5a37
+msgid "License for Sphinx"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:4
+#: 0724495e2bf4464d912bb8b932511a88
+msgid ""
+"Unless otherwise indicated, all code in the Sphinx project is licenced "
+"under the two clause BSD licence below."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:7
+#: a54d7f8a1705480d94cc3228b74332d2
+msgid ""
+"Copyright (c) 2007-2024 by the Sphinx team (see AUTHORS file). All rights"
+" reserved."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:35
+#: ff1b2ef9d7374205ba6c12fddff922ab
+msgid "Licenses for incorporated software"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:37
+#: 1323d5c2d81442e7bf615b20ad8c4d3c
+msgid ""
+"The included implementation of "
+"NumpyDocstring._parse_numpydoc_see_also_section was derived from code "
+"under the following license:"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:42
+#: 4e59393bef704f569239fae16276714f
+msgid ""
+"Copyright (C) 2008 Stefan van der Walt <stefan@mentat.za.net>, Pauli "
+"Virtanen <pav@iki.fi>"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx-7.4.7.dist-info/LICENSE.rst:55
+#: 2608a2347fc24391a73c6841ab66828d
+msgid ""
+"THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR "
+"IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES"
+" OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. "
+"IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, "
+"INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT "
+"NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,"
+" DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY "
+"THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT "
+"(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF "
+"THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx/ext/autosummary/templates/autosummary/base.rst:1
+#: ../../venv/lib/python3.11/site-packages/sphinx/ext/autosummary/templates/autosummary/class.rst:1
+#: ../../venv/lib/python3.11/site-packages/sphinx/ext/autosummary/templates/autosummary/module.rst:1
+#: 0451370ee9314f7c906ab2836764c47a 34eae62f4d5740edb136c49059b2f68a
+#: 9fa2c23ace9742ef857c70bd4efa6475
+msgid "{{ fullname | escape | underline}}"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx/ext/autosummary/templates/autosummary/module.rst:49
+#: 2a32ebb5750d4a979e7eb61b0b2a43d1
+msgid "{%- block modules %} {%- if modules %} .. rubric:: Modules"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx/ext/autosummary/templates/autosummary/module.rst:56
+#: d57cb8ab9dca45e4aea575779c41d097
+#, python-format
+msgid "{% for item in modules %}"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx/ext/autosummary/templates/autosummary/module.rst:57
+#: 7cceed397e184649b97d1c43c3bdf7cc
+msgid "{{ item }}"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx/ext/autosummary/templates/autosummary/module.rst:58
+#: 92d7e04737254ad29257454aef84d60e
+#, python-format
+msgid "{%- endfor %} {% endif %} {%- endblock %}"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx_intl-2.2.0.dist-info/AUTHORS.rst:3
+#: bcacc45f6d95492d8bad5f48f0118261
+msgid "AUTHORS"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx_intl-2.2.0.dist-info/AUTHORS.rst:5
+#: 593ea41c5a514301b5452416e55ede81
+msgid "Takayuki Shimizukawa <https://github.com/shimizukawa>"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx_intl-2.2.0.dist-info/AUTHORS.rst:6
+#: e742c33eb1364000ba767acc24bfa569
+msgid "Takeshi Komiya <https://github.com/tk0miya>"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx_intl-2.2.0.dist-info/AUTHORS.rst:9
+#: 44931f9b8feb4787ab34eb833e84679d
+msgid "Original"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx_intl-2.2.0.dist-info/AUTHORS.rst:11
+#: 9f8934708c8843d08acf1b7ee6f45a3b
+msgid "This utility derived from these projects."
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx_intl-2.2.0.dist-info/AUTHORS.rst:13
+#: 967f61e50bfc436b8f5d6b4bf16d2534
+msgid "https://bitbucket.org/tk0miya/sphinx-gettext-helper"
+msgstr ""
+
+#: ../../venv/lib/python3.11/site-packages/sphinx_intl-2.2.0.dist-info/AUTHORS.rst:14
+#: cdbc970fd030448782c80d668fa88cf6
+msgid "https://bitbucket.org/shimizukawa/sphinx-transifex"
+msgstr ""
+

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ docutils
 linkify-it-py
 sphinx_rtd_theme
 myst-parser
+sphinx-intl

--- a/docs/translating.md
+++ b/docs/translating.md
@@ -1,0 +1,69 @@
+# Contributing to Translation
+
+These docs and the main journal website welcome corrections or translations into
+additional languages.
+
+Both are available in the same repository [openjournals/joss](https://github.com/openjournals/joss)
+with slightly different contributor workflows:
+
+## Python Docs
+
+The documents in the `docs` directory (this site) are built with `sphinx`
+and internationalized with `sphinx-intl`. These translations use standard
+`gettext`-style `.pot` and `.po` files. 
+
+The `.pot` files are generated from the source pages on each update and not versioned,
+and the translations are contained within `.po` files in the `locale` directory.
+A CI action ensures that any change to the english source text is reflected in
+the generated `.po` files.
+
+### Adding a new language
+
+- Install the requirements, ideally in a virtual environment: 
+  `python -m pip install -r requirements.txt`
+- Add a new [ISO-639](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes) code
+  to the `languages` list in `conf.py`
+- Run `make i18n` (which just calls `update_i18n.py`) to generate the `.po` files
+- Open a PR with the empty `.po` files - the maintainers of the site will have to add
+  the new language as a [readthedocs project](https://docs.readthedocs.io/en/stable/localization.html#projects-with-multiple-translations),
+  so this early PR gives them time to get that ready by the time the translation is relatively complete
+- Work on the translations in the `.po` files!
+
+### Translating
+
+You can run the `sphinx-intl stat` command to get a sense of what
+files need the most work:
+
+From `docs`:
+
+```shell
+$ sphinx-intl stat -l es
+locale/es/LC_MESSAGES/sample_messages.po: 0 translated, 0 fuzzy, 8 untranslated.
+locale/es/LC_MESSAGES/review_criteria.po: 0 translated, 0 fuzzy, 61 untranslated.
+locale/es/LC_MESSAGES/editor_onboarding.po: 0 translated, 0 fuzzy, 88 untranslated.
+locale/es/LC_MESSAGES/editor_tips.po: 0 translated, 0 fuzzy, 21 untranslated.
+locale/es/LC_MESSAGES/expectations.po: 0 translated, 0 fuzzy, 24 untranslated.
+locale/es/LC_MESSAGES/installing.po: 0 translated, 0 fuzzy, 73 untranslated.
+locale/es/LC_MESSAGES/policies.po: 0 translated, 0 fuzzy, 9 untranslated.
+locale/es/LC_MESSAGES/example_paper.po: 0 translated, 0 fuzzy, 5 untranslated.
+locale/es/LC_MESSAGES/reviewer_guidelines.po: 0 translated, 0 fuzzy, 13 untranslated.
+locale/es/LC_MESSAGES/editing.po: 0 translated, 0 fuzzy, 134 untranslated.
+locale/es/LC_MESSAGES/index.po: 0 translated, 0 fuzzy, 20 untranslated.
+locale/es/LC_MESSAGES/submitting.po: 0 translated, 0 fuzzy, 80 untranslated.
+locale/es/LC_MESSAGES/paper.po: 0 translated, 0 fuzzy, 150 untranslated.
+locale/es/LC_MESSAGES/venv.po: 0 translated, 0 fuzzy, 136 untranslated.
+locale/es/LC_MESSAGES/review_checklist.po: 0 translated, 0 fuzzy, 29 untranslated.
+locale/es/LC_MESSAGES/editorial_bot.po: 0 translated, 0 fuzzy, 69 untranslated.
+```
+
+See the [pyopensci `TRANSLATING.md` guide in the `python-package-guide`](https://github.com/pyOpenSci/python-package-guide/blob/main/TRANSLATING.md)
+for further instructions!
+
+After you are finished, run `make i18n` again to reformat your strings
+to fit the standard style that the CI will check for.
+
+## JOSS Website
+
+```{admonition}
+TODO!
+```

--- a/docs/update_i18n.py
+++ b/docs/update_i18n.py
@@ -1,0 +1,54 @@
+"""
+Script to update i18n files.
+"""
+
+import argparse
+from pathlib import Path
+import subprocess
+
+from sphinx_intl.basic import update
+
+import conf
+
+SOURCE_DIR = Path(__file__).parent.resolve()
+LOCALES_DIR = SOURCE_DIR / 'locale'
+BUILD_DIR = SOURCE_DIR / '_build'
+TEMPLATE_DIR = BUILD_DIR / "gettext"
+
+
+def make_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Update i18n files for JOSS docs",
+    )
+    parser.add_argument(
+        '-l', '--lang',
+        help="Language code (one of the enabled languages in conf.py:languages). "
+            "If ``None``, update all languages. Argument may be passed multiple times for multiple languages",
+        action="append",
+        default=None
+    )
+    return parser
+
+def update_pot():
+    """
+    Update .pot template files
+    """
+    res = subprocess.run(['sphinx-build', '-b', 'gettext', str(SOURCE_DIR), str(TEMPLATE_DIR)], capture_output=True)
+    if res.returncode != 0:
+        raise OSError("Error updating .pot files:\n" + res.stderr)
+
+
+def main():
+    parser = make_parser()
+    args = parser.parse_args()
+
+    if not args.lang:
+        languages = conf.languages
+    else:
+        languages = args.lang
+
+    update_pot()
+    update(LOCALES_DIR, TEMPLATE_DIR, languages)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR adds some initial .po files for adding translation to the python docs.

It contains
- A python script to generate/update all configured language files
- A CI action that checks that any changes to the source english documents are reflected in the .po files
- Some initial threadbare translation docs
- The generated .po files for a few languages that we had volunteers to translate.

Questions for the JOSS:
- Do we want to just enable all languages that have some partial translation (anything is better than nothing) with a note that we welcome contributions to complete the translation? or should we only publish translated docs that are above some threshold of completeness?
- Readthedocs handles building multiple language versions ( https://docs.readthedocs.io/en/stable/localization.html#projects-with-multiple-translations ), but we need the project maintainers to add each language as a subproject before they appear. Does that need additional documentation or is that self-explanatory?
- What does review look like? do we need to do code-review style multiple readers? Or what!? ROpenSci has some pretty good docs on this that we're learning from over in pyopensci :)