### PR TITLE
Disable submit button on homepage

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -5,7 +5,7 @@
       <p class="lead">Committed to publishing quality research software with zero article processing charges or
         subscription fees.</p>
       <div class="hero-ctas">
-        <%= link_to "Submit a paper to #{Rails.application.settings['abbreviation']}".html_safe, new_paper_path, class: "btn" %>
+        <%# link_to "Submit a paper to #{Rails.application.settings['abbreviation']}".html_safe, new_paper_path, class: "btn" %>
         <%= link_to "🎉 Volunteer to review".html_safe, setting(:reviewers_signup_url), class: "btn" %>
       </div>
     </div>


### PR DESCRIPTION
This PR disables the submit button on the website homepage until we accept new submission again after JuliaCon 2026.