### PR TITLE
Update tests to Postgres v18

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:13
+        image: postgres:18
         ports: ['5432:5432']
         env:
           POSTGRES_USER: postgres


### PR DESCRIPTION
Testing Postgres 18 as the new DB version to be upgraded in production