### PR TITLE
comment out compiling tools checkpoint

### DIFF
--- a/app/views/papers/_form.html.erb
+++ b/app/views/papers/_form.html.erb
@@ -70,10 +70,12 @@
       <input type="checkbox" id="author-check" class="pre-check form-check-input">
       <label class="form-check-label" for="author-check">I certify that I am submitting materials for which I am a primary author</label>
     </div>
+    <!--
     <div class="col form-check" style="margin-left: 15px;">
       <input type="checkbox" id="paper-check" class="pre-check form-check-input">
       <label class="form-check-label" for="paper-check">I have verified that my paper compiles using one of <a href="https://joss.readthedocs.io/en/latest/paper.html#checking-that-your-paper-compiles" target="_blank">these tools</a>.</label>
     </div>
+    -->
     <div class="col form-check">
       <input type="checkbox" id="coc-check" class="pre-check form-check-input">
       <label class="form-check-label" for="coc-check">I confirm that I read and will adhere to the <%= setting(:abbreviation) %> <a href="/about#code_of_conduct" target="_blank">code of conduct</a></label>


### PR DESCRIPTION
The box pointed to JOSS documentation, which mentions markdown, this confused a few people, since we use latex (and explicitly say you shouldn't have markdown).

Ideally, we would point to our compiling instructions, but those need some ironing, so I'm commenting out the box for now 