### PR TITLE
[style] fix orcid button alignment, less awkward intermediate-width menu

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -808,8 +808,10 @@ $btn-primary-border: darken($btn-primary-bg, 5%) !default;
 }
 
 .navbar-nav {
+    align-items: center;
+
     @include media-breakpoint-down(md) {
-        display: inline-block;
+        align-items: flex-end;
     }
 }
 
@@ -817,7 +819,7 @@ $btn-primary-border: darken($btn-primary-bg, 5%) !default;
     padding: 1em !important;
     color: #2E294E;
     align-self: center;
-    transition: background-color 0.5s ease;
+    transition: background-color 0.5s ease, font-size 0.25s ease;
     white-space: nowrap;
     position: relative;
 
@@ -825,7 +827,7 @@ $btn-primary-border: darken($btn-primary-bg, 5%) !default;
     &::after {
         opacity: 0;
         position: absolute;
-        top: 100%;
+        bottom: 0;
         left: 0;
         width: 100%;
         height: 4px;
@@ -838,8 +840,12 @@ $btn-primary-border: darken($btn-primary-bg, 5%) !default;
 
 
     &:hover {
-        color: #2E294E;
-
+        @include media-breakpoint-down(md) {
+            &:not(.orcid) {
+                font-size: 1.25em;
+            }
+            transition: font-size 0.25s ease;
+        }
 
         &:hover::before,
         &:hover::after,
@@ -847,12 +853,17 @@ $btn-primary-border: darken($btn-primary-bg, 5%) !default;
         &:focus::after {
             opacity: 1;
             transform: translateY(10px) scale(1);
+
+            @include media-breakpoint-down(md) {
+                opacity: 0;
+            }
         }
     }
 
     @include media-breakpoint-down(md) {
         font-size: 1.125em;
-        padding: 1em 0 !important;
+        padding: 0 !important;
+        height: 3rem;
         width: 100%;
         text-align: right;
 
@@ -861,6 +872,14 @@ $btn-primary-border: darken($btn-primary-bg, 5%) !default;
             color: #007BFF;
         }
 
+        &.orcid {
+            padding: 1em !important; // bootstrap forces this important
+            margin-bottom: 0.5em;
+            &:hover {
+                color: #fff;
+                border-color: #1f1d1d;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
currently the orcid button is out of alignment:

<img width="683" alt="Screenshot 2024-11-01 at 11 35 52 PM" src="https://github.com/user-attachments/assets/3f5722ad-0284-425f-a098-652c2a676348">

and on the mobile menu is has no horizontal padding. the underlines also extend too low into the neighboring item

<img width="248" alt="Screenshot 2024-11-01 at 11 36 08 PM" src="https://github.com/user-attachments/assets/b0923ec6-a10d-4d19-86e0-916dcb6b1f4e">

---

So this pr aligns it

<img width="701" alt="Screenshot 2024-11-01 at 11 38 21 PM" src="https://github.com/user-attachments/assets/56de7260-c2a7-4080-b167-5a54ee28db69">

and since the horizontal line animation only really works on a horizontal menu, and the only time it's seen is on intermediate widths on desktops/laptops (since tablets/phones don't hover) where we would be scooting a mouse up and down, so i replaced it with a small size animation that has vertical rather than horizontal flow

and also added padding to the orcid button and prevented it from inverting color on hover since it was the only thing to do that


https://github.com/user-attachments/assets/55f37f22-bc95-42cc-bdd9-b952141a68ae

