### PR TITLE
Making it possible to edit tags from the admin UI

### DIFF
--- a/app/controllers/papers_controller.rb
+++ b/app/controllers/papers_controller.rb
@@ -209,6 +209,7 @@ class PapersController < ApplicationController
       @paper.metadata['paper']['title'] = params[:title]
     end
     @paper.metadata['paper']['tags'] = params[:tags].split(',').map(&:strip).reject(&:blank?) if params[:tags].present?
+    @paper.metadata['paper']['languages'] = params[:languages].split(',').map(&:strip).reject(&:blank?) if params[:languages].present?
     @paper.citation_string = params[:citation_string] if params[:citation_string].present?
 
     if @paper.save

--- a/app/views/papers/_actions.html.erb
+++ b/app/views/papers/_actions.html.erb
@@ -81,6 +81,12 @@
           <div class="form-group" style="margin-top: 0.75em;">
             <%= label_tag :tags, "Tags (comma-separated)" %>
             <%= text_field_tag :tags, paper.metadata.dig('paper', 'tags')&.join(', '), class: "form-control", placeholder: "Leave blank to keep current value" %>
+            <small class="form-text text-muted">Tags that duplicate a displayed language are hidden from the Tags section on the paper page.</small>
+          </div>
+          <div class="form-group" style="margin-top: 0.75em;">
+            <%= label_tag :languages, "Languages (comma-separated)" %>
+            <%= text_field_tag :languages, paper.metadata.dig('paper', 'languages')&.join(', '), class: "form-control", placeholder: "Leave blank to keep current value" %>
+            <small class="form-text text-muted">Some languages are never displayed on the paper page: <%= Paper::IGNORED_LANGUAGES.join(', ') %>.</small>
           </div>
           <div class="form-group" style="margin-top: 0.75em;">
             <%= label_tag :citation_string, "Citation string" %>

--- a/spec/controllers/papers_controller_spec.rb
+++ b/spec/controllers/papers_controller_spec.rb
@@ -541,6 +541,23 @@ describe PapersController, type: :controller do
       expect(paper.metadata['paper']['tags']).to eq(["foo", "bar"])
     end
 
+    it "allows an AEiC to update languages" do
+      allow(controller).to receive(:current_user).and_return(aeic_user)
+
+      post :update_metadata, params: { id: paper.sha, languages: "C++, Python, CMake" }
+      expect(response).to be_redirect
+      expect(flash[:notice]).to be_present
+      expect(paper.reload.metadata['paper']['languages']).to eq(["C++", "Python", "CMake"])
+    end
+
+    it "does not update languages if the param is blank" do
+      allow(controller).to receive(:current_user).and_return(aeic_user)
+      original_languages = paper.metadata['paper']['languages']
+
+      post :update_metadata, params: { id: paper.sha, languages: "" }
+      expect(paper.reload.metadata['paper']['languages']).to eq(original_languages)
+    end
+
     it "allows an AEiC to update the citation string" do
       allow(controller).to receive(:current_user).and_return(aeic_user)
 


### PR DESCRIPTION
This pull request adds support for managing a list of programming languages for each paper, alongside tags, in both the backend and frontend. It updates the metadata update logic, enhances the paper actions form to include a new field for languages, and introduces relevant tests to ensure correct behavior.
