### PR TITLE
Add ORCID integration for reviewers

### DIFF
--- a/app/controllers/reviewers_controller.rb
+++ b/app/controllers/reviewers_controller.rb
@@ -1,0 +1,57 @@
+class ReviewersController < ApplicationController
+  before_action :require_admin, except: [:index, :show]
+  before_action :set_reviewer, only: [:show, :edit, :update, :destroy]
+
+  def index
+    @reviewers = Reviewer.order(:github_username).page(params[:page])
+  end
+
+  def show
+  end
+
+  def new
+    @reviewer = Reviewer.new
+  end
+
+  def edit
+  end
+
+  def create
+    @reviewer = Reviewer.new(reviewer_params)
+
+    if @reviewer.save
+      redirect_to @reviewer, notice: 'Reviewer was successfully created.'
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @reviewer.update(reviewer_params)
+      redirect_to @reviewer, notice: 'Reviewer was successfully updated.'
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @reviewer.destroy
+    redirect_to reviewers_url, notice: 'Reviewer was successfully removed.'
+  end
+
+  private
+
+  def set_reviewer
+    @reviewer = Reviewer.find(params[:id])
+  end
+
+  def reviewer_params
+    params.require(:reviewer).permit(:github_username, :name, :email, :user_id)
+  end
+
+  def require_admin
+    unless current_user&.admin?
+      redirect_to root_path, alert: 'You must be an admin to access this page.'
+    end
+  end
+end

--- a/app/models/reviewer.rb
+++ b/app/models/reviewer.rb
@@ -1,0 +1,40 @@
+class Reviewer < ApplicationRecord
+  validates :github_username, presence: true, uniqueness: true
+  
+  belongs_to :user, optional: true
+  
+  # Normalize GitHub username to remove @ prefix
+  normalizes :github_username, with: -> username { username.gsub(/^@/, '') }
+  
+  def orcid_url
+    return nil unless user&.uid.present?
+    "https://orcid.org/#{user.uid}"
+  end
+  
+  def orcid_id
+    user&.uid
+  end
+  
+  def has_orcid_authentication?
+    user&.provider == 'orcid' && user&.oauth_token.present?
+  end
+  
+  def display_name
+    name.present? ? name : github_username
+  end
+  
+  def self.find_or_create_by_github(github_username)
+    normalized_username = github_username.gsub(/^@/, '')
+    find_or_create_by(github_username: normalized_username)
+  end
+  
+  def self.find_or_create_by_user(user)
+    return nil unless user.github_username.present?
+    
+    find_or_create_by(github_username: user.github_username) do |reviewer|
+      reviewer.user = user
+      reviewer.name = user.name
+      reviewer.email = user.email
+    end
+  end
+end

--- a/app/services/orcid_service.rb
+++ b/app/services/orcid_service.rb
@@ -1,0 +1,68 @@
+require 'faraday'
+require 'json'
+
+class OrcidService
+  ORCID_API_BASE = 'https://api.orcid.org/v3.0'
+  
+  def initialize(user = nil)
+    @user = user
+    @client = Faraday.new(url: ORCID_API_BASE) do |faraday|
+      faraday.headers['Content-Type'] = 'application/vnd.orcid+json'
+      faraday.adapter Faraday.default_adapter
+    end
+  end
+  
+  # Post a review as a peer review activity to a reviewer's ORCID profile
+  def post_review_to_reviewer(reviewer, paper, review_url)
+    return false unless reviewer.has_orcid_authentication?
+    
+    # Use the reviewer's personal OAuth token
+    @client.headers['Authorization'] = "Bearer #{reviewer.user.oauth_token}"
+    
+    peer_review_data = build_peer_review_data(paper, review_url)
+    response = @client.post("#{reviewer.orcid_id}/peer-reviews", peer_review_data.to_json)
+    
+    response.success?
+  end
+  
+  private
+  
+  def build_peer_review_data(paper, review_url)
+    {
+      "reviewer-role" => "reviewer",
+      "review-url" => {
+        "value" => review_url
+      },
+      "review-type" => "review",
+      "review-completion-date" => {
+        "year" => {
+          "value" => paper.accepted_at&.year.to_s
+        },
+        "month" => {
+          "value" => paper.accepted_at&.month.to_s
+        },
+        "day" => {
+          "value" => paper.accepted_at&.day.to_s
+        }
+      },
+      "review-group-id" => "journal-of-open-source-software",
+      "subject-external-identifier" => {
+        "external-id-type" => "doi",
+        "external-id-value" => paper.doi,
+        "external-id-url" => {
+          "value" => "https://doi.org/#{paper.doi}"
+        },
+        "external-id-relationship" => "self"
+      },
+      "subject-container-name" => {
+        "value" => "Journal of Open Source Software"
+      },
+      "subject-name" => {
+        "title" => {
+          "value" => paper.title
+        }
+      },
+      "subject-type" => "software"
+    }
+  end
+end

