### PR TITLE
Replace "USA" to "United States" in `example_paper.md`

### DIFF
--- a/docs/example_paper.md
+++ b/docs/example_paper.md
@@ -29,7 +29,7 @@ authors:
     surname: Beethoven
     affiliation: 3
 affiliations:
- - name: Lyman Spitzer, Jr. Fellow, Princeton University, USA
+ - name: Lyman Spitzer, Jr. Fellow, Princeton University, United States
    index: 1
    ror: 00hx57361
  - name: Institution Name, Country


### PR DESCRIPTION
### Context

One of the final checklist items indicates (https://github.com/openjournals/joss-reviews/issues/7205):

```
- [ ] Please spell out country names in your affiliations, so do not use the acronym USA.
```

### Solution 

Replace `USA` to `United States` in `doc/example_paper.md`

