### PR TITLE
Remove figshare form documentation

### DIFF
--- a/docs/editing.md
+++ b/docs/editing.md
@@ -58,7 +58,7 @@ This doesn’t mean that you’re the editor, just that you’ve been suggested 
 **Step 11: The editor pings the EiC team to get the paper published**
 
 - Make a final check of the paper with `@editorialbot generate pdf` and that all references have DOIs (where appropriate) with `@editorialbot check references`.
-- If everything looks good, ask the author to make a new release (if possible) of the software being reviewed and deposit a new archive the software with Zenodo/figshare. Update the review thread with this archive DOI: `@editorialbot set 10.5281/zenodo.xxxxxx as archive`.
+- If everything looks good, ask the author to make a new release (if possible) of the software being reviewed and deposit a new archive the software with Zenodo. Update the review thread with this archive DOI: `@editorialbot set 10.5281/zenodo.xxxxxx as archive`.
 - Editors can get a checklist of the final steps using the `@editorialbot create post-review checklist` command
 - Finally, use `@editorialbot recommend-accept` on the review thread to ping the `@openjournals/joss-eics` team letting them know the paper is ready to be accepted.
 

--- a/docs/editorial_bot.md
+++ b/docs/editorial_bot.md
@@ -144,7 +144,7 @@ Most units of times are understood by EditorialBot e.g. `hour/hours/day/days/wee
 
 ### Setting the software archive
 
-When a submission is accepted, we ask that the authors to create an archive (on [Zenodo](https://zenodo.org/), [fig**share**](https://figshare.com/), or other) and post the archive DOI in the `REVIEW` issue. The editor should ask `@editorialbot` to add the archive to the issue as follows:
+When a submission is accepted, we ask that the authors to create an archive (on [Zenodo](https://zenodo.org/) or other) and post the archive DOI in the `REVIEW` issue. The editor should ask `@editorialbot` to add the archive to the issue as follows:
 
 ```text
 @editorialbot set 10.0000/zenodo.00000 as archive

--- a/docs/sample_messages.md
+++ b/docs/sample_messages.md
@@ -78,7 +78,7 @@ Please feel free to ping me (@editorname) if you have any questions/concerns.
 ```
 At this point could you:
 - Make a tagged release of your software, and list the version tag of the archived version here.
-- Archive the reviewed software in Zenodo or a similar service (e.g., figshare, an institutional repository)
+- Archive the reviewed software in Zenodo or a similar service (e.g., an institutional repository)
 - Check the archival deposit (e.g., in Zenodo) has the correct metadata. This includes the title (should match the paper title) and author list (make sure the list is correct and people who only made a small fix are not on it). You may also add the authors' ORCID.
 - Please list the DOI of the archived version here.
 

--- a/docs/submitting.md
+++ b/docs/submitting.md
@@ -119,7 +119,7 @@ After submission:
 - Authors will respond to reviewer-raised issues (if any are raised) on the submission repository's issue tracker. Reviewer and editor contributions, like any other contributions, should be acknowledged in the repository. 
 - **JOSS reviews are iterative and conversational in nature.** Reviewers are encouraged to post comments/questions/suggestions in the review thread as they arise, and authors are expected to respond in a timely fashion.
 - Authors and reviewers are asked to be patient when waiting for a response from an editor. Please allow a week for an editor to respond to a question before prompting them for further action.
-- Upon successful completion of the review, authors will make a tagged release of the software, and deposit a copy of the repository with a data-archiving service such as [Zenodo](https://zenodo.org/) or [figshare](https://figshare.com/), get a DOI for the archive, and update the review issue thread with the version number and DOI.
+- Upon successful completion of the review, authors will make a tagged release of the software, and deposit a copy of the repository with a data-archiving service such as [Zenodo](https://zenodo.org/), get a DOI for the archive, and update the review issue thread with the version number and DOI.
 - After we assign a DOI for your accepted JOSS paper, its metadata is deposited with CrossRef and listed on the JOSS website.
 - The review issue will be closed, and an automatic post from [@JOSS at Mastodon](https://fosstodon.org/@joss) will announce it!
 


### PR DESCRIPTION
I removed figshare from the documentation as discussed on slack. 

There is still one occurrence left here: https://github.com/diehlpk/joss/blob/b9c760c2ccb73fd4aeb7d94a769d9b114d31f42b/spec/models/paper_spec.rb#L158