### PR TITLE
fix: disable misspellings/fuzzy matching for tag search (fixes #1536)

### DIFF
--- a/app/controllers/papers_controller.rb
+++ b/app/controllers/papers_controller.rb
@@ -117,7 +117,7 @@ class PapersController < ApplicationController
       @term = "reviewed by #{params['reviewer']}"
       @badge = {type: "reviewer", value: params['reviewer']}
     elsif params['tag']
-      @papers = Paper.search(params['tag'], fields: [:tags, :title], order: { accepted_at: :desc },
+      @papers = Paper.search(params['tag'], fields: [:tags, :title], misspellings: false, order: { accepted_at: :desc },
                   page: params[:page],
                   per_page: 10)
       @term = "#{params['tag']}"

--- a/spec/controllers/papers_controller_spec.rb
+++ b/spec/controllers/papers_controller_spec.rb
@@ -610,6 +610,34 @@ describe PapersController, type: :controller do
     end
   end
 
+  describe "GET #filter by tag" do
+    # Stands in for a Searchkick::Results object: the controller passes it to
+    # Pagy.new_from_searchkick and the view iterates over it.
+    let(:empty_search_results) do
+      instance_double(Searchkick::Results,
+                      total_count: 0,
+                      options: { page: 1, per_page: 10 }).tap do |results|
+        allow(results).to receive(:each)
+        allow(results).to receive(:size).and_return(0)
+        allow(results).to receive(:to_ary).and_return([])
+      end
+    end
+
+    # Searchkick's default misspellings setting applies an edit distance of 1 to
+    # short terms, so a search for a tag like "CWL" also matched papers tagged
+    # "OWL", "CTL" or "CSL". See https://github.com/openjournals/joss/issues/1536
+    it "disables misspellings/fuzzy matching when filtering by tag" do
+      expect(Paper).to receive(:search).with(
+        "CWL",
+        hash_including(fields: [:tags, :title], misspellings: false)
+      ).and_return(empty_search_results)
+
+      get :filter, params: { tag: "CWL" }
+
+      expect(response).to be_successful
+    end
+  end
+
   describe "Paper/by/{author} route" do
     it "handles author names with periods" do
       assert_routing "/papers/by/Author%20T.%20Lastname", { controller: "papers", action: "filter", author: "Author T. Lastname" }


### PR DESCRIPTION
## Summary

Fixes false positives in the tag search (`/papers/tagged/:tag`) caused by
Searchkick's default fuzzy matching (misspellings) kicking in on short tags.

As reported in the issue, searching for `CWL` matched papers tagged `OWL`,
`CTL`, `CRU`, `CSL`, and `BEM` — all edit-distance 1 from "CWL" under
Searchkick's default settings. The `author`, `editor`, and `reviewer`
branches of the same `filter` action already disable this with
`misspellings: false`; the `tag` branch was missing it.

## Changes

- `app/controllers/papers_controller.rb`: add `misspellings: false` to the
  tag search branch, consistent with the other three branches.
- `spec/controllers/papers_controller_spec.rb`: add a regression test
  asserting `Paper.search` is called with `misspellings: false` when
  filtering by tag.

## Note on scope

The tag search also matches against `:title` (`fields: [:tags, :title]`).
This means a paper without the `CWL` tag but with "CWL" mentioned in its
title would still appear in `/papers/tagged/CWL/`. I left this untouched
since it's a separate behavioral question (should tag search only match
curated tags, or also full text?) that maintainers may want to decide
independently of this bug fix.

## Testing

I wasn't able to run the test suite locally (no Ruby/Elasticsearch
environment set up on this machine), so the new spec hasn't been executed
yet — happy to iterate based on CI results or review feedback.

Fixes #1536