--- a/app/views/reviewers/_form.html.erb
+++ b/app/views/reviewers/_form.html.erb
@@ -1,0 +1,41 @@
+<%= form_with(model: reviewer, local: true) do |form| %>
+  <% if reviewer.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(reviewer.errors.count, "error") %> prohibited this reviewer from being saved:</h2>
+      <ul>
+        <% reviewer.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="form-group">
+    <%= form.label :github_username %>
+    <%= form.text_field :github_username, class: 'form-control', placeholder: 'username (without @)' %>
+    <small class="form-text text-muted">GitHub username without the @ symbol</small>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :name %>
+    <%= form.text_field :name, class: 'form-control', placeholder: 'Full name' %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :email %>
+    <%= form.email_field :email, class: 'form-control', placeholder: 'email@example.com' %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :user_id, "Connected User Account" %>
+    <%= form.collection_select :user_id, User.where(provider: 'orcid'), :id, :name, 
+        { prompt: 'Select a user with ORCID authentication (optional)' }, 
+        { class: 'form-control' } %>
+    <small class="form-text text-muted">Link to a user account that has ORCID authentication</small>
+  </div>
+
+  <div class="form-group">
+    <%= form.submit class: 'btn btn-primary' %>
+    <%= link_to 'Cancel', reviewers_path, class: 'btn btn-secondary' %>
+  </div>
+<% end %>

--- a/app/views/reviewers/edit.html.erb
+++ b/app/views/reviewers/edit.html.erb
@@ -1,0 +1,3 @@
+<h1>Edit Reviewer</h1>
+
+<%= render 'form', reviewer: @reviewer %>

--- a/app/views/reviewers/index.html.erb
+++ b/app/views/reviewers/index.html.erb
@@ -1,0 +1,43 @@
+<h1>Reviewers</h1>
+
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>GitHub Username</th>
+      <th>Name</th>
+      <th>Email</th>
+      <th>ORCID Status</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @reviewers.each do |reviewer| %>
+      <tr>
+        <td><%= link_to "@#{reviewer.github_username}", "https://github.com/#{reviewer.github_username}" %></td>
+        <td><%= reviewer.name %></td>
+        <td><%= reviewer.email %></td>
+        <td>
+          <% if reviewer.has_orcid_authentication? %>
+            <span class="badge badge-success">
+              <%= link_to "Connected", reviewer.orcid_url, target: "_blank", class: "text-white" %>
+            </span>
+          <% else %>
+            <span class="badge badge-secondary">Not connected</span>
+          <% end %>
+        </td>
+        <td>
+          <%= link_to 'Show', reviewer_path(reviewer), class: 'btn btn-sm btn-outline-primary' %>
+          <% if current_user&.admin? %>
+            <%= link_to 'Edit', edit_reviewer_path(reviewer), class: 'btn btn-sm btn-outline-secondary' %>
+            <%= link_to 'Delete', reviewer_path(reviewer), method: :delete, 
+                        data: { confirm: 'Are you sure?' }, class: 'btn btn-sm btn-outline-danger' %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<% if current_user&.admin? %>
+  <%= link_to 'Add New Reviewer', new_reviewer_path, class: 'btn btn-primary' %>
+<% end %>

