### PR TITLE
Adding UI element to show previous submissions for the same git url

### DIFF
--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -186,6 +186,23 @@ class Paper < ApplicationRecord
     recent
   end
 
+  def self.prior_submissions_for(repository_url, excluding_id: nil)
+    return none if repository_url.blank?
+
+    scope = where("lower(repository_url) IN (?)", repository_url_variants(repository_url))
+    scope = scope.where.not(id: excluding_id) if excluding_id
+    scope
+  end
+
+  def self.repository_url_variants(repository_url)
+    base = repository_url.to_s.downcase.strip.sub(/\/?(\.git\/?)?\z/, '')
+    [base, "#{base}/", "#{base}.git", "#{base}.git/"].uniq
+  end
+
+  def prior_submissions
+    self.class.prior_submissions_for(repository_url, excluding_id: id)
+  end
+
   def published?
     accepted? || retracted?
   end

--- a/app/views/papers/_resubmission_check.html.erb
+++ b/app/views/papers/_resubmission_check.html.erb
@@ -1,0 +1,26 @@
+<% priors = paper.prior_submissions %>
+<% if priors.any? %>
+  <div class="card border-warning">
+    <div class="card-header bg-warning">
+      Possible resubmission
+    </div>
+    <div class="card-body">
+      <p class="card-text">
+        <%= pluralize(priors.size, 'other paper') %> with the same repository address
+        <% if paper.repository_url.present? %>
+          (<%= link_to paper.repository_url, paper.repository_url, target: "_blank", rel: "noopener" %>)
+        <% end %>:
+      </p>
+      <ul class="card-text">
+        <% priors.each do |prior| %>
+          <li>
+            <%= link_to prior.title, prior.doi? ? prior.seo_url : paper_path(prior) %>
+            &mdash; <strong><%= prior.pretty_state %></strong>
+            <span class="text-muted">(submitted <%= prior.created_at.to_date.to_formatted_s(:long) %>)</span>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+  <br />
+<% end %>

--- a/app/views/papers/_show_unpublished.html.erb
+++ b/app/views/papers/_show_unpublished.html.erb
@@ -11,6 +11,7 @@
   <div class="row">
     <div id="joss-paper-pdf-container" class="col-md-9">
       <div class="generic-content-item" style="margin-top: 0;">
+        <%= render partial: "papers/resubmission_check", locals: { paper: @paper } if current_editor %>
         <%= render partial: "papers/status", locals: { paper: @paper } %>
         <%= render partial: "papers/eic_summary", locals: { paper: @paper } if current_user %>
         <%= render partial: "papers/vote_summary", locals: { paper: @paper } if current_editor %>

--- a/app/views/papers/admin.html.erb
+++ b/app/views/papers/admin.html.erb
@@ -32,6 +32,7 @@
       <div class="col-md-9">
         <div class="generic-content-item" style="margin-top: 0;">
           <%= render partial: "papers/status", locals: { paper: @paper } %>
+          <%= render partial: "papers/resubmission_check", locals: { paper: @paper } %>
           <%= render partial: "papers/eic_summary", locals: { paper: @paper } %>
           <%= render partial: "papers/notes", locals: { paper: @paper } %>
           <%= render partial: "papers/actions", locals: { paper: @paper } %>

--- a/app/views/papers/admin.html.erb
+++ b/app/views/papers/admin.html.erb
@@ -31,8 +31,8 @@
     <div class="row">
       <div class="col-md-9">
         <div class="generic-content-item" style="margin-top: 0;">
-          <%= render partial: "papers/status", locals: { paper: @paper } %>
           <%= render partial: "papers/resubmission_check", locals: { paper: @paper } %>
+          <%= render partial: "papers/status", locals: { paper: @paper } %>
           <%= render partial: "papers/eic_summary", locals: { paper: @paper } %>
           <%= render partial: "papers/notes", locals: { paper: @paper } %>
           <%= render partial: "papers/actions", locals: { paper: @paper } %>

