### PR TITLE
Titles in ToC

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
     gtag('config', '<%= setting(:google_analytics) %>');
   </script>
   
-  <title><%= setting(:name) %></title>
+  <title><% if content_for(:title) %><%= yield :title %> - <%= setting(:name) %><% else %><%= setting(:name) %><% end %></title>
   <%= stylesheet_link_tag    'application', media: 'all' %>
   <%= javascript_importmap_tags %>
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/app/views/toc/current_issue.html.erb
+++ b/app/views/toc/current_issue.html.erb
@@ -1,3 +1,6 @@
+<% content_for :title do %>
+Current Issue
+<% end %>
 <div class="container" id="toc-header">
   <div class="welcome"><%= link_to "Table of Contents", toc_index_path %> Current issue</div>
   <div class="hero-small">

--- a/app/views/toc/index.html.erb
+++ b/app/views/toc/index.html.erb
@@ -1,3 +1,6 @@
+<% content_for :title do %>
+Table of Contents
+<% end %>
 <div class="container" id="toc-header">
   <div class="welcome">All volumes and issues</div>
   <div class="hero-small">

--- a/app/views/toc/issue.html.erb
+++ b/app/views/toc/issue.html.erb
@@ -1,3 +1,6 @@
+<% content_for :title do %>
+Issue <%= params[:issue] %>
+<% end %>
 <div class="container" id="toc-header">
   <div class="welcome"><%= link_to "Table of Contents", toc_index_path %> <%= Date::MONTHNAMES[@month] %> <%= @year %> Volume <%= @volume %></div>
   <div class="hero-small">

--- a/app/views/toc/volume.html.erb
+++ b/app/views/toc/volume.html.erb
@@ -1,3 +1,6 @@
+<% content_for :title do %>
+Volume <%= params[:volume] %>
+<% end %>
 <div class="container" id="toc-header">
   <div class="welcome"><%= link_to "Table of Contents", toc_index_path %> <%= "Year " + @year.to_s if @year %></div>
   <div class="hero-small">

--- a/app/views/toc/year.html.erb
+++ b/app/views/toc/year.html.erb
@@ -1,3 +1,6 @@
+<% content_for :title do %>
+<%= params[:year] %>
+<% end %>
 <div class="container" id="toc-header">
   <div class="welcome"><%= link_to "Table of Contents", toc_index_path %></div>
   <div class="hero-small">


### PR DESCRIPTION
Partial fix of: https://github.com/openjournals/joss/issues/1377

Cool! learned how to use `yield` and `content_for` in rails templates.

<img width="419" alt="Screenshot 2024-10-23 at 1 19 19 PM" src="https://github.com/user-attachments/assets/9dc9f197-c16e-4304-8d02-ac8644a34ce5">

Should keep page title the same if there is no title provided, and otherwise be `{title} - Journal of Open Source Software`

Put the page name first because i don't think i'm alone in having my tabs often looking like this

<img width="225" alt="Screenshot 2024-10-23 at 1 20 21 PM" src="https://github.com/user-attachments/assets/100929ee-92ca-4377-a387-bbdd13861e59">
