### PR TITLE
Add ROR affiliation links to example paper

### DIFF
--- a/docs/example_paper.md
+++ b/docs/example_paper.md
@@ -31,6 +31,7 @@ authors:
 affiliations:
  - name: Lyman Spitzer, Jr. Fellow, Princeton University, USA
    index: 1
+   ror: 00hx57361
  - name: Institution Name, Country
    index: 2
  - name: Independent Researcher, Country

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -98,6 +98,29 @@ authors:
   <!--     given-names: 瀧 -->
   <!--     surname: 立花 -->
 
+## Affiliations
+
+Each affiliation requires an `index` and `name`.
+
+Optionally, the Research Organization Registry (ROR) identifier for the top-level
+organization can be annotated with the `ror` key. Note that ROR does not include
+departments in its [scope](https://ror.org/registry/#scope-and-criteria-for-inclusion),
+so ROR annotations are typically made to the top-level organization.
+
+```yaml
+authors:
+  - name: Albert Krewinkel
+    affiliation: [ 1, 2, 3 ]
+
+affiliations:
+  - index: 1
+    name: Open Journals
+  - index: 2
+    name: Pandoc Development Team
+  - index: 3
+    name: Technische Universitaet Hamburg
+    ror: 04bs1pb34
+```
 
 ## Internal references
 


### PR DESCRIPTION
Closes #1353

In https://github.com/openjournals/inara/pull/72, I added ROR support to Inara such that ROR identifiers can be added to affiliations. They therefore show up with nice icons in the PDF exports, inside the Crossref XML output, and in the JATS output.

As suggested by Arfon in https://github.com/openjournals/inara/pull/72#issuecomment-2325088069, I've updated the JOSS documentation to give users a hint on how they can take advantage of this themselves. This PR specifically does the following:

- [x] add ROR to example paper
- [x] update paper guidelines

As mentioned in https://github.com/openjournals/inara/pull/72#issuecomment-2329888306, there are a few deployment things that need to be done before this is live, but I think we're ready to merge this anyway :)