### PR TITLE
Editor badges :)

### DIFF
--- a/app/controllers/badges_controller.rb
+++ b/app/controllers/badges_controller.rb
@@ -24,6 +24,18 @@ class BadgesController < ApplicationController
     }
   end
 
+  def edited_by
+    n_edits = Paper.visible.where(":editor = editor", editor: params[:editor]).count
+    @key = string_item("JOSS Editor", COLORS[:gray])
+    @value = string_item(n_edits.to_s, COLORS[:blue], @key[:outer_width])
+    @badge_width = @key[:outer_width] + @value[:outer_width]
+
+    render template: 'badges/badge', locals: {
+      scale_up_factor: SCALE_UP_FACTOR,
+      scale_down_factor: SCALE_DOWN_FACTOR
+    }
+  end
+
   private
 
   def string_item(str, color, offset=0)

--- a/app/controllers/badges_controller.rb
+++ b/app/controllers/badges_controller.rb
@@ -9,7 +9,8 @@ class BadgesController < ApplicationController
 
   COLORS = {
     gray: "#555",
-    blue: "#007ec6"
+    blue: "#007ec6",
+    purple: "#4f4686"
   }
 
   def reviewed_by
@@ -25,9 +26,12 @@ class BadgesController < ApplicationController
   end
 
   def edited_by
-    n_edits = Paper.visible.where(":editor = editor", editor: params[:editor]).count
+    n_edits = Paper.visible
+                   .joins("JOIN editors ON editors.id = papers.editor_id")
+                   .where(editors: {login:params[:editor]})
+                   .count
     @key = string_item("JOSS Editor", COLORS[:gray])
-    @value = string_item(n_edits.to_s, COLORS[:blue], @key[:outer_width])
+    @value = string_item(n_edits.to_s, COLORS[:purple], @key[:outer_width])
     @badge_width = @key[:outer_width] + @value[:outer_width]
 
     render template: 'badges/badge', locals: {

--- a/app/controllers/badges_controller.rb
+++ b/app/controllers/badges_controller.rb
@@ -26,8 +26,8 @@ class BadgesController < ApplicationController
   end
 
   def edited_by
-  login = params[:editor].to_s.delete_prefix('@').downcase
-  n_edits = Paper.joins(:editor).where("lower(editors.login) = ?", login).count
+    login = params[:editor].to_s.delete_prefix('@').downcase
+    n_edits = Paper.joins(:editor).where("lower(editors.login) = ?", login).count
     @key = string_item("JOSS Editor", COLORS[:gray])
     @value = string_item(n_edits.to_s, COLORS[:purple], @key[:outer_width])
     @badge_width = @key[:outer_width] + @value[:outer_width]

--- a/app/controllers/badges_controller.rb
+++ b/app/controllers/badges_controller.rb
@@ -26,8 +26,7 @@ class BadgesController < ApplicationController
   end
 
   def edited_by
-    n_edits = Paper.visible
-                   .joins("JOIN editors ON editors.id = papers.editor_id")
+    n_edits = Paper.joins("JOIN editors ON editors.id = papers.editor_id")
                    .where(editors: { login: params[:editor] })
                    .count
     @key = string_item("JOSS Editor", COLORS[:gray])

--- a/app/controllers/badges_controller.rb
+++ b/app/controllers/badges_controller.rb
@@ -26,9 +26,8 @@ class BadgesController < ApplicationController
   end
 
   def edited_by
-    n_edits = Paper.joins("JOIN editors ON editors.id = papers.editor_id")
-                   .where(editors: { login: params[:editor] })
-                   .count
+    login = params[:editor].to_s.delete_prefix('@').downcase
+    n_edits = Paper.joins(:editor).where("lower(editors.login) = ?", login).count
     @key = string_item("JOSS Editor", COLORS[:gray])
     @value = string_item(n_edits.to_s, COLORS[:purple], @key[:outer_width])
     @badge_width = @key[:outer_width] + @value[:outer_width]

--- a/app/controllers/badges_controller.rb
+++ b/app/controllers/badges_controller.rb
@@ -28,7 +28,7 @@ class BadgesController < ApplicationController
   def edited_by
     n_edits = Paper.visible
                    .joins("JOIN editors ON editors.id = papers.editor_id")
-                   .where(editors: {login:params[:editor]})
+                   .where(editors: { login: params[:editor] })
                    .count
     @key = string_item("JOSS Editor", COLORS[:gray])
     @value = string_item(n_edits.to_s, COLORS[:purple], @key[:outer_width])

--- a/app/controllers/badges_controller.rb
+++ b/app/controllers/badges_controller.rb
@@ -26,9 +26,8 @@ class BadgesController < ApplicationController
   end
 
   def edited_by
-    n_edits = Paper.joins("JOIN editors ON editors.id = papers.editor_id")
-                   .where(editors: { login: params[:editor] })
-                   .count
+  login = params[:editor].to_s.delete_prefix('@').downcase
+  n_edits = Paper.joins(:editor).where("lower(editors.login) = ?", login).count
     @key = string_item("JOSS Editor", COLORS[:gray])
     @value = string_item(n_edits.to_s, COLORS[:purple], @key[:outer_width])
     @badge_width = @key[:outer_width] + @value[:outer_width]

--- a/app/controllers/papers_controller.rb
+++ b/app/controllers/papers_controller.rb
@@ -109,6 +109,7 @@ class PapersController < ApplicationController
                   page: params[:page],
                   per_page: 10)
       @term = "edited by #{params['editor']}"
+      @badge = {type: "editor", value: params['editor']}
     elsif params['reviewer']
       @papers = Paper.search(params['reviewer'], fields: [:reviewers], misspellings: false, order: { accepted_at: :desc },
                   page: params[:page],

--- a/app/views/papers/_badge.html.erb
+++ b/app/views/papers/_badge.html.erb
@@ -1,12 +1,15 @@
 <% if badge[:type] == 'reviewer' %>
   <% badge_url = badges_by_reviewer_url(reviewer: badge[:value]) %>
   <% badge_markdown = "[![JOSS Reviews](#{badge_url})](#{papers_by_reviewer_url(reviewer: badge[:value])})" %>
+<% elsif badge[:type] == 'editor' %>
+  <% badge_url = badges_by_editor_url(editor: badge[:value]) %>
+  <% badge_markdown = "[![JOSS Editor](#{badge_url})](#{papers_by_editor_url(editor: badge[:value])})" %>
 <% else %>
   <% badge_url = "" %>
   <% badge_markdown = "" %>
 <% end %>
 <div class="badge-container" id="markdown-badge">
-  <img id="reviewer-badge" src="<%= badge_url %>">
+  <img id="joss-badge" src="<%= badge_url %>">
     <button
       id="badge-copy-button"
       class="btn btn-outline-secondary btn-sm"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,7 @@ Rails.application.routes.draw do
 
   get '/blog' => redirect("http://blog.joss.theoj.org"), as: :blog
 
+  get '/badges/edited_by/:editor', to: "badges#edited_by", format: "svg", as: "badges_by_editor"
   get '/badges/reviewed_by/:reviewer', to: "badges#reviewed_by", format: "svg", as: "badges_by_reviewer"
 
   # API methods

--- a/spec/controllers/badges_controller_spec.rb
+++ b/spec/controllers/badges_controller_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.describe BadgesController, type: :controller do
+  render_views
+
+  describe "GET #edited_by" do
+    let(:editor) { create(:editor, login: "editor-jane") }
+
+    # Pulls the count out of the SVG's aria-label, which is rendered as
+    # `aria-label="JOSS Editor: 3"` by app/views/badges/badge.svg.erb.
+    def rendered_count
+      response.body[/aria-label="JOSS Editor: (\d+)"/, 1]
+    end
+
+    it "renders an SVG badge for the editor" do
+      get :edited_by, params: { editor: editor.login }, format: :svg
+
+      expect(response).to be_successful
+      expect(response.content_type).to include("image/svg+xml")
+      expect(response.body).to include('aria-label="JOSS Editor:')
+    end
+
+    it "counts papers edited by the given editor" do
+      create_list(:accepted_paper, 3, editor: editor)
+      get :edited_by, params: { editor: editor.login }, format: :svg
+
+      expect(rendered_count).to eq("3")
+    end
+
+    it "counts papers in any state, including rejected and retracted" do
+      create(:accepted_paper,  editor: editor)
+      create(:rejected_paper,  editor: editor)
+      create(:retracted_paper, editor: editor)
+      get :edited_by, params: { editor: editor.login }, format: :svg
+
+      expect(rendered_count).to eq("3")
+    end
+
+    it "returns 0 for an editor with no papers" do
+      get :edited_by, params: { editor: editor.login }, format: :svg
+
+      expect(rendered_count).to eq("0")
+    end
+
+    it "does not count papers edited by other editors" do
+      other = create(:editor, login: "someone-else")
+      create_list(:accepted_paper, 2, editor: other)
+      create(:accepted_paper, editor: editor)
+      get :edited_by, params: { editor: editor.login }, format: :svg
+
+      expect(rendered_count).to eq("1")
+    end
+
+    it "returns 0 for an unknown editor login" do
+      get :edited_by, params: { editor: "no-such-editor" }, format: :svg
+
+      expect(rendered_count).to eq("0")
+    end
+
+    it "matches editor login case-insensitively" do
+      create(:accepted_paper, editor: editor)
+      get :edited_by, params: { editor: editor.login.upcase }, format: :svg
+
+      expect(rendered_count).to eq("1")
+    end
+
+    it "tolerates a leading @ on the editor login" do
+      create(:accepted_paper, editor: editor)
+      get :edited_by, params: { editor: "@#{editor.login}" }, format: :svg
+
+      expect(rendered_count).to eq("1")
+    end
+  end
+end


### PR DESCRIPTION
i had a few minutes free and was like hey why don't we have editor badges.

Pretty much the same thing as #1389 , which was written with this in mind anyway. hopefully self explanatory.

@arfon i don't know if we need the migration/fix from #1509 , since editors actually do have their own table/model? i see that there is some handling of the editor in the metadata dict though - unsure how to test rly because it works fine with the seed data, and not sure how to simulate the process that happens in prod so i can write an rspec test for it.

anyway, ezpz hopefully.

i made it purple because the footer is purple and the buttons are purple, but i lightened it up a tiny bit because in such a small area it was just reading as black. but obvi i can change it to match and also make it whatever other color

I removed the `visible` scope from this badge, since papers that were rejected or withdrawn should still count as performing your editorial duty!

<img width="1052" height="650" alt="Screenshot 2026-05-07 at 4 10 12 PM" src="https://github.com/user-attachments/assets/34d9c9e6-3763-433d-9888-f3ec253bec7c" />
