### PR TITLE
Raise 404 for unpublished pdfs

### DIFF
--- a/app/controllers/papers_controller.rb
+++ b/app/controllers/papers_controller.rb
@@ -286,6 +286,7 @@ class PapersController < ApplicationController
     respond_to do |format|
       format.html { render layout: false }
       format.pdf {
+        return head :not_found unless @paper.doi.present?
         data = URI.open(@paper.pdf_url)
         send_data data.read,
           :type => data.content_type,

--- a/spec/controllers/papers_controller_spec.rb
+++ b/spec/controllers/papers_controller_spec.rb
@@ -355,6 +355,15 @@ describe PapersController, type: :controller do
     end
   end
 
+  describe "PDF requests" do
+    it "returns 404 for a PDF request for an unpublished paper" do
+      paper = create(:submitted_paper)
+
+      get :show, params: {id: paper.sha}, format: "pdf"
+      expect(response.status).to eq(404)
+    end
+  end
+
   describe "Status badges" do
     it "should return the correct status badge for a submitted paper" do
       submitted_paper = create(:paper, state: 'submitted')

--- a/spec/controllers/papers_controller_spec.rb
+++ b/spec/controllers/papers_controller_spec.rb
@@ -357,7 +357,7 @@ describe PapersController, type: :controller do
 
   describe "PDF requests" do
     it "returns 404 for a PDF request for an unpublished paper" do
-      paper = create(:submitted_paper)
+      paper = create(:under_review_paper)
 
       get :show, params: {id: paper.sha}, format: "pdf"
       expect(response.status).to eq(404)


### PR DESCRIPTION
Sometimes people (or bots) attempt to retrieve PDFs before they are published. This returns a `404` to avoid raising other errors in the response.