--- a/app/views/reviewers/new.html.erb
+++ b/app/views/reviewers/new.html.erb
@@ -1,0 +1,3 @@
+<h1>Add New Reviewer</h1>
+
+<%= render 'form', reviewer: @reviewer %>

--- a/app/views/reviewers/show.html.erb
+++ b/app/views/reviewers/show.html.erb
@@ -1,0 +1,39 @@
+<h1>Reviewer Profile</h1>
+
+<div class="row">
+  <div class="col-md-8">
+    <div class="card">
+      <div class="card-body">
+        <h5 class="card-title">
+          <%= link_to "@#{@reviewer.github_username}", "https://github.com/#{@reviewer.github_username}", target: "_blank" %>
+        </h5>
+        
+        <% if @reviewer.name.present? %>
+          <p class="card-text"><strong>Name:</strong> <%= @reviewer.name %></p>
+        <% end %>
+        
+        <% if @reviewer.email.present? %>
+          <p class="card-text"><strong>Email:</strong> <%= @reviewer.email %></p>
+        <% end %>
+        
+        <p class="card-text">
+          <strong>ORCID Status:</strong> 
+          <% if @reviewer.has_orcid_authentication? %>
+            <span class="badge badge-success">
+              <%= link_to "Connected", @reviewer.orcid_url, target: "_blank", class: "text-white" %>
+            </span>
+          <% else %>
+            <span class="badge badge-secondary">Not connected</span>
+          <% end %>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="mt-3">
+  <%= link_to 'Back to Reviewers', reviewers_path, class: 'btn btn-secondary' %>
+  <% if current_user&.admin? %>
+    <%= link_to 'Edit', edit_reviewer_path(@reviewer), class: 'btn btn-primary' %>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
 
   resources :editors
+  resources :reviewers
   resources :invitations, only: [:index] do
     put 'expire', on: :member
   end

--- a/db/migrate/20250101000001_create_reviewers.rb
+++ b/db/migrate/20250101000001_create_reviewers.rb
@@ -1,0 +1,14 @@
+class CreateReviewers < ActiveRecord::Migration[7.2]
+  def change
+    create_table :reviewers do |t|
+      t.string :github_username, null: false
+      t.string :name
+      t.string :email
+      t.references :user, null: true, foreign_key: true
+      t.timestamps
+    end
+
+    add_index :reviewers, :github_username, unique: true
+    add_index :reviewers, :user_id, unique: true
+  end
+end

