### PR TITLE
Change examples in affiliation snippet to include country

### DIFF
--- a/docs/paper.md
+++ b/docs/paper.md
@@ -114,11 +114,11 @@ authors:
 
 affiliations:
   - index: 1
-    name: Open Journals
+    name: Laboratório Nacional de Luz Síncrotron, Brazil
   - index: 2
-    name: Pandoc Development Team
+    name: Gadjah Mada University, Indonesia
   - index: 3
-    name: Technische Universitaet Hamburg
+    name: Technische Universitaet Hamburg, Germany
     ror: 04bs1pb34
 ```
 


### PR DESCRIPTION
I've noticed myself asking various authors to add countries to affiliations when publishing articles. The [example paper](https://joss.readthedocs.io/en/latest/example_paper.html) has countries in the affiliations but I noticed [this snippet in the docs](https://joss.readthedocs.io/en/latest/paper.html#affiliations) doesn't so I've picked some fairly random institutions and added their country.

I don't have my heart set on these particular institutions (if we use real institutions at all!) but I just think we should have examples with countries and I wasn't sure what country "The Open Journals" or "Pandoc Development Team" should be.