### PR TITLE
Making language consistent with #1554

### DIFF
--- a/app/views/home/about.html.erb
+++ b/app/views/home/about.html.erb
@@ -35,12 +35,12 @@
 
         <h2>Scope and significance</h2>
 
-        <p>JOSS publishes articles about software that demonstrates clear research impact or credible scholarly significance. Your software should represent a meaningful contribution to the research community rather than being a one-off tool for a single analysis.</p>
+        <p>JOSS publishes articles about software that has demonstrated clear research impact. Your software should represent a meaningful contribution to the research community rather than being a one-off tool for a single analysis.</p>
 
         <p>We evaluate submissions based on evidence of research impact, intellectual contribution, and good open-source practices. Some factors that reviewers and editors consider include:</p>
 
         <ul>
-          <li>Evidence of research impact: publications or analyses using the software, external adopters or integrations, or credible near-term significance demonstrated through benchmarks and reproducible materials.</li>
+          <li>Evidence of research impact: publications or analyses using the software, external adopters or integrations.</li>
           <li>Design thinking: meaningful architectural decisions, trade-offs considered, and conceptual frameworks that capture domain expertise. We value work that builds upon existing software ecosystems rather than reinventing solutions.</li>
           <li>Open development practices: sustained development over time with evidence of collaborative effort, public development history, comprehensive testing, clear documentation, and pathways for community contribution.</li>
           <li>Whether the software is sufficiently useful that it is <em>likely to be cited</em> by other researchers in your domain.</li>


### PR DESCRIPTION
This pull request makes minor clarifications to the "Scope and significance" section of the `about.html.erb` page. The changes refine the criteria for research impact and simplify the language for better clarity.

- Content clarifications:
  * Updated the description to specify that JOSS publishes articles about software that has demonstrated clear research impact, rather than just credible scholarly significance.
  * Simplified the list of evidence for research impact by removing "credible near-term significance demonstrated through benchmarks and reproducible materials" from the examples.