### PR TITLE
Making PDF links in paper#show consistent

### DIFF
--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -358,8 +358,8 @@ class Paper < ApplicationRecord
   end
 
   # Return the seo_url plus '.pdf'. This is for Google Scholar so that we can
-  # point to PDFs on the same domain on the JOSS site (although they are then
-  # 301 redirected to a pdf_url later).
+  # point to PDFs on the same domain as the paper landing page (the PDF bytes
+  # are proxied from pdf_url by PapersController#show, not redirected).
   def seo_pdf_url
     "#{seo_url}.pdf"
   end

--- a/app/views/papers/_sidebar_published.html.erb
+++ b/app/views/papers/_sidebar_published.html.erb
@@ -28,7 +28,7 @@
         Paper review
       <% end %>
 
-      <%= link_to @paper.pdf_url, class: 'btn paper-btn' do %>
+      <%= link_to @paper.seo_pdf_url, class: 'btn paper-btn' do %>
         <%= image_tag "dl-icon.svg" %>
         Download paper
       <% end %>

--- a/spec/system/papers/show_published_spec.rb
+++ b/spec/system/papers/show_published_spec.rb
@@ -26,7 +26,7 @@ feature "Published paper's show page" do
 
     expect(page).to have_link("Software repository")
     expect(page).to have_link("Paper review")
-    expect(page).to have_link("Download paper")
+    expect(page).to have_link("Download paper", href: @accepted_paper.seo_pdf_url)
     expect(page).to have_link("Software archive")
 
     expect(page).to_not have_link("Retraction notice")


### PR DESCRIPTION
This pull request updates how the PDF download link for published papers is handled, ensuring that the download uses the SEO-friendly URL and that the PDF is proxied instead of redirected. It also updates the tests to match this new behavior.

**PDF Download Link Handling:**

* Updated the `seo_pdf_url` method in `paper.rb` to clarify that the PDF is now proxied via `PapersController#show` rather than being redirected, making the download URL consistent with the paper landing page.
* Changed the download button in `_sidebar_published.html.erb` to use `@paper.seo_pdf_url` instead of `@paper.pdf_url`, ensuring users download the PDF from the SEO-friendly URL.

**Test Adjustments:**

* Updated the system spec in `show_published_spec.rb` to expect the "Download paper" link to point to `@accepted_paper.seo_pdf_url`.