### PR TITLE
Update Elasticsearch version in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Elasticsearch
         uses: ankane/setup-elasticsearch@v1
         with:
-          elasticsearch-version: 7.12.0
+          elasticsearch-version: 9
       - name: Verify Elasticsearch connection and create index
         env:
           ELASTICSEARCH_URL: http://localhost:9200


### PR DESCRIPTION
This PR updates the CI workflow to use ElasticSearch version 9 when running tests.

Currently every build is failing because the version we are running in the production server is not supported in the elasticsearch GitHub action anymore.

So this is just a temporary fix, because it will cause a difference between the enviroments in production and testing, but will allow us to continue running tests in a GH workflow.