### PR TITLE
Fix clipboard copy buttons broken

### DIFF
--- a/app/javascript/custom/clipboards.js
+++ b/app/javascript/custom/clipboards.js
@@ -1,5 +1,9 @@
-$(document).ready(function(){
-  if (typeof ClipboardJS !== 'undefined') {
-    new ClipboardJS('.clipboard-btn')
-  }
+document.addEventListener('DOMContentLoaded', function() {
+  new ClipboardJS('.clipboard-btn');
+
+  document.querySelectorAll('a.clipboard-btn').forEach(function(el) {
+    el.addEventListener('click', function(e) {
+      e.preventDefault();
+    });
+  });
 });


### PR DESCRIPTION
Replace jQuery $(document).ready() with native DOMContentLoaded to remove the implicit jQuery dependency that caused a silent ReferenceError in Firefox, preventing ClipboardJS from ever initialising. Also call preventDefault() on anchor clipboard buttons to stop href="#" scrolling the page to the top after a successful copy in Chromium.