--- a/db/migrate/20260503000001_add_index_on_papers_repository_url_lower.rb
+++ b/db/migrate/20260503000001_add_index_on_papers_repository_url_lower.rb
@@ -1,0 +1,11 @@
+class AddIndexOnPapersRepositoryUrlLower < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def up
+    execute "CREATE INDEX CONCURRENTLY IF NOT EXISTS index_papers_on_lower_repository_url ON papers (lower(repository_url))"
+  end
+
+  def down
+    execute "DROP INDEX CONCURRENTLY IF EXISTS index_papers_on_lower_repository_url"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_02_27_000001) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_03_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_stat_statements"
@@ -115,6 +115,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_27_000001) do
     t.bigint "track_id"
     t.string "suggested_subject"
     t.bigint "retraction_for_id"
+    t.index "lower((repository_url)::text)", name: "index_papers_on_lower_repository_url"
     t.index ["editor_id"], name: "index_papers_on_editor_id"
     t.index ["eic_id"], name: "index_papers_on_eic_id"
     t.index ["labels"], name: "index_papers_on_labels", using: :gin

--- a/spec/models/paper_spec.rb
+++ b/spec/models/paper_spec.rb
@@ -160,6 +160,42 @@ describe Paper do
     expect(paper.pretty_repository_name).to eq("openjournals / joss-reviews")
   end
 
+  describe "#prior_submissions" do
+    before { allow_any_instance_of(Paper).to receive(:check_repository_address).and_return(true) }
+
+    it "returns other papers that share the same repository_url" do
+      original = create(:paper, repository_url: "https://github.com/foo/bar", state: "rejected")
+      resubmission = create(:paper, repository_url: "https://github.com/foo/bar")
+
+      expect(resubmission.prior_submissions).to contain_exactly(original)
+    end
+
+    it "matches across case, trailing slash, and .git suffix variants" do
+      original = create(:paper, repository_url: "https://github.com/Foo/Bar.git")
+      resubmission = create(:paper, repository_url: "https://github.com/foo/bar/")
+
+      expect(resubmission.prior_submissions).to contain_exactly(original)
+    end
+
+    it "excludes the paper itself" do
+      paper = create(:paper, repository_url: "https://github.com/foo/bar")
+
+      expect(paper.prior_submissions).to be_empty
+    end
+
+    it "returns nothing when no other paper shares the repo" do
+      create(:paper, repository_url: "https://github.com/foo/other")
+      paper = create(:paper, repository_url: "https://github.com/foo/bar")
+
+      expect(paper.prior_submissions).to be_empty
+    end
+
+    it "returns nothing for blank repository_url" do
+      expect(Paper.prior_submissions_for("")).to be_empty
+      expect(Paper.prior_submissions_for(nil)).to be_empty
+    end
+  end
+
   it 'should know how to return the archive DOI with a full URL' do
     paper = create(:paper, archive_doi: '10.6084/m9.figshare.828487')
 


### PR DESCRIPTION
This pull request introduces a feature to detect and display possible resubmissions of papers based on their repository URLs. It adds logic to identify prior submissions with matching repository addresses (accounting for common URL variants), surfaces this information in the admin UI, and optimizes the database for efficient lookup. Comprehensive tests are included to ensure correct behavior.

Key changes:

Resubmission detection logic:
* Added `prior_submissions` instance method and supporting class methods to the `Paper` model, allowing lookup of other papers with the same (or variant) repository URL, excluding the current paper. This includes normalization to handle differences in case, trailing slashes, and `.git` suffixes.

Admin UI enhancements:
* Introduced a new partial, `_resubmission_check.html.erb`, which displays a warning card in the admin view if prior submissions with the same repository URL exist, including links and submission details.
* Updated the `admin.html.erb` template to render the resubmission check partial.

Database performance improvements:
* Added a concurrent index on `lower(repository_url)` in the `papers` table to speed up case-insensitive lookups for repository URLs. Includes migration and schema updates. 

Testing:
* Added model specs to verify the correct identification of prior submissions, including handling of URL variants, exclusion of the current paper, and behavior with blank URLs.