### PR TITLE
Fix inactive "Submit paper" button 

### DIFF
--- a/app/javascript/custom/papers.js
+++ b/app/javascript/custom/papers.js
@@ -4,7 +4,7 @@ var authorCheck, setPaperSize;
 authorCheck = function() {
   var checkBoxCount;
   checkBoxCount = $(".pre-check:checked").length;
-  if (checkBoxCount === 3) {
+  if (checkBoxCount === 2) {
     $("#author-submit").removeClass('disabled');
     $("#author-submit").prop('disabled', false);
   } else {


### PR DESCRIPTION
When trying to submit a new paper the submit button won't activate. 
The cause is that at some point this checkbox was [commented out](https://github.com/openjournals/joss/blob/juliacon/app/views/papers/_form.html.erb#L73-L78), but the number of checkboxes the user has checked [is used to activate the button](https://github.com/openjournals/joss/blob/juliacon/app/javascript/custom/papers.js#L7). So now we need to have 3 checked boxes but there are only 2, so the button is always disabled. 

This PR fixes that. 