### PR TITLE
fix: Derive AEiC track display from track_aeics instead of free-text title

### DIFF
--- a/app/models/editor.rb
+++ b/app/models/editor.rb
@@ -93,6 +93,12 @@ class Editor < ApplicationRecord
     kind == "board"
   end
 
+  def board_title
+    return title unless JournalFeatures.tracks? && managed_tracks.any?
+
+    "Associate Editor-in-Chief: #{managed_tracks.map(&:name).join('; ')}"
+  end
+
   def board_removed?
     kind_changed? && kind_was == "board"
   end

--- a/app/models/editor.rb
+++ b/app/models/editor.rb
@@ -96,7 +96,11 @@ class Editor < ApplicationRecord
   def board_title
     return title unless JournalFeatures.tracks? && managed_tracks.any?
 
-    "Associate Editor-in-Chief: #{managed_tracks.map(&:name).join('; ')}"
+    if board? && title.blank? && JournalFeatures.tracks? && managed_tracks.any?
+      "Associate Editor-in-Chief: #{managed_tracks.map(&:name).join('; ')}"
+    else
+      title
+    end
   end
 
   def board_removed?

--- a/app/views/home/about.html.erb
+++ b/app/views/home/about.html.erb
@@ -92,7 +92,7 @@
       <div class="generic-content-item" id="editorial_board">
         <h1>Editorial Board</h1>
 
-        <%- Editor.board.order('last_name ASC').each do |editor| %>
+        <%- Editor.board.includes(:managed_tracks).order('last_name ASC').each do |editor| %>
         <%= render partial: "shared/editor", locals: { editor: editor } %>
         <%- end %>
 

--- a/app/views/shared/_editor.html.erb
+++ b/app/views/shared/_editor.html.erb
@@ -13,7 +13,7 @@
     <%- unless editor.retired? %>
     <div class="small">
       <%- if editor.board? %>
-        <%= editor.title %>
+        <%= editor.board_title %>
       <%- else %>
         Editor <%- if editor.categories.present? %>: <%= editor.category_list %><%- end %>
       <%- end %>

--- a/spec/models/editor_spec.rb
+++ b/spec/models/editor_spec.rb
@@ -81,6 +81,38 @@ RSpec.describe Editor, type: :model do
     end
   end
 
+  describe "#board_title" do
+    it "is built from the managed track's name" do
+      board_editor = create(:board_editor)
+      create(:track, name: "Track One", aeics: [board_editor])
+
+      expect(board_editor.board_title).to eq("Associate Editor-in-Chief: Track One")
+    end
+
+    it "includes all managed tracks" do
+      board_editor = create(:board_editor)
+      create(:track, name: "Track One", aeics: [board_editor])
+      create(:track, name: "Track Two", aeics: [board_editor])
+
+      expect(board_editor.board_title).to eq("Associate Editor-in-Chief: Track One; Track Two")
+    end
+
+    it "falls back to the editor's title if there are no managed tracks" do
+      board_editor = create(:board_editor, title: "Editor-in-Chief")
+
+      expect(board_editor.board_title).to eq("Editor-in-Chief")
+    end
+
+    it "falls back to the editor's title if the tracks feature is disabled" do
+      board_editor = create(:board_editor, title: "Editor-in-Chief")
+      create(:track, aeics: [board_editor])
+
+      disable_feature(:tracks) do
+        expect(board_editor.board_title).to eq("Editor-in-Chief")
+      end
+    end
+  end
+
   describe "normalize login" do
     it "removes initial @'s" do
       editor = create(:editor, login: "@somebody")

--- a/spec/system/about_page_spec.rb
+++ b/spec/system/about_page_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+feature "About page" do
+  scenario "editorial board members' titles include their managed tracks" do
+    aeic = create(:board_editor)
+    create(:track, name: "Track One", aeics: [aeic])
+    create(:track, name: "Track Two", aeics: [aeic])
+
+    visit about_path
+
+    expect(page).to have_content("Associate Editor-in-Chief: Track One; Track Two")
+  end
+
+  scenario "editorial board members with no managed tracks show their title" do
+    create(:board_editor, title: "Editor-in-Chief")
+
+    visit about_path
+
+    expect(page).to have_content("Editor-in-Chief")
+  end
+end


### PR DESCRIPTION
## Description

On the about page's editorial board section, board editors rendered only the free-text title column, so an AEiC whose title was blank (never set, or wiped by the clear_title callback) showed no role or track at all.

Derive the label from the track_aeics association instead: board editors with managed tracks now always display "Associate Editor-in-Chief:" plus all of their managed tracks, falling back to the title column otherwise (e.g. for the Editor-in-Chief, or journals without the tracks feature).

I don't really know Ruby, so if there is a much better way to do this I would be happy to implement that instead.

## Motivation

I noticed that on the Editorial Board page my associated track doesn't render.

### View from 441c426ec938a41244ce17adf4bc2632e66f1907

<img width="1255" height="575" alt="image" src="https://github.com/user-attachments/assets/1959430d-f7a6-4570-b6d3-271a2595841c" />

## Local preview view from this PR

<img width="1255" height="575" alt="image" src="https://github.com/user-attachments/assets/6099abdb-878c-412f-8943-02a444b98156" />

## Disclosure

The changes in this PR were generated by agentic model Claude Code Opus 4.8 with steering and input from me.