### PR TITLE
Make ToC dates y-m-d

### DIFF
--- a/app/views/toc/_list.html.erb
+++ b/app/views/toc/_list.html.erb
@@ -7,7 +7,7 @@
           <%= link_to paper.title, paper.seo_url, title: paper.title, class: "d-inline-block text-truncate", style: "max-width: 450px;" %>
         </td>
         <td>
-          <div class="time">Published <%= paper.accepted_at.strftime("%d-%m-%Y") %> </div>
+          <div class="time">Published <%= paper.accepted_at.strftime("%Y-%m-%d") %> </div>
         </td>
         <td>
           <%= image_tag 'doi.svg' %><%= link_to paper.doi, paper.seo_url %>


### PR DESCRIPTION
Partial fix of: https://github.com/openjournals/joss/issues/1377

Just makes the dates `'%Y-%m-%d'` in the toc listings :). this is the only place that uses `'%d-%m-%Y'` on the site according to regex :)