### PR TITLE
Check author when showing scope notes and votes

### DIFF
--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -211,6 +211,10 @@ class Paper < ApplicationRecord
     retraction_for_id.present?
   end
 
+  def submitted_by?(user)
+    user.present? && user_id == user.id
+  end
+
   def invite_editor(editor_handle)
     return false unless editor = Editor.find_by_login(editor_handle)
     Notifications.editor_invite_email(self, editor).deliver_now

--- a/app/views/papers/_show_unpublished.html.erb
+++ b/app/views/papers/_show_unpublished.html.erb
@@ -14,8 +14,8 @@
         <%= render partial: "papers/resubmission_check", locals: { paper: @paper } if current_editor %>
         <%= render partial: "papers/status", locals: { paper: @paper } %>
         <%= render partial: "papers/eic_summary", locals: { paper: @paper } if current_user %>
-        <%= render partial: "papers/vote_summary", locals: { paper: @paper } if current_editor %>
-        <%= render partial: "papers/notes", locals: { paper: @paper } if current_editor %>
+        <%= render partial: "papers/vote_summary", locals: { paper: @paper } if current_editor && !@paper.submitted_by?(current_user) %>
+        <%= render partial: "papers/notes", locals: { paper: @paper } if current_editor && !@paper.submitted_by?(current_user) %>
         <%= render partial: "papers/actions", locals: { paper: @paper } if current_user %>
       </div>
     </div>

--- a/spec/models/paper_spec.rb
+++ b/spec/models/paper_spec.rb
@@ -52,6 +52,29 @@ describe Paper do
     expect(paper.submitting_author).to eq(user)
   end
 
+  describe "#submitted_by?" do
+    it "is true for the submitting author" do
+      user = create(:user)
+      paper = create(:paper, user_id: user.id)
+
+      expect(paper.submitted_by?(user)).to be true
+    end
+
+    it "is false for a different user" do
+      author = create(:user)
+      other_user = create(:user)
+      paper = create(:paper, user_id: author.id)
+
+      expect(paper.submitted_by?(other_user)).to be false
+    end
+
+    it "is false when no user is given" do
+      paper = create(:paper, user_id: create(:user).id)
+
+      expect(paper.submitted_by?(nil)).to be false
+    end
+  end
+
   it "should have a complete value for repository url" do
     params = { title: 'Test paper',
                body: 'A test paper description',


### PR DESCRIPTION
This pull request introduces a new method to the `Paper` model to check if a given user is the submitting author and updates the UI to restrict editors from seeing certain sections for their own submissions. It also adds tests to ensure the new method works as expected.

**Model changes:**

* Added the `submitted_by?(user)` method to the `Paper` model to determine if a given user is the submitting author.

**UI changes:**

* Updated the unpublished paper view (`_show_unpublished.html.erb`) so that editors do not see the "vote summary" and "notes" sections for papers they themselves submitted.

**Testing:**

* Added tests for the `submitted_by?` method in `paper_spec.rb` to verify correct behavior for the submitting author, other users, and nil cases.

Fixes #1550 