### PR TITLE
Add note about removing optional fields from example paper

### DIFF
--- a/docs/example_paper.md
+++ b/docs/example_paper.md
@@ -40,7 +40,7 @@ date: 13 August 2017
 bibliography: paper.bib
 
 # Optional fields for papers that are part of a joint submission.
-# For example submitting to a AAS journal too, see this blog post:
+# For example, submitting to a AAS journal too, see this blog post:
 # https://blog.joss.theoj.org/2018/12/a-new-collaboration-with-aas-publishing
 #
 # If you are not making a joint submission you should remove these lines.

--- a/docs/example_paper.md
+++ b/docs/example_paper.md
@@ -39,10 +39,16 @@ affiliations:
 date: 13 August 2017
 bibliography: paper.bib
 
-# Optional fields if submitting to a AAS journal too, see this blog post:
+# Optional fields for papers that are part of a joint submission.
+# For example submitting to a AAS journal too, see this blog post:
 # https://blog.joss.theoj.org/2018/12/a-new-collaboration-with-aas-publishing
+# or to RSECon26.
+#
+# If you are not making a joint submission you should remove these lines.
+#
 aas-doi: 10.3847/xxxxx <- update this with the DOI from AAS once you know it.
 aas-journal: Astrophysical Journal <- The name of the AAS journal.
+rsecon26: accepted
 ---
 
 # Summary

--- a/docs/example_paper.md
+++ b/docs/example_paper.md
@@ -42,13 +42,11 @@ bibliography: paper.bib
 # Optional fields for papers that are part of a joint submission.
 # For example submitting to a AAS journal too, see this blog post:
 # https://blog.joss.theoj.org/2018/12/a-new-collaboration-with-aas-publishing
-# or to RSECon26.
 #
 # If you are not making a joint submission you should remove these lines.
 #
 aas-doi: 10.3847/xxxxx <- update this with the DOI from AAS once you know it.
 aas-journal: Astrophysical Journal <- The name of the AAS journal.
-rsecon26: accepted
 ---
 
 # Summary


### PR DESCRIPTION
I had a recent submission where the authors had copied the example paper from the docs and left the AAS tags in.

This PR adds a note to explicitly say these should be removed by authors if they are not relevant to the submission.

Alternatively, I would advocate for removing the optional flags entirely as the majority of submissions to JOSS (that will use this as a starting point) will not require them.
If they are part of a joint submission they can be made aware of the need to add a tag elsewhere (e.g. as was done for RSECon26). I leave this as an option for the reviewers/maintainers to discuss.

I also added reference to the fact that there may be other tags/joint submissions besides AAS, but am happy to leave it as just referencing AAS if preferred. 