### PR TITLE
Editor badges (the production deploy)

### DIFF
--- a/app/controllers/badges_controller.rb
+++ b/app/controllers/badges_controller.rb
@@ -24,6 +24,18 @@ class BadgesController < ApplicationController
     }
   end
 
+  def edited_by
+    n_edits = Paper.visible.where(":editor = editor", editor: params[:editor]).count
+    @key = string_item("JOSS Editor", COLORS[:gray])
+    @value = string_item(n_edits.to_s, COLORS[:blue], @key[:outer_width])
+    @badge_width = @key[:outer_width] + @value[:outer_width]
+
+    render template: 'badges/badge', locals: {
+      scale_up_factor: SCALE_UP_FACTOR,
+      scale_down_factor: SCALE_DOWN_FACTOR
+    }
+  end
+
   private
 
   def string_item(str, color, offset=0)

--- a/app/controllers/badges_controller.rb
+++ b/app/controllers/badges_controller.rb
@@ -9,7 +9,8 @@ class BadgesController < ApplicationController
 
   COLORS = {
     gray: "#555",
-    blue: "#007ec6"
+    blue: "#007ec6",
+    purple: "#4f4686"
   }
 
   def reviewed_by
@@ -25,9 +26,12 @@ class BadgesController < ApplicationController
   end
 
   def edited_by
-    n_edits = Paper.visible.where(":editor = editor", editor: params[:editor]).count
+    n_edits = Paper.visible
+                   .joins("JOIN editors ON editors.id = papers.editor_id")
+                   .where(editors: {login:params[:editor]})
+                   .count
     @key = string_item("JOSS Editor", COLORS[:gray])
-    @value = string_item(n_edits.to_s, COLORS[:blue], @key[:outer_width])
+    @value = string_item(n_edits.to_s, COLORS[:purple], @key[:outer_width])
     @badge_width = @key[:outer_width] + @value[:outer_width]
 
     render template: 'badges/badge', locals: {

--- a/app/controllers/badges_controller.rb
+++ b/app/controllers/badges_controller.rb
@@ -26,8 +26,8 @@ class BadgesController < ApplicationController
   end
 
   def edited_by
-  login = params[:editor].to_s.delete_prefix('@').downcase
-  n_edits = Paper.joins(:editor).where("lower(editors.login) = ?", login).count
+    login = params[:editor].to_s.delete_prefix('@').downcase
+    n_edits = Paper.joins(:editor).where("lower(editors.login) = ?", login).count
     @key = string_item("JOSS Editor", COLORS[:gray])
     @value = string_item(n_edits.to_s, COLORS[:purple], @key[:outer_width])
     @badge_width = @key[:outer_width] + @value[:outer_width]

--- a/app/controllers/badges_controller.rb
+++ b/app/controllers/badges_controller.rb
@@ -26,8 +26,7 @@ class BadgesController < ApplicationController
   end
 
   def edited_by
-    n_edits = Paper.visible
-                   .joins("JOIN editors ON editors.id = papers.editor_id")
+    n_edits = Paper.joins("JOIN editors ON editors.id = papers.editor_id")
                    .where(editors: { login: params[:editor] })
                    .count
     @key = string_item("JOSS Editor", COLORS[:gray])

--- a/app/controllers/badges_controller.rb
+++ b/app/controllers/badges_controller.rb
@@ -26,9 +26,8 @@ class BadgesController < ApplicationController
   end
 
   def edited_by
-    n_edits = Paper.joins("JOIN editors ON editors.id = papers.editor_id")
-                   .where(editors: { login: params[:editor] })
-                   .count
+    login = params[:editor].to_s.delete_prefix('@').downcase
+    n_edits = Paper.joins(:editor).where("lower(editors.login) = ?", login).count
     @key = string_item("JOSS Editor", COLORS[:gray])
     @value = string_item(n_edits.to_s, COLORS[:purple], @key[:outer_width])
     @badge_width = @key[:outer_width] + @value[:outer_width]

--- a/app/controllers/badges_controller.rb
+++ b/app/controllers/badges_controller.rb
@@ -28,7 +28,7 @@ class BadgesController < ApplicationController
   def edited_by
     n_edits = Paper.visible
                    .joins("JOIN editors ON editors.id = papers.editor_id")
-                   .where(editors: {login:params[:editor]})
+                   .where(editors: { login: params[:editor] })
                    .count
     @key = string_item("JOSS Editor", COLORS[:gray])
     @value = string_item(n_edits.to_s, COLORS[:purple], @key[:outer_width])

--- a/app/controllers/badges_controller.rb
+++ b/app/controllers/badges_controller.rb
@@ -26,9 +26,8 @@ class BadgesController < ApplicationController
   end
 
   def edited_by
-    n_edits = Paper.joins("JOIN editors ON editors.id = papers.editor_id")
-                   .where(editors: { login: params[:editor] })
-                   .count
+  login = params[:editor].to_s.delete_prefix('@').downcase
+  n_edits = Paper.joins(:editor).where("lower(editors.login) = ?", login).count
     @key = string_item("JOSS Editor", COLORS[:gray])
     @value = string_item(n_edits.to_s, COLORS[:purple], @key[:outer_width])
     @badge_width = @key[:outer_width] + @value[:outer_width]

--- a/app/controllers/papers_controller.rb
+++ b/app/controllers/papers_controller.rb
@@ -109,6 +109,7 @@ class PapersController < ApplicationController
                   page: params[:page],
                   per_page: 10)
       @term = "edited by #{params['editor']}"
