### PR TITLE
docs: add Podman instructions alongside Docker (fixes #1552)

### DIFF
--- a/docs/paper.md
+++ b/docs/paper.md
@@ -393,6 +393,18 @@ docker run --rm \
     openjournals/inara
 ```
 
+### Podman
+
+If you use [Podman](https://podman.io) instead of Docker, you can compile a draft of your paper locally with the same container image. Podman does not require root privileges and is available on many Linux distributions:
+
+```text
+podman run --rm \
+    --volume $PWD/paper:/data \
+    --userns=keep-id \
+    --env JOURNAL=joss \
+    docker.io/openjournals/inara
+```
+
 ### Locally
 
 The materials for the `inara` container image above are themselves open source and available in [its own repository](https://github.com/openjournals/inara). You can clone that repository and run the `inara` script locally with `make` after installing the necessary dependencies, which can be inferred from the [`Dockerfile`](https://github.com/openjournals/inara/blob/main/Dockerfile).


### PR DESCRIPTION
## Summary

Adds Podman instructions alongside the existing Docker instructions for
compiling a paper draft locally.

Podman is a rootless alternative to Docker available on many Linux
platforms. The added section uses `--userns=keep-id` (Podman's rootless
equivalent to matching file ownership between host and container) instead
of Docker's `--user $(id -u):$(id -g)`.

Fixes #1552

## Changes

- `docs/paper.md`: new "Podman" subsection right after the existing
  "Docker" subsection, same style/formatting.

## Notes

The exact command was proposed by @MarDiehl in the issue.