### PR TITLE
Mock orcid login in dev environment

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -3,6 +3,8 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  config.log_level = :debug
+
   # In the development environment your application's code is reloaded any time
   # it changes. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
@@ -78,4 +80,23 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions.
   config.action_controller.raise_on_missing_callback_actions = true
+
+  # Mock the OmniAuth provider for orcid in dev environment
+  # Rather than actually pinging orcid, auto-login as a
+  # test user that is an editor and admin (see db/seed.rb)
+  # the uid and provider need to match in order for
+  # a new account to not be created (and use the one in db/seed.rb)
+  OmniAuth.config.test_mode = true
+  OmniAuth.config.mock_auth[:orcid] = OmniAuth::AuthHash.new({
+    :provider => 'orcid',
+    :uid => '12345',
+    :info => {
+      :name => 'Lord Fakington',
+      :email => 'lordfake@example.com'
+    },
+    :credentials => {
+      :token => '56789',
+      :expires_at => 10.years.since
+    }
+  })
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -357,21 +357,34 @@ Editor.create(
 
 case Rails.env
 when "development"
-  aeic = Editor.create!(
+  aeic = Editor.find_or_initialize_by(login: "aeicfake")
+  aeic.update(
     kind: "board",
     first_name: "Editor In Chief",
     last_name: "Fakington",
-    login: "aeicfake",
     email: "aeicfake@example.com",
     categories: ["Astronomy"]
   )
-  track = Track.create!(
-    code: 0,
+  aeic.save
+
+  track = Track.find_or_initialize_by(code: 0)
+  track.update(
     name: "Railroad",
     short_name: "rail",
     aeics: [aeic]
   )
-  editor = Editor.create!(
+  track.save
+
+  subject = Subject.find_or_initialize_by(name: "Trains")
+  subject.update(
+    track: track,
+    created_at: 10.minutes.ago,
+    updated_at: Time.now
+  )
+  subject.save
+
+  editor = Editor.find_or_initialize_by(login: 'lordfake')
+  editor.update(
     kind: "topic",
     first_name: "Lord",
     last_name: "Fakington",
@@ -380,13 +393,26 @@ when "development"
     categories: ["Astronomy"],
     tracks: [track]
   )
-  user = User.create!(
+  editor.save
+
+  editor_user = User.find_or_initialize_by(uid: 12345)
+  editor_user.update(
+    name: 'Lord Fakington',
+    email: 'lordfake@example.com',
+    admin: true,
+    provider: 'orcid',
+    github_username: 'lordfake_namedoesnt_exist',
+    editor: editor
+  )
+  editor_user.save
+
+  user = User.create(
     name: "Sneakers T. Rat",
     email: "sneakers@example.com",
     github_username: "fakeuser_namedoesnt_exist"
   )
 
-  paper = Paper.create!(
+  paper = Paper.create(
     editor: editor,
     submitting_author: user,
     title: "On the mysteries of draperies and various such textiles",


### PR DESCRIPTION
Fix: https://github.com/openjournals/joss/issues/1374

It is currently impossible to login in the dev environment, meaning that we can't interactively try and replicate bugs in prod that require a login like paper submission. In general it's great to be able to test things in a dev environment instead of needing to test in prod! 

This PR just mocks the OmniAuth provider using [instructions from their docs](https://github.com/omniauth/omniauth/wiki/Integration-Testing#setting-up-the-controller) to automatically log us in as the Lord Fake user.

I updated the seed.db entries to match that (added uid and provider fields) and also updated those to upsert instead of error if they already exist. 

It was also impossible to create a paper without a subject existing, so i added one.