### PR TITLE
fix tests: temporarily add net-pop to deps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,10 @@ gem 'puma'
 # Use Redis for Action Cable
 gem "redis", "~> 5.0"
 
+# Can remove when upgrading to 3.3.4
+# see: https://github.com/ruby/net-pop/issues/26
+gem 'net-pop', github: 'ruby/net-pop'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,9 @@
+GIT
+  remote: https://github.com/ruby/net-pop.git
+  revision: e8d0afe2773b9eb6a23c39e9e437f6fc0fc7c733
+  specs:
+    net-pop (0.1.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -248,7 +254,6 @@ GEM
     net-imap (0.5.0)
       date
       net-protocol
-    net-pop (0.1.2)
     net-protocol (0.2.2)
       timeout
     net-sftp (4.0.0)
@@ -518,6 +523,7 @@ DEPENDENCIES
   issue
   jbuilder (~> 2.11)
   mini_racer
+  net-pop!
   net-sftp (~> 4.0)
   octicons_helper
   octokit


### PR DESCRIPTION
The tests are broken :(

We are getting this bug: https://github.com/ruby/net-pop/issues/26

so until we can update to 3.3.4, this is a temporary workaround that forces the dependency resolution to run by installing from github rather than ruby gems