### PR TITLE
[DOC] Correctly specify formatting for ROR affiliation

### DIFF
--- a/docs/paper.md
+++ b/docs/paper.md
@@ -127,7 +127,7 @@ affiliations:
     name: Gadjah Mada University, Indonesia
   - index: 3
     name: Technische Universitaet Hamburg, Germany
-    ror: 04bs1pb34
+    ror: "04bs1pb34"
 ```
 
 ## Internal references


### PR DESCRIPTION
During my review of a JOSS paper, we came across an issue where the ROR links rendered in the manuscript PDF were broken:
https://github.com/ADSCIAN/ssalib/issues/8#issuecomment-3460343108

The author @dadelforge found that adding quotation marks resolved the issue. This PR updates the recommended formatting to resolve this issue.