### PR TITLE
Remove the 'waitlisted' label if it exists

### DIFF
--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -361,7 +361,7 @@ class Paper < ApplicationRecord
     return false unless editor = Editor.where("lower(login) = ?", editor_handle.downcase).first
 
     if labels.any?
-      new_labels = labels.keys + ["review"] - ["pre-review"]
+      new_labels = labels.keys + ["review"] - ["pre-review", "waitlisted"]
     else
       new_labels = ["review"]
     end


### PR DESCRIPTION
When moving between pre-review and review, we should remove the 'waitlisted' label if present.