### PR TITLE
Add AI Policy link to about page side navigation

### DIFF
--- a/app/views/home/about.html.erb
+++ b/app/views/home/about.html.erb
@@ -297,6 +297,7 @@
         <a class="menu-item" href="#contact">Contact <%= setting(:abbreviation) %></a>
         <a class="menu-item" href="#code_of_conduct">Code of Conduct</a>
         <a class="menu-item" href="#ethics">Ethics Guidelines</a>
+        <a class="menu-item" href="#ai-policy">AI Usage Policy</a>
         <a class="menu-item" href="#costs">Cost and Sustainability Model</a>
         <a class="menu-item" href="#content_license">Content Licensing &amp; Open Access</a>
       </nav>


### PR DESCRIPTION
This pull request adds a new menu item to the About page navigation for the AI Policy section.
