### PR TITLE
Fix BibTeX author name formatting for compound surnames

### DIFF
--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -216,7 +216,14 @@ class Paper < ApplicationRecord
 
   def bibtex_authors
     return nil unless published?
-    metadata['paper']['authors'].collect {|a| "#{a['given_name']} #{a['middle_name']} #{a['last_name']}".squish}.join(' and ')
+    metadata['paper']['authors'].collect do |a|
+      given_parts = [a['given_name'], a['middle_name']].compact.join(' ')
+      if given_parts.present?
+        "#{a['last_name']}, #{given_parts}"
+      else
+        a['last_name']
+      end
+    end.join(' and ')
   end
 
   def bibtex_key

--- a/spec/models/paper_spec.rb
+++ b/spec/models/paper_spec.rb
@@ -508,4 +508,42 @@ describe Paper do
       expect(@paper.reload.track).to eq(@track_2)
     end
   end
+
+  describe "#bibtex_authors" do
+    it "should format author names correctly for BibTeX" do
+      paper = create(:accepted_paper)
+      paper.metadata['paper']['authors'] = [
+        {'given_name' => 'Rhoslyn', 'last_name' => 'Roebuck Williams'},
+        {'given_name' => 'Harry', 'middle_name' => 'J.', 'last_name' => 'Stroud'},
+        {'given_name' => 'Ludwig', 'last_name' => 'van Beethoven'}
+      ]
+      paper.save!
+
+      expected_bibtex = "Roebuck Williams, Rhoslyn and Stroud, Harry J. and van Beethoven, Ludwig"
+      expect(paper.bibtex_authors).to eq(expected_bibtex)
+    end
+
+    it "should handle authors with no given name" do
+      paper = create(:accepted_paper)
+      paper.metadata['paper']['authors'] = [
+        {'given_name' => 'John', 'last_name' => 'Smith'},
+        {'last_name' => 'Collective'}
+      ]
+      paper.save!
+
+      expected_bibtex = "Smith, John and Collective"
+      expect(paper.bibtex_authors).to eq(expected_bibtex)
+    end
+
+    it "should handle authors with only middle name" do
+      paper = create(:accepted_paper)
+      paper.metadata['paper']['authors'] = [
+        {'middle_name' => 'J.', 'last_name' => 'Smith'}
+      ]
+      paper.save!
+
+      expected_bibtex = "Smith, J."
+      expect(paper.bibtex_authors).to eq(expected_bibtex)
+    end
+  end
 end


### PR DESCRIPTION
Fixes #1439

### Problem
The `bibtex_authors` method was formatting author names as "First Middle Last" instead of the proper BibTeX format "Last, First Middle". This caused issues with compound surnames like "Rhoslyn Roebuck Williams" appearing incorrectly in generated BibTeX citations.

### Solution
Updated the `bibtex_authors` method in the Paper model to:
- Format names as "Last, First Middle" following BibTeX standards
- Handle edge cases like authors with no given names or only middle names
- Preserve the existing `scholar_authors` method (which correctly uses "First Middle Last" for Google Scholar)

### Before/After
**Before:**
```bibtex
author = {Harry J. Stroud and Mark D. Wonnacott and Jonathan Barnoud and Rhoslyn Roebuck Williams and Mohamed Dhouioui...}
```

**After:**
```bibtex
author = {Stroud, Harry J. and Wonnacott, Mark D. and Barnoud, Jonathan and Roebuck Williams, Rhoslyn and Dhouioui, Mohamed...}
```

### Testing
Added tests covering:
- Normal cases with compound surnames
- Authors with no given names
- Authors with only middle names

All existing tests continue to pass.
```