### PR TITLE
Remove link to now defunk Syllabus Journal

### DIFF
--- a/app/views/content/about/_general.html.erb
+++ b/app/views/content/about/_general.html.erb
@@ -47,8 +47,7 @@
 <p>
   We do <strong>not</strong> mean openly available slides, lecture notes, or YouTube videos,
   though these may be acceptable as supplementary materials. In addition, course syllabi
-  by themselves are not suitable for submission
-  (<a href="http://syllabusjournal.org/" target="_blank"><em>Syllabus</em></a> may be more appropriate).
+  by themselves are not suitable for submission.
 </p>
 
 <p>


### PR DESCRIPTION
This link now directs to a gambling website and there is now sign from a quick search that the journal remains active elsewhere.