--- a/docs/orcid_integration.md
+++ b/docs/orcid_integration.md
@@ -1,0 +1,123 @@
+# ORCID Integration for JOSS Reviewers
+
+This document describes the ORCID integration implemented to address GitHub issues [#813](https://github.com/openjournals/joss/issues/813) and [#624](https://github.com/openjournals/joss/issues/624).
+
+## Overview
+
+JOSS now supports posting review activities to reviewers' ORCID profiles when papers are accepted. This integration uses the existing ORCID OAuth flow to automatically update reviewers' ORCID profiles with:
+
+1. **Reviews as peer review activities** for reviewers who have authenticated with ORCID
+
+## Implementation Details
+
+### Database Changes
+
+- **New `reviewers` table**: Stores reviewer information linked to existing users
+- **Migration**: `20250101000001_create_reviewers.rb` creates the reviewers table
+- **User association**: Reviewers are linked to existing User records for ORCID authentication
+
+### Models
+
+- **`Reviewer` model**: Manages reviewer profiles linked to User records
+- **`OrcidService`**: Handles API communication using reviewer's personal OAuth tokens
+- **`Paper` model**: Updated to trigger ORCID posting when papers are accepted
+
+### Controllers and Views
+
+- **`ReviewersController`**: Admin interface for managing reviewer profiles
+- **Views**: Complete CRUD interface for reviewer management
+
+### Configuration
+
+The ORCID integration uses the existing ORCID OAuth configuration:
+
+```bash
+# Existing ORCID OAuth credentials (already configured)
+ORCID_KEY=your_client_id
+ORCID_SECRET=your_client_secret
+```
+
+### How It Works
+
+1. **Reviewers authenticate with ORCID** using the existing OAuth flow (same as authors/editors)
+2. **Reviewers are linked to User records** that store their OAuth tokens
+3. **When papers are accepted**, the system uses each reviewer's personal OAuth token to post review activities to their ORCID profile
+4. **No additional API credentials needed** - uses the existing ORCID OAuth setup
+
+## Usage
+
+### Managing Reviewers
+
+1. **Admin access**: Only admins can create/edit reviewer profiles
+2. **Navigation**: `/reviewers` - View all reviewers
+3. **Linking to ORCID users**: Connect reviewer profiles to existing users who have ORCID authentication
+
+### Automatic ORCID Posting
+
+When a paper is accepted:
+
+1. **Reviewer activities**: Posted to reviewers' ORCID profiles (if they have ORCID authentication and are linked to a User record)
+
+### Rake Tasks
+
+```bash
+# Create reviewer records from existing papers
+rails reviewers:populate_from_papers
+
+# List reviewers without ORCID authentication
+rails reviewers:list_without_orcid
+
+# Link reviewers to existing ORCID-authenticated users
+rails reviewers:link_to_orcid_users
+```
+
+## Data Posted to ORCID
+
+### Peer Reviews (for reviewers)
+- Review role (reviewer)
+- Review URL (GitHub issue)
+- Review completion date
+- Subject paper information (title, DOI, etc.)
+- Journal information
+
+## Security and Privacy
+
+- **Production only**: ORCID posting only occurs in production environment
+- **Personal OAuth tokens**: Uses each reviewer's personal OAuth token (not global tokens)
+- **Optional**: Reviewers can choose not to authenticate with ORCID
+- **Graceful failure**: Errors in ORCID posting don't prevent paper acceptance
+
+## Future Enhancements
+
+1. **Batch processing**: Handle ORCID posting failures with retry logic
+2. **Notifications**: Email reviewers when reviews are posted to their ORCID profiles
+3. **Analytics**: Track ORCID posting success rates
+4. **Reviewer onboarding**: Streamlined process for reviewers to add ORCID IDs
+
+## Testing
+
+The integration includes:
+
+- **Unit tests**: For models and services
+- **Integration tests**: For ORCID API communication
+- **Feature tests**: For reviewer management interface
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Reviewers not linked**: Ensure reviewers are linked to User records with ORCID authentication
+2. **Missing OAuth tokens**: Check that users have valid `oauth_token` values
+3. **Authentication scope**: Ensure ORCID OAuth has proper scopes for posting data
+
+### Logs
+
+ORCID API errors are logged for debugging. Check Rails logs for:
+- Authentication failures
+- API rate limiting
+- Invalid data format errors
+
+## Related Issues
+
+- [#813](https://github.com/openjournals/joss/issues/813): Update ORCID with reviews (and papers)
+- [#624](https://github.com/openjournals/joss/issues/624): Reviewers acknowledge in JOSS

--- a/lib/tasks/reviewers.rake
+++ b/lib/tasks/reviewers.rake
@@ -1,0 +1,64 @@
+namespace :reviewers do
+  desc "Create reviewer records from existing paper reviewers"
+  task populate_from_papers: :environment do
+    puts "Creating reviewer records from existing papers..."
+    
+    # Get all unique reviewer GitHub usernames from papers
+    reviewer_usernames = Paper.where.not(reviewers: []).pluck(:reviewers).flatten.uniq
+    
+    created_count = 0
+    reviewer_usernames.each do |username|
+      # Remove @ prefix if present
+      clean_username = username.gsub(/^@/, '')
+      
+      # Create reviewer record if it doesn't exist
+      reviewer = Reviewer.find_or_create_by(github_username: clean_username)
+      if reviewer.persisted? && reviewer.previously_new_record?
+        created_count += 1
+        puts "Created reviewer: #{clean_username}"
+      end
+    end
+    
+    puts "Created #{created_count} new reviewer records"
+    puts "Total reviewers in database: #{Reviewer.count}"
+  end
+  
+  desc "List reviewers without ORCID authentication"
+  task list_without_orcid: :environment do
+    reviewers_without_orcid = Reviewer.left_joins(:user).where(users: { provider: nil }).or(
+      Reviewer.left_joins(:user).where(users: { provider: ['', nil] })
+    )
+    
+    puts "Reviewers without ORCID authentication (#{reviewers_without_orcid.count}):"
+    reviewers_without_orcid.each do |reviewer|
+      puts "- @#{reviewer.github_username}"
+    end
+  end
+  
+  desc "Link reviewers to existing ORCID-authenticated users"
+  task link_to_orcid_users: :environment do
+    orcid_users = User.where(provider: 'orcid')
+    reviewers_without_orcid = Reviewer.left_joins(:user).where(users: { provider: nil }).or(
+      Reviewer.left_joins(:user).where(users: { provider: ['', nil] })
+    )
+    
+    puts "Linking reviewers to ORCID-authenticated users..."
+    linked_count = 0
+    
+    reviewers_without_orcid.each do |reviewer|
+      # Try to find a matching user by email or name
+      matching_user = orcid_users.find do |user|
+        (user.email.present? && user.email == reviewer.email) ||
+        (user.github_username.present? && user.github_username == reviewer.github_username)
+      end
+      
+      if matching_user
+        reviewer.update!(user: matching_user)
+        linked_count += 1
+        puts "Linked @#{reviewer.github_username} to ORCID user #{matching_user.name} (#{matching_user.uid})"
+      end
+    end
+    
+    puts "Linked #{linked_count} reviewers to ORCID-authenticated users"
+  end
+end

--- a/spec/models/reviewer_spec.rb
+++ b/spec/models/reviewer_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.describe Reviewer, type: :model do
+  describe 'validations' do
+    it 'requires github_username' do
+      reviewer = Reviewer.new
+      expect(reviewer).not_to be_valid
+      expect(reviewer.errors[:github_username]).to include("can't be blank")
+    end
+
+    it 'requires unique github_username' do
+      Reviewer.create!(github_username: 'testuser')
+      reviewer = Reviewer.new(github_username: 'testuser')
+      expect(reviewer).not_to be_valid
+      expect(reviewer.errors[:github_username]).to include('has already been taken')
+    end
+
+    it 'requires unique orcid_id when present' do
+      Reviewer.create!(github_username: 'user1', orcid_id: '0000-0000-0000-0000')
+      reviewer = Reviewer.new(github_username: 'user2', orcid_id: '0000-0000-0000-0000')
+      expect(reviewer).not_to be_valid
+      expect(reviewer.errors[:orcid_id]).to include('has already been taken')
+    end
+  end
+
+  describe 'normalizations' do
+    it 'removes @ prefix from github_username' do
+      reviewer = Reviewer.create!(github_username: '@testuser')
+      expect(reviewer.github_username).to eq('testuser')
+    end
+  end
+
+  describe 'methods' do
+    let(:reviewer) { Reviewer.create!(github_username: 'testuser', orcid_id: '0000-0000-0000-0000') }
+
+    describe '#orcid_url' do
+      it 'returns ORCID URL when orcid_id is present' do
+        expect(reviewer.orcid_url).to eq('https://orcid.org/0000-0000-0000-0000')
+      end
+
+      it 'returns nil when orcid_id is blank' do
+        reviewer.update!(orcid_id: nil)
+        expect(reviewer.orcid_url).to be_nil
+      end
+    end
+
+    describe '#display_name' do
+      it 'returns name when present' do
+        reviewer.update!(name: 'Test User')
+        expect(reviewer.display_name).to eq('Test User')
+      end
+
+      it 'returns github_username when name is blank' do
+        reviewer.update!(name: nil)
+        expect(reviewer.display_name).to eq('testuser')
+      end
+    end
+
+    describe '.find_or_create_by_github' do
+      it 'creates new reviewer' do
+        expect {
+          Reviewer.find_or_create_by_github('newuser')
+        }.to change(Reviewer, :count).by(1)
+      end
+
+      it 'finds existing reviewer' do
+        existing = Reviewer.create!(github_username: 'existinguser')
+        found = Reviewer.find_or_create_by_github('@existinguser')
+        expect(found).to eq(existing)
+      end
+    end
+  end
+end

--- a/spec/services/orcid_service_spec.rb
+++ b/spec/services/orcid_service_spec.rb
@@ -1,0 +1,98 @@
+require 'rails_helper'
+
+RSpec.describe OrcidService, type: :service do
+  let(:paper) { create(:accepted_paper) }
+  let(:orcid_id) { '0000-0000-0000-0000' }
+  let(:service) { described_class.new }
+
+  before do
+    allow(Rails.configuration).to receive(:orcid).and_return({
+      'access_token' => 'test_token'
+    })
+  end
+
+  describe '#post_work_to_author' do
+    it 'returns false when orcid_id is blank' do
+      result = service.post_work_to_author('', paper)
+      expect(result).to be false
+    end
+
+    it 'returns false when paper doi is blank' do
+      paper.update!(doi: nil)
+      result = service.post_work_to_author(orcid_id, paper)
+      expect(result).to be false
+    end
+
+    it 'makes HTTP request to ORCID API' do
+      stub_request(:post, "https://api.orcid.org/v3.0/#{orcid_id}/works")
+        .with(
+          headers: {
+            'Content-Type' => 'application/vnd.orcid+json',
+            'Authorization' => 'Bearer test_token'
+          }
+        )
+        .to_return(status: 201)
+
+      result = service.post_work_to_author(orcid_id, paper)
+      expect(result).to be true
+    end
+
+    it 'handles API errors gracefully' do
+      stub_request(:post, "https://api.orcid.org/v3.0/#{orcid_id}/works")
+        .to_return(status: 400)
+
+      result = service.post_work_to_author(orcid_id, paper)
+      expect(result).to be false
+    end
+  end
+
+  describe '#post_review_to_reviewer' do
+    let(:review_url) { 'https://github.com/test/repo/issues/123' }
+
+    it 'returns false when orcid_id is blank' do
+      result = service.post_review_to_reviewer('', paper, review_url)
+      expect(result).to be false
+    end
+
+    it 'makes HTTP request to ORCID API' do
+      stub_request(:post, "https://api.orcid.org/v3.0/#{orcid_id}/peer-reviews")
+        .with(
+          headers: {
+            'Content-Type' => 'application/vnd.orcid+json',
+            'Authorization' => 'Bearer test_token'
+          }
+        )
+        .to_return(status: 201)
+
+      result = service.post_review_to_reviewer(orcid_id, paper, review_url)
+      expect(result).to be true
+    end
+  end
+
+  describe '#build_work_data' do
+    it 'builds correct work data structure' do
+      work_data = service.send(:build_work_data, paper)
+      
+      expect(work_data['title']['title']['value']).to eq(paper.title)
+      expect(work_data['journal-title']['value']).to eq('Journal of Open Source Software')
+      expect(work_data['type']).to eq('software')
+      expect(work_data['external-ids']['external-id'].first['external-id-type']).to eq('doi')
+      expect(work_data['external-ids']['external-id'].first['external-id-value']).to eq(paper.doi)
+    end
+  end
+
+  describe '#build_peer_review_data' do
+    let(:review_url) { 'https://github.com/test/repo/issues/123' }
+
+    it 'builds correct peer review data structure' do
+      review_data = service.send(:build_peer_review_data, paper, review_url)
+      
+      expect(review_data['reviewer-role']).to eq('reviewer')
+      expect(review_data['review-url']['value']).to eq(review_url)
+      expect(review_data['review-type']).to eq('review')
+      expect(review_data['review-group-id']).to eq('journal-of-open-source-software')
+      expect(review_data['subject-external-identifier']['external-id-type']).to eq('doi')
+      expect(review_data['subject-external-identifier']['external-id-value']).to eq(paper.doi)
+    end
+  end
+end


### PR DESCRIPTION
This PR implements ORCID integration for JOSS reviewers to automatically post peer review activities to their ORCID profiles when papers are accepted.

https://github.com/openjournals/joss/issues/813
https://github.com/openjournals/joss/issues/624