### PR TITLE
Add codespell support (config) and make it fix few typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,*.pdf,*.svg,vendor,*.lock,*.css,.codespellrc
+check-hidden = true
+ignore-regex= .*view=FitH.*
+ignore-words-list = te,aas,nwo

--- a/.codespellrc
+++ b/.codespellrc
@@ -3,4 +3,5 @@
 skip = .git*,*.pdf,*.svg,vendor,*.lock,*.css,.codespellrc
 check-hidden = true
 ignore-regex= .*view=FitH.*
-ignore-words-list = te,aas,nwo
+# TODO: fix "superceded" typo in the model
+ignore-words-list = te,aas,nwo,superceded

--- a/app/javascript/custom/papers.js
+++ b/app/javascript/custom/papers.js
@@ -13,7 +13,7 @@ authorCheck = function() {
   }
 };
 
-// Set the height of the paper container when loaded and everytime window is resized
+// Set the height of the paper container when loaded and every time window is resized
 setPaperSize = function() {
   var height, paper, paper_container, width;
   if ($("#joss-paper").length > 0) {

--- a/app/views/content/layout/_footer.html.erb
+++ b/app/views/content/layout/_footer.html.erb
@@ -1,7 +1,7 @@
 <div class="row footer">
   <div class="col-sm-6">
     <%= link_to image_tag("osi.png", height: "65px"), "https://opensource.org" %>
-    <p><%= Rails.application.settings['name'] %> is an <a href="https://opensource.org/affiliates/list">affiliate</a> of the <a href="https://opensource.org">Open Source Inititative</a>.</p>
+    <p><%= Rails.application.settings['name'] %> is an <a href="https://opensource.org/affiliates/list">affiliate</a> of the <a href="https://opensource.org">Open Source Initiative</a>.</p>
   </div>
 
   <div class="col-sm-6">

--- a/docs/editor_onboarding.md
+++ b/docs/editor_onboarding.md
@@ -79,7 +79,7 @@ All new editors at JOSS have an onboarding call with an Editor-in-Chief. You can
 **Wrapping up**
 
 - Make sure you've highlighted everything in the ['top tips'](editor_tips) section of our docs.
-- Reinforce that this is a commitment, and thay regular attention to their submissions is absolutely critical (i.e., check in a couple of times per week).
+- Reinforce that this is a commitment, and that regular attention to their submissions is absolutely critical (i.e., check in a couple of times per week).
 - Ask if they would like to move forward or would like time to consider the opportunity.
 - If they want to move forward, highlight they will receive a small number of invites: One to the JOSS editors GitHub team, a Slack invite, a Google Group invite, and an invite to the JOSS website to fill out their profile.
 - If they are joining the team, make sure they mark themselves as unavailable in the [JOSS reviewers database](https://reviewers.joss.theoj.org/) (so they don't get asked to review any longer).

--- a/lib/tasks/utils.rake
+++ b/lib/tasks/utils.rake
@@ -283,7 +283,7 @@ namespace :utils do
 
       editor = review.editor.gsub('@', '')
 
-      # This is a pre-preview issue without an editor asssigned
+      # This is a pre-preview issue without an editor assigned
       if editor == "Pending" && review.pre_review?
         puts "Doing nothing for #{review.number}"
       else

--- a/spec/models/paper_spec.rb
+++ b/spec/models/paper_spec.rb
@@ -247,7 +247,7 @@ describe Paper do
       expect(paper.is_a_retraction_notice?).to be true
     end
 
-    it "should return false oherwise" do
+    it "should return false otherwise" do
       paper = create(:paper)
 
       expect(paper.retraction_for_id).to be_nil


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

This is a reincarnated prior attempt 
- https://github.com/openjournals/joss/pull/1241

from a year ago, which shows that
- new typos got detected (and/or introduced)
- it is inconvenient to look for new typos without codespell config present so I had to copy it from that older PR
- there is a typo in the model (`superceded`) which if already permeated to other places -- I guess ok to keep around , but otherwise ideally should have been fixed.

@xuanxu mentions

> We want to keep the actions we have to mantain for the repo at a minimum, so prefer not to run codespell.

which is I guess ok, but is there another level of assistance/automation to look adding it to?