+      @badge = {type: "editor", value: params['editor']}
     elsif params['reviewer']
       @papers = Paper.search(params['reviewer'], fields: [:reviewers], misspellings: false, order: { accepted_at: :desc },
                   page: params[:page],

--- a/app/views/papers/_badge.html.erb
+++ b/app/views/papers/_badge.html.erb
@@ -1,12 +1,15 @@
 <% if badge[:type] == 'reviewer' %>
   <% badge_url = badges_by_reviewer_url(reviewer: badge[:value]) %>
   <% badge_markdown = "[![JOSS Reviews](#{badge_url})](#{papers_by_reviewer_url(reviewer: badge[:value])})" %>
+<% elsif badge[:type] == 'editor' %>
+  <% badge_url = badges_by_editor_url(editor: badge[:value]) %>
+  <% badge_markdown = "[![JOSS Editor](#{badge_url})](#{papers_by_editor_url(editor: badge[:value])})" %>
 <% else %>
   <% badge_url = "" %>
   <% badge_markdown = "" %>
 <% end %>
 <div class="badge-container" id="markdown-badge">
-  <img id="reviewer-badge" src="<%= badge_url %>">
+  <img id="joss-badge" src="<%= badge_url %>">
     <button
       id="badge-copy-button"
       class="btn btn-outline-secondary btn-sm"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,7 @@ Rails.application.routes.draw do
 
   get '/blog' => redirect("http://blog.joss.theoj.org"), as: :blog
 
+  get '/badges/edited_by/:editor', to: "badges#edited_by", format: "svg", as: "badges_by_editor"
   get '/badges/reviewed_by/:reviewer', to: "badges#reviewed_by", format: "svg", as: "badges_by_reviewer"
 
   # API methods

--- a/spec/controllers/badges_controller_spec.rb
+++ b/spec/controllers/badges_controller_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.describe BadgesController, type: :controller do
+  render_views
+
+  describe "GET #edited_by" do
+    let(:editor) { create(:editor, login: "editor-jane") }
+
+    # Pulls the count out of the SVG's aria-label, which is rendered as
+    # `aria-label="JOSS Editor: 3"` by app/views/badges/badge.svg.erb.
+    def rendered_count
+      response.body[/aria-label="JOSS Editor: (\d+)"/, 1]
+    end
+
+    it "renders an SVG badge for the editor" do
+      get :edited_by, params: { editor: editor.login }, format: :svg
+
+      expect(response).to be_successful
+      expect(response.content_type).to include("image/svg+xml")
+      expect(response.body).to include('aria-label="JOSS Editor:')
+    end
+
+    it "counts papers edited by the given editor" do
+      create_list(:accepted_paper, 3, editor: editor)
+      get :edited_by, params: { editor: editor.login }, format: :svg
+
+      expect(rendered_count).to eq("3")
+    end
+
+    it "counts papers in any state, including rejected and retracted" do
+      create(:accepted_paper,  editor: editor)
+      create(:rejected_paper,  editor: editor)
+      create(:retracted_paper, editor: editor)
+      get :edited_by, params: { editor: editor.login }, format: :svg
+
+      expect(rendered_count).to eq("3")
+    end
+
+    it "returns 0 for an editor with no papers" do
+      get :edited_by, params: { editor: editor.login }, format: :svg
+
+      expect(rendered_count).to eq("0")
+    end
+
+    it "does not count papers edited by other editors" do
+      other = create(:editor, login: "someone-else")
+      create_list(:accepted_paper, 2, editor: other)
+      create(:accepted_paper, editor: editor)
+      get :edited_by, params: { editor: editor.login }, format: :svg
+
+      expect(rendered_count).to eq("1")
+    end
+
+    it "returns 0 for an unknown editor login" do
+      get :edited_by, params: { editor: "no-such-editor" }, format: :svg
+
+      expect(rendered_count).to eq("0")
+    end
+
+    it "matches editor login case-insensitively" do
+      create(:accepted_paper, editor: editor)
+      get :edited_by, params: { editor: editor.login.upcase }, format: :svg
+
+      expect(rendered_count).to eq("1")
+    end
+
+    it "tolerates a leading @ on the editor login" do
+      create(:accepted_paper, editor: editor)
+      get :edited_by, params: { editor: "@#{editor.login}" }, format: :svg
+
+      expect(rendered_count).to eq("1")
+    end
+  end
+end


### PR DESCRIPTION
<img width="1552" height="1041" alt="Screenshot 2026-05-09 at 10 43 06" src="https://github.com/user-attachments/assets/13017ed2-473a-4372-9461-d19633e0b488" />

Looking good in production, although the fact we don't scope to `visible` means that the count in the top right, is different from the paginated count... 

cc @sneakers-the-rat 