### PR TITLE
Adding banner to JOSS site

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1005,3 +1005,19 @@ header {
 table.sortable th:not(.sorttable_sorted):not(.sorttable_sorted_reverse):not(.sorttable_nosort):after {
     content: " \25B4\25BE"
 }
+
+// Scope update banner
+.scope-update-banner {
+    margin-bottom: 1.5em;
+    border-left: 4px solid #0c5460;
+
+    .container {
+        padding: 0;
+    }
+
+    .close {
+        position: absolute;
+        right: 1rem;
+        top: 0.5rem;
+    }
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -69,4 +69,10 @@ module ApplicationHelper
     links << link_to("Mastodon", setting(:mastodon_url), target: "_blank", rel: "me", title: "#{setting(:mastodon_url)}").html_safe if setting(:mastodon_url).present?
     links
   end
+
+  # Decide whether to show the scope update banner
+  def show_scope_update_banner?
+    # Don't show if user has dismissed it (cookie check)
+    cookies[:scope_banner_dismissed] != "true"
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -73,6 +73,7 @@
       <%= render partial: "shared/flashes" %>
     </div>
     <%= render partial: "shared/profile" if show_profile_banner? %>
+    <%= render partial: "shared/scope_update_banner" if show_scope_update_banner? %>
   </div>
 
   <%= yield %>

--- a/app/views/shared/_scope_update_banner.html.erb
+++ b/app/views/shared/_scope_update_banner.html.erb
@@ -1,0 +1,17 @@
+<div class="alert alert-info scope-update-banner" role="alert" id="scope-update-banner">
+  <div class="container">
+    <button type="button" class="close" data-dismiss="alert" aria-label="Close" onclick="dismissScopeBanner()">
+      <span aria-hidden="true">&times;</span>
+    </button>
+    <strong>Important Update:</strong> <%= Rails.application.settings["abbreviation"] %> has updated its submission scope requirements, affecting what is eligible for submission and what information is required in your paper.
+    <%= link_to "Read the announcement &rarr;".html_safe, "https://blog.joss.theoj.org/2026/01/preparing-joss-for-a-generative-ai-future", target: "_blank", class: "alert-link" %> • 
+    <%= link_to "View updated requirements &rarr;".html_safe, "https://joss.readthedocs.io/en/latest/submitting.html#scope-and-significance", target: "_blank", class: "alert-link" %>
+  </div>
+</div>
+
+<script>
+function dismissScopeBanner() {
+  document.cookie = "scope_banner_dismissed=true; max-age=2592000; path=/"; // 30 days
+  document.getElementById('scope-update-banner').style.display = 'none';
+}
+</script>


### PR DESCRIPTION
This pull request adds a dismissible banner to notify users about updated submission scope requirements. The banner appears at the top of the application unless the user has previously dismissed it, in which case it is hidden via a cookie. The implementation includes new styles, a helper method, a partial view, and integration into the main layout.
