### PR TITLE
fix disabling browser autcompletion from history

### DIFF
--- a/app/views/papers/index.html.erb
+++ b/app/views/papers/index.html.erb
@@ -32,10 +32,10 @@
       <% end %>
     </div>
 
-    <%= form_for("", url: search_papers_path, method: 'get', html: { class: "form-inline my-2 my-lg-0 float-right"}) do |f| %>
+    <%= form_for("", url: search_papers_path, method: 'get', html: { class: "form-inline my-2 my-lg-0 float-right", autocomplete: "off"}) do |f| %>
     <div class="input-group mb-3">
       <%- placeholder_text = params[:q].nil? ? "Search by title, tag, author, or language":params[:q]%>
-      <%= f.text_field :q, placeholder:placeholder_text , class: "form-control", size: "35" %>
+      <%= f.text_field :q, placeholder:placeholder_text , class: "form-control", size: "35", autocomplete: "off" %>
       <div class="input-group-append">
         <%= button_tag(type: 'submit', class: "btn btn-outline-secondary", name: "search_button") do %>
           <%= octicon "search" %>


### PR DESCRIPTION
## What
Disable browser autocomplete/past searches on the papers search input.

## Why
Browser history suggestions interferes and make search frustrating for users (e.g., when searching by author or tag and other things are popping up).