### PR TITLE
Updating language around collaborative effort for docs

### DIFF
--- a/docs/review_criteria.md
+++ b/docs/review_criteria.md
@@ -57,7 +57,7 @@ The project should show evidence of sustained development over time (preferably 
 - Evolution of features and capabilities
 
 > **Good:** Commits distributed over 6+ months showing gradual feature development<br />
-> **OK:** Shorter development period but clear evidence of iterative refinement and sustained effort<br />
+> **OK:** Development spanning 6+ months but with sporadic or bursty activity patterns (e.g., concentrated bursts, rather than steady continuous development)<br />
 > **Not acceptable:** All or most commits concentrated in the last few weeks before submission
 
 #### Open development


### PR DESCRIPTION
Tweaking reviewer guidelines around collaborative effort, development timeline, and open development:

1. Collaborative effort: Added Good/OK/Not acceptable thresholds
2. Development timeline: Added an OK tier and renamed "Concerning" to "Not acceptable":                                                 
3. Open development: Renamed "Concerning" to "Not acceptable" for consistency with the rest of the thresholds.

The goal here is to give reviewers clearer guidance, particularly that single-author submissions are acceptable as long as there's some evidence of community